### PR TITLE
Showing error messages

### DIFF
--- a/src/qt/automintdialog.cpp
+++ b/src/qt/automintdialog.cpp
@@ -6,6 +6,7 @@
 #include "lelantusmodel.h"
 #include "ui_automintdialog.h"
 
+#include <QMessageBox>
 #include <QPushButton>
 #include <QDebug>
 
@@ -55,8 +56,8 @@ void AutoMintDialog::accept()
         repaint();
 
         if (!lelantusModel->unlockWallet(passphase, lock ? 0 : 60 * 1000)) {
-            QDialog::accept();
-            lelantusModel->sendAckMintAll(AutoMintAck::FailToUnlock);
+            QMessageBox::critical(this, tr("Wallet unlock failed"),
+                                  tr("The passphrase was incorrect."));
             return;
         }
     }

--- a/src/sigma.cpp
+++ b/src/sigma.cpp
@@ -61,7 +61,7 @@ bool IsSigmaAllowed()
 
 bool IsSigmaAllowed(int height)
 {
-	return height >= ::Params().GetConsensus().nSigmaStartBlock;
+	return height >= ::Params().GetConsensus().nSigmaStartBlock && height < ::Params().GetConsensus().nLelantusStartBlock;
 }
 
 bool IsRemintWindow(int height) {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3215,7 +3215,7 @@ UniValue mint(const JSONRPCRequest& request)
     // Ensure Sigma mints is already accepted by network so users will not lost their coins
     // due to other nodes will treat it as garbage data.
     if (!sigma::IsSigmaAllowed()) {
-        throw JSONRPCError(RPC_WALLET_ERROR, "Sigma is not activated yet");
+        throw JSONRPCError(RPC_WALLET_ERROR, "Sigma is not active");
     }
 
     CAmount nAmount = AmountFromValue(request.params[0]);
@@ -3771,7 +3771,7 @@ UniValue spendmany(const JSONRPCRequest& request) {
         );
 
     if (!sigma::IsSigmaAllowed()) {
-        throw JSONRPCError(RPC_WALLET_ERROR, "Sigma is not activated yet");
+        throw JSONRPCError(RPC_WALLET_ERROR, "Sigma is not active");
     }
 
     EnsureSigmaWalletIsAvailable();


### PR DESCRIPTION
Fixes issue of not showing error message when password is incorrect on Anonymize dialog,
Adds error message when you call  sigma min/spend rpc after HF block passes.
