### PR TITLE
Fix qt mint error message

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5912,7 +5912,7 @@ string CWallet::MintAndStoreZerocoin(vector<CRecipient> vecSend,
 
     LogPrintf("payTxFee.GetFeePerK()=%s\n", payTxFee.GetFeePerK());
     CReserveKey reservekey(this);
-    int64_t nFeeRequired;
+    int64_t nFeeRequired = 0;
 
     int nChangePosRet = -1;
     bool isSigmaMint = false;
@@ -5985,7 +5985,7 @@ string CWallet::MintAndStoreZerocoinV3(vector<CRecipient> vecSend,
 
     LogPrintf("payTxFee.GetFeePerK()=%s\n", payTxFee.GetFeePerK());
     CReserveKey reservekey(this);
-    int64_t nFeeRequired;
+    int64_t nFeeRequired = 0;
 
     int nChangePosRet = -1;
     bool isSigmaMint = true;
@@ -6056,7 +6056,7 @@ string CWallet::MintZerocoin(CScript pubCoin, int64_t nValue, bool isSigmaMint, 
         return _("Insufficient funds");
     LogPrintf("payTxFee.GetFeePerK()=%s\n", payTxFee.GetFeePerK());
     CReserveKey reservekey(this);
-    int64_t nFeeRequired;
+    int64_t nFeeRequired = 0;
 
     if (IsLocked()) {
         string strError = _("Error: Wallet locked, unable to create transaction!");


### PR DESCRIPTION
qt show error message because nFeeRequired is not initialized and the value exceed balance.