### PR TITLE
Fix a bug when ProRegTx and transaction spending collateral are both in the mempool

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -866,10 +866,13 @@ void BlockAssembler::FillBlackListForBlockTemplate() {
             txBlackList.erase(mi);
         }
 
-        // ProRegTx referencing external collateral can't be in same block with the collateral itself
         if (tx.nVersion >= 3 && tx.nType == TRANSACTION_PROVIDER_REGISTER) {
             CProRegTx proTx;
-            if (GetTxPayload(tx, proTx) && !proTx.collateralOutpoint.hash.IsNull() && mempool.get(proTx.collateralOutpoint.hash))
+            if (GetTxPayload(tx, proTx) && !proTx.collateralOutpoint.hash.IsNull() &&
+                    // ProRegTx referencing external collateral can't be in same block with the collateral itself
+                    (mempool.get(proTx.collateralOutpoint.hash) ||
+                    // ProRegTx cannot be in the same block as transaction spending external collateral
+                        mempool.isSpent(proTx.collateralOutpoint)))
                 mempool.CalculateDescendants(mi, txBlackList);
         }
     }


### PR DESCRIPTION
## PR intention
Fixes a situation inherited from DASH causing miners to behave incorrectly when two conflicting transactions are in the mempool at the same time

## Code changes brief
Changes to `miner.cpp` are made in order to ensure protx is blocked from block when such a conflict is detected
Changes to `txmempool.cpp` are to ensure correct behavior of DASH code resolving mempool transaction conflicts. This code will remove protx when collateral spend transaction is mined into the block
