### PR TITLE
Add test coverage to CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,15 +15,15 @@ pipeline {
                 sh 'mkdir -p dist'
                 sh 'tar -C dist --strip-components=1 -xzf zcoin-*.tar.gz'
                 dir('dist') {
-                    sh './configure --enable-elysium --enable-tests'
+                    sh './configure --enable-elysium --enable-tests --enable-lcov'
                     sh 'make -j6'
                 }
             }
         }
-        stage('Test') {
+        stage('Test & Coverage') {
             steps {
                 dir('dist') {
-                    sh 'make check'
+                    sh 'make cov -j6'
                 }
             }
         }


### PR DESCRIPTION
Partial fix for https://github.com/zcoinofficial/zcoin/issues/681 (yet to be added to https://codecov.io )

Will fail as it needs the two dependancies added to the Dockerfile.

As we are upgrading to Bionic for building, we should probably add the new Dockerfile along with the changes from that PR at the same time. TBD

## PR intention
Add test coverage to our CI, modifying the builder Dockerfile and Jenkins.


## Code changes brief
- `Jenkinsfile`: `--enable-lcov` in `./configure`, `make cov` instead of `make check` (performs `make check` then creates test coverage report)
- `Dockerfile`: Add necessary deps (`lcov` and `default-jre`)
