### PR TITLE
Lelantus unittests and fixes

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -102,6 +102,9 @@ if ENABLE_ZMQ:
 
 testScripts = [
     'lelantus_mint.py',
+    'lelantus_setmintstatus_validation.py',
+    'lelantus_mintspend.py',
+    'lelantus_spend_gettransaction.py',
     'elysium_create_denomination.py',
     'elysium_property_creation_fee.py',
     'elysium_sendmint.py',

--- a/qa/rpc-tests/lelantus_mintspend.py
+++ b/qa/rpc-tests/lelantus_mintspend.py
@@ -21,8 +21,8 @@ class LelantusMintSpendTest(BitcoinTestFramework):
 
         mint_trans = list()
         coin = 100000000;
-        mint_trans.append(self.nodes[0].mintlelantus(1 * coin))
-        mint_trans.append(self.nodes[0].mintlelantus(2 * coin))
+        mint_trans.append(self.nodes[0].mintlelantus(1))
+        mint_trans.append(self.nodes[0].mintlelantus(2))
 
         # Get last added transaction and fee for it
         info = self.nodes[0].gettransaction(mint_trans[-1])
@@ -53,7 +53,7 @@ class LelantusMintSpendTest(BitcoinTestFramework):
             res = False
             args = {'THAYjKnnCsN5xspnEcb1Ztvw4mSPBuwxzU': coin}
             try:
-                res = self.nodes[0].joinsplit("", args)
+                res = self.nodes[0].joinsplit(args)
             except JSONRPCException as ex:
                 assert ex.error['message'] == 'Insufficient funds'
 
@@ -89,7 +89,7 @@ class LelantusMintSpendTest(BitcoinTestFramework):
         print(coin)
         args = {myaddr: coin}
 
-        spend_trans.append(self.nodes[0].joinsplit("", args))
+        spend_trans.append(self.nodes[0].joinsplit(args))
 
         info = self.nodes[0].gettransaction(spend_trans[-1])
         confrms = info['confirmations']

--- a/qa/rpc-tests/lelantus_mintspend.py
+++ b/qa/rpc-tests/lelantus_mintspend.py
@@ -20,17 +20,16 @@ class LelantusMintSpendTest(BitcoinTestFramework):
         start_bal = self.nodes[0].getbalance()
 
         mint_trans = list()
-        coin = 100000000;
         mint_trans.append(self.nodes[0].mintlelantus(1))
         mint_trans.append(self.nodes[0].mintlelantus(2))
 
         # Get last added transaction and fee for it
-        info = self.nodes[0].gettransaction(mint_trans[-1])
+        info = self.nodes[0].gettransaction(mint_trans[-1][0])
 
         # fee in transaction is negative
         fee = -(info['fee'] * 2)
         cur_bal = self.nodes[0].getbalance()
-        start_bal = float(start_bal) - float(fee) - coin * 3
+        start_bal = float(start_bal) - float(fee) - 3
         start_bal = Decimal(format(start_bal, '.8f'))
 
         assert start_bal == cur_bal, \
@@ -40,7 +39,7 @@ class LelantusMintSpendTest(BitcoinTestFramework):
         # confirmations should be i due to less than 4 blocks was generated after transactions send
         for i in range(5):
             for tr in mint_trans:
-                info = self.nodes[0].gettransaction(tr)
+                info = self.nodes[0].gettransaction(tr[0])
                 confrms = info['confirmations']
                 assert confrms == i, \
                     'Confirmations should be {}, ' \
@@ -51,7 +50,7 @@ class LelantusMintSpendTest(BitcoinTestFramework):
                 assert tr_type == 'mint', 'Unexpected transaction type: {}'.format(tr_type)
 
             res = False
-            args = {'THAYjKnnCsN5xspnEcb1Ztvw4mSPBuwxzU': coin}
+            args = {'THAYjKnnCsN5xspnEcb1Ztvw4mSPBuwxzU': 1}
             try:
                 res = self.nodes[0].joinsplit(args)
             except JSONRPCException as ex:
@@ -67,7 +66,7 @@ class LelantusMintSpendTest(BitcoinTestFramework):
         self.sync_all()
 
         for tr in mint_trans:
-            info = self.nodes[0].gettransaction(tr)
+            info = self.nodes[0].gettransaction(tr[0])
             confrms = info['confirmations']
             assert confrms == 6, \
                 'Confirmations should be 6, ' \
@@ -86,8 +85,8 @@ class LelantusMintSpendTest(BitcoinTestFramework):
         total_spend_fee = 0
 
         myaddr = self.nodes[0].listreceivedbyaddress(0, True)[0]['address']
-        print(coin)
-        args = {myaddr: coin}
+        print(1)
+        args = {myaddr: 1}
 
         spend_trans.append(self.nodes[0].joinsplit(args))
 
@@ -97,7 +96,7 @@ class LelantusMintSpendTest(BitcoinTestFramework):
         total_spend_fee += -info['fee']
         print(info['fee'])
         print(self.nodes[0].getbalance())
-        spend_total = float(spend_total) + coin
+        spend_total = float(spend_total) + 1
         assert confrms == 0, \
             'Confirmations should be 0, ' \
             'due to 0 blocks was generated after transaction was created,' \

--- a/qa/rpc-tests/lelantus_mintspend.py
+++ b/qa/rpc-tests/lelantus_mintspend.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+from decimal import *
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+
+class LelantusMintSpendTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 4
+        self.setup_clean_chain = False
+
+    def run_test(self):
+        # Decimal formating: 6 digits for balance will be enought 000.000
+        getcontext().prec = 6
+        self.nodes[0].generate(1001)
+        self.sync_all()
+
+        start_bal = self.nodes[0].getbalance()
+
+        mint_trans = list()
+        coin = 100000000;
+        mint_trans.append(self.nodes[0].mintlelantus(1 * coin))
+        mint_trans.append(self.nodes[0].mintlelantus(2 * coin))
+
+        # Get last added transaction and fee for it
+        info = self.nodes[0].gettransaction(mint_trans[-1])
+
+        # fee in transaction is negative
+        fee = -(info['fee'] * 2)
+        cur_bal = self.nodes[0].getbalance()
+        start_bal = float(start_bal) - float(fee) - coin * 3
+        start_bal = Decimal(format(start_bal, '.8f'))
+
+        assert start_bal == cur_bal, \
+            'Unexpected current balance: {}, should be minus two mints and two fee, ' \
+            'but start was {}'.format(cur_bal, start_bal)
+
+        # confirmations should be i due to less than 4 blocks was generated after transactions send
+        for i in range(5):
+            for tr in mint_trans:
+                info = self.nodes[0].gettransaction(tr)
+                confrms = info['confirmations']
+                assert confrms == i, \
+                    'Confirmations should be {}, ' \
+                    'due to {} blocks was generated after transaction was created,' \
+                    'but was {}'.format(i, i, confrms)
+
+                tr_type = info['details'][0]['category']
+                assert tr_type == 'mint', 'Unexpected transaction type: {}'.format(tr_type)
+
+            res = False
+            args = {'THAYjKnnCsN5xspnEcb1Ztvw4mSPBuwxzU': coin}
+            try:
+                res = self.nodes[0].joinsplit("", args)
+            except JSONRPCException as ex:
+                assert ex.error['message'] == 'Insufficient funds'
+
+            assert not res, 'Did not raise spend exception, but should be.'
+
+            self.nodes[0].generate(1)
+            self.sync_all()
+
+        # generate last confirmation block - now all transactions should be confimed
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        for tr in mint_trans:
+            info = self.nodes[0].gettransaction(tr)
+            confrms = info['confirmations']
+            assert confrms == 6, \
+                'Confirmations should be 6, ' \
+                'due to 6 blocks was generated after transaction was created,' \
+                'but was {}.'.format(confrms)
+            tr_type = info['details'][0]['category']
+            assert tr_type == 'mint', 'Unexpected transaction type'
+
+        spend_trans = list()
+        spend_total = Decimal(0)
+
+        self.sync_all()
+
+        start_bal = self.nodes[0].getbalance()
+        print(start_bal)
+        total_spend_fee = 0
+
+        myaddr = self.nodes[0].listreceivedbyaddress(0, True)[0]['address']
+        print(coin)
+        args = {myaddr: coin}
+
+        spend_trans.append(self.nodes[0].joinsplit("", args))
+
+        info = self.nodes[0].gettransaction(spend_trans[-1])
+        confrms = info['confirmations']
+        tr_type = info['details'][0]['category']
+        total_spend_fee += -info['fee']
+        print(info['fee'])
+        print(self.nodes[0].getbalance())
+        spend_total = float(spend_total) + coin
+        assert confrms == 0, \
+            'Confirmations should be 0, ' \
+            'due to 0 blocks was generated after transaction was created,' \
+            'but was {}.'.format(confrms)
+        assert tr_type == 'spend', 'Unexpected transaction type'
+        print(self.nodes[0].getbalance())
+
+        before_new = self.nodes[0].getbalance()
+        self.nodes[0].generate(2)
+        after_new = self.nodes[0].getbalance()
+        delta = after_new - before_new
+        self.sync_all()
+
+        # # Start balance increase on generated blocks to confirm
+        start_bal += delta
+        cur_bal = Decimal(format(self.nodes[0].getbalance(), '.1f'))
+        spend_total = Decimal(format(spend_total, '.8f'))
+
+        #TODO check why currently was not minused from total sum
+        start_bal = start_bal + spend_total
+
+        assert start_bal == cur_bal, \
+            'Unexpected current balance: {}, should increase on {}, ' \
+            'but start was {}'.format(cur_bal, spend_total, start_bal)
+
+        for tr in spend_trans:
+            info = self.nodes[0].gettransaction(tr)
+
+            confrms = info['confirmations']
+            tr_type = info['details'][0]['category']
+            assert confrms >= 1, \
+                'Confirmations should be 1 or more, ' \
+                'due to 1 blocks was generated after transaction was created,' \
+                'but was {}.'.format(confrms)
+            assert tr_type == 'spend', 'Unexpected transaction type'
+
+
+if __name__ == '__main__':
+    LelantusMintSpendTest().main()

--- a/qa/rpc-tests/lelantus_setmintstatus_validation.py
+++ b/qa/rpc-tests/lelantus_setmintstatus_validation.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+class SetLelantusMintSatusValidationWithFundsTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 4
+        self.setup_clean_chain = False
+
+    def setup_nodes(self):
+        # This test requires mocktime
+        enable_mocktime()
+        return start_nodes(self.num_nodes, self.options.tmpdir)
+
+    def run_test(self):
+        self.nodes[0].generate(1000)
+        self.sync_all()
+
+        txid = self.nodes[0].mintlelantus(10)
+
+        lelantus_mint = self.nodes[0].listlelantusmints()
+
+        assert len(lelantus_mint) == len(txid), 'Should be same number.'
+
+        mint_info = lelantus_mint[0]
+
+        assert not mint_info['IsUsed'], \
+            'This mint with txid: {} should not be Used.'.format(txid)
+
+        print('Set mint status from False to True.')
+
+        self.nodes[0].setlelantusmintstatus(mint_info['serialNumber'], True)
+
+        lelantus_mint = self.nodes[0].listlelantusmints()
+
+        assert len(lelantus_mint) == len(txid), 'Should be same number.'
+
+        mint_info = lelantus_mint[0]
+
+        assert mint_info['IsUsed'], \
+            'This mint with txid: {} should be Used.'.format(txid)
+
+        print('Set mint status from True to False back.')
+
+        self.nodes[0].setlelantusmintstatus(mint_info['serialNumber'], False)
+
+        lelantus_mint = self.nodes[0].listlelantusmints()
+
+        assert len(lelantus_mint) == len(txid), 'Should be same number.'
+
+        mint_info = lelantus_mint[0]
+
+        assert not mint_info['IsUsed'], \
+            'This mint with txid: {} should not be Used.'.format(txid)
+
+
+        assert_raises(JSONRPCException, self.nodes[0].setlelantusmintstatus, [(mint_info['serialNumber'], "sometext")])
+        assert_raises(JSONRPCException, self.nodes[0].setlelantusmintstatus, [mint_info['serialNumber']])
+        assert_raises(JSONRPCException, self.nodes[0].setlelantusmintstatus, [])
+        assert_raises(JSONRPCException, self.nodes[0].setlelantusmintstatus, ["sometext"])
+        assert_raises(JSONRPCException, self.nodes[0].setlelantusmintstatus, [123])
+
+
+if __name__ == '__main__':
+    SetLelantusMintSatusValidationWithFundsTest().main()

--- a/qa/rpc-tests/lelantus_setmintstatus_validation.py
+++ b/qa/rpc-tests/lelantus_setmintstatus_validation.py
@@ -25,7 +25,7 @@ class SetLelantusMintSatusValidationWithFundsTest(BitcoinTestFramework):
 
         mint_info = lelantus_mint[0]
 
-        assert not mint_info['IsUsed'], \
+        assert not mint_info['isUsed'], \
             'This mint with txid: {} should not be Used.'.format(txid)
 
         print('Set mint status from False to True.')
@@ -38,7 +38,7 @@ class SetLelantusMintSatusValidationWithFundsTest(BitcoinTestFramework):
 
         mint_info = lelantus_mint[0]
 
-        assert mint_info['IsUsed'], \
+        assert mint_info['isUsed'], \
             'This mint with txid: {} should be Used.'.format(txid)
 
         print('Set mint status from True to False back.')
@@ -51,7 +51,7 @@ class SetLelantusMintSatusValidationWithFundsTest(BitcoinTestFramework):
 
         mint_info = lelantus_mint[0]
 
-        assert not mint_info['IsUsed'], \
+        assert not mint_info['isUsed'], \
             'This mint with txid: {} should not be Used.'.format(txid)
 
 

--- a/qa/rpc-tests/lelantus_spend_gettransaction.py
+++ b/qa/rpc-tests/lelantus_spend_gettransaction.py
@@ -33,7 +33,7 @@ class JoinSplitGettransactionTest(BitcoinTestFramework):
         self.sync_all()
 
         # case 1: Spend many with watchonly address
-        spendto_wo_id = self.nodes[0].joinsplit("", {watchonly_address: 1})
+        spendto_wo_id = self.nodes[0].joinsplit({watchonly_address: 1})
         spendto_wo_tx = self.nodes[0].gettransaction(spendto_wo_id)
 
         assert spendto_wo_tx['amount'] == Decimal('-1')
@@ -43,7 +43,7 @@ class JoinSplitGettransactionTest(BitcoinTestFramework):
         assert spendto_wo_tx['details'][0]['involvesWatchonly']
 
         # case 2: Spend many with watchonly address and valid address
-        spendto_wo_and_valid_id = self.nodes[0].joinsplit("", {watchonly_address: 1, valid_address: 2})
+        spendto_wo_and_valid_id = self.nodes[0].joinsplit({watchonly_address: 1, valid_address: 2})
         spendto_wo_and_valid_tx = self.nodes[0].gettransaction(spendto_wo_and_valid_id)
 
         assert spendto_wo_and_valid_tx['amount'] == Decimal('-1')
@@ -59,7 +59,7 @@ class JoinSplitGettransactionTest(BitcoinTestFramework):
         assert involves_watch_only_count == 1
 
         # case 3: spend many with watchonly address and invalid address
-        assert_raises(JSONRPCException, self.nodes[0].joinsplit, ["", {watchonly_address: 1, 'invalidaddress': 2}])
+        assert_raises(JSONRPCException, self.nodes[0].joinsplit, [{watchonly_address: 1, 'invalidaddress': 2}])
 
 if __name__ == '__main__':
     JoinSplitGettransactionTest().main()

--- a/qa/rpc-tests/lelantus_spend_gettransaction.py
+++ b/qa/rpc-tests/lelantus_spend_gettransaction.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+from decimal import *
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+class JoinSplitGettransactionTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 4
+        self.setup_clean_chain = True
+
+    def setup_nodes(self):
+        # This test requires mocktime
+        enable_mocktime()
+        return start_nodes(self.num_nodes, self.options.tmpdir)
+
+    def run_test(self):
+        self.nodes[0].generate(1001)
+        self.sync_all()
+
+        # get a watch only address
+        watchonly_address = self.nodes[3].getnewaddress()
+        watchonly_pubkey = self.nodes[3].validateaddress(watchonly_address)["pubkey"]
+        self.nodes[0].importpubkey(watchonly_pubkey, "", True)
+
+        valid_address = self.nodes[0].getnewaddress()
+
+        for _ in range(10):
+            self.nodes[0].mintlelantus(1)
+
+        self.nodes[0].generate(10)
+        self.sync_all()
+
+        # case 1: Spend many with watchonly address
+        spendto_wo_id = self.nodes[0].joinsplit("", {watchonly_address: 1})
+        spendto_wo_tx = self.nodes[0].gettransaction(spendto_wo_id)
+
+        assert spendto_wo_tx['amount'] == Decimal('-1')
+        assert spendto_wo_tx['fee'] < Decimal('0')
+        assert isinstance(spendto_wo_tx['details'], list)
+        assert len(spendto_wo_tx['details']) == 1
+        assert spendto_wo_tx['details'][0]['involvesWatchonly']
+
+        # case 2: Spend many with watchonly address and valid address
+        spendto_wo_and_valid_id = self.nodes[0].joinsplit("", {watchonly_address: 1, valid_address: 2})
+        spendto_wo_and_valid_tx = self.nodes[0].gettransaction(spendto_wo_and_valid_id)
+
+        assert spendto_wo_and_valid_tx['amount'] == Decimal('-1')
+        assert spendto_wo_and_valid_tx['fee'] < Decimal('0')
+        assert isinstance(spendto_wo_and_valid_tx['details'], list)
+        assert len(spendto_wo_and_valid_tx['details']) == 3
+
+        involves_watch_only_count = 0
+        for detial in spendto_wo_and_valid_tx['details']:
+            if 'involvesWatchonly' in detial and bool(detial['involvesWatchonly']):
+                involves_watch_only_count += 1
+
+        assert involves_watch_only_count == 1
+
+        # case 3: spend many with watchonly address and invalid address
+        assert_raises(JSONRPCException, self.nodes[0].joinsplit, ["", {watchonly_address: 1, 'invalidaddress': 2}])
+
+if __name__ == '__main__':
+    JoinSplitGettransactionTest().main()
+
+

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -129,6 +129,7 @@ BITCOIN_TESTS = \
   test/lelantus_tests.cpp \
   test/lelantus_mintspend_test.cpp \
   test/lelantus_state_tests.cpp \
+  test/sigma_lelantus_transition.cpp \
   test/limitedmap_tests.cpp \
   test/main_tests.cpp \
   test/mbstring_tests.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -126,8 +126,8 @@ BITCOIN_TESTS = \
   test/hash_tests.cpp \
   test/key_tests.cpp \
   test/dbwrapper_tests.cpp \
-  # test/lelantus_tests.cpp \
-  # test/lelantus_state_tests.cpp \
+  test/lelantus_tests.cpp \
+  test/lelantus_state_tests.cpp \
   test/limitedmap_tests.cpp \
   test/main_tests.cpp \
   test/mbstring_tests.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -127,6 +127,7 @@ BITCOIN_TESTS = \
   test/key_tests.cpp \
   test/dbwrapper_tests.cpp \
   test/lelantus_tests.cpp \
+  test/lelantus_mintspend_test.cpp \
   test/lelantus_state_tests.cpp \
   test/limitedmap_tests.cpp \
   test/main_tests.cpp \

--- a/src/hdmint/tracker.cpp
+++ b/src/hdmint/tracker.cpp
@@ -1222,11 +1222,7 @@ std::vector<CMintMeta> CHDMintTracker::ListMints(bool fUnusedOnly, bool fMatureO
 
 std::vector<CLelantusMintMeta> CHDMintTracker::ListLelantusMints(bool fUnusedOnly, bool fMatureOnly, bool fUpdateStatus, bool fLoad, bool fWrongSeed)
 {
-    std::vector<CLelantusMintMeta> vOverWrite;
-    std::set<uint256> setMempool = GetMempoolTxids();
-
     std::vector<CLelantusMintMeta> setMints;
-
     if (fLoad) {
         LOCK2(cs_main, pwalletMain->cs_wallet);
         CWalletDB walletdb(strWalletFile);
@@ -1237,6 +1233,9 @@ std::vector<CLelantusMintMeta> CHDMintTracker::ListLelantusMints(bool fUnusedOnl
         }
         LogPrint("zero", "%s: added %d lelantus hdmint from DB\n", __func__, listDeterministicDB.size());
     }
+
+    std::vector<CLelantusMintMeta> vOverWrite;
+    std::set<uint256> setMempool = GetMempoolTxids();
 
     for (auto& it : mapLelantusSerialHashes) {
         CLelantusMintMeta mint = it.second;

--- a/src/hdmint/tracker.cpp
+++ b/src/hdmint/tracker.cpp
@@ -1226,9 +1226,11 @@ std::vector<CLelantusMintMeta> CHDMintTracker::ListLelantusMints(bool fUnusedOnl
     std::set<uint256> setMempool = GetMempoolTxids();
 
     std::vector<CLelantusMintMeta> setMints;
-    LOCK2(cs_main, pwalletMain->cs_wallet);
-    CWalletDB walletdb(strWalletFile);
+
     if (fLoad) {
+        LOCK2(cs_main, pwalletMain->cs_wallet);
+        CWalletDB walletdb(strWalletFile);
+
         std::list<CHDMint> listDeterministicDB = walletdb.ListHDMints(true);
         for (auto& dMint : listDeterministicDB) {
             AddLelantus(walletdb, dMint, false, false);

--- a/src/hdmint/tracker.cpp
+++ b/src/hdmint/tracker.cpp
@@ -515,6 +515,19 @@ void CHDMintTracker::SetPubcoinNotUsed(const uint256& hashPubcoin)
     UpdateState(meta);
 }
 
+void CHDMintTracker::SetLelantusPubcoinNotUsed(const uint256& hashPubcoin)
+{
+    CLelantusMintMeta meta;
+    if(!GetLelantusMetaFromPubcoin(hashPubcoin, meta))
+        return;
+    meta.isUsed = false;
+
+    if (mapPendingSpends.count(meta.hashSerial))
+        mapPendingSpends.erase(meta.hashSerial);
+
+    UpdateState(meta);
+}
+
 
 /**
  * Check mempool for the spend associated with the mint serial hash passed

--- a/src/hdmint/wallet.cpp
+++ b/src/hdmint/wallet.cpp
@@ -250,7 +250,7 @@ void CHDMintWallet::SetWalletTransactionBlock(CWalletTx &wtx, const CBlockIndex 
  */
 void CHDMintWallet::SyncWithChain(bool fGenerateMintPool, boost::optional<std::list<std::pair<uint256, MintPoolEntry>>> listMints)
 {
-    LOCK(pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwalletMain->cs_wallet);
     CWalletDB walletdb(strWalletFile);
     bool found = true;
 

--- a/src/hdmint/wallet.cpp
+++ b/src/hdmint/wallet.cpp
@@ -250,7 +250,6 @@ void CHDMintWallet::SetWalletTransactionBlock(CWalletTx &wtx, const CBlockIndex 
  */
 void CHDMintWallet::SyncWithChain(bool fGenerateMintPool, boost::optional<std::list<std::pair<uint256, MintPoolEntry>>> listMints)
 {
-    LOCK2(cs_main, pwalletMain->cs_wallet);
     CWalletDB walletdb(strWalletFile);
     bool found = true;
 

--- a/src/lelantus.cpp
+++ b/src/lelantus.cpp
@@ -264,9 +264,11 @@ bool CheckLelantusJMintTransaction(
                 "CheckLelantusMintTransaction: double mint");
     }
 
-     uint64_t amount;
-     if(!pwalletMain->DecryptMintAmount(encryptedValue, pubCoinValue, amount))
-         amount = 0;
+    uint64_t amount = 0;
+    if (pwalletMain) {
+        if (!pwalletMain->DecryptMintAmount(encryptedValue, pubCoinValue, amount))
+            amount = 0;
+    }
     if (lelantusTxInfo != NULL && !lelantusTxInfo->fInfoIsComplete) {
 
         // Update public coin list in the info

--- a/src/lelantus.cpp
+++ b/src/lelantus.cpp
@@ -1019,7 +1019,9 @@ CLelantusState::CLelantusState(
     :containers(surgeCondition),
     maxCoinInGroup(maxCoinInGroup),
     startGroupSize(startGroupSize)
-{}
+{
+    Reset();
+}
 
 void CLelantusState::AddMintsToStateAndBlockIndex(
         CBlockIndex *index,

--- a/src/lelantus.h
+++ b/src/lelantus.h
@@ -14,6 +14,8 @@
 #include <functional>
 #include "coin_containers.h"
 
+namespace lelantus_mintspend { class lelantus_mintspend_test; }
+
 namespace lelantus {
 
 // Lelantus transaction info, added to the CBlock to ensure zerocoin mint/spend transactions got their info stored into index
@@ -249,9 +251,13 @@ private:
         metainfo_container_t extendedMintMetaInfo, mintMetaInfo, spendMetaInfo;
 
         void CheckSurgeCondition();
+
+        friend class lelantus_mintspend::lelantus_mintspend_test;
     };
 
     Containers containers;
+
+    friend class lelantus_mintspend::lelantus_mintspend_test;
 };
 
 } // end of namespace lelantus

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -753,6 +753,7 @@ int main(int argc, char *argv[])
     // - hdseed not set (default, not setting hd seed from conf file instead)
 
     if(GetBoolArg("-usemnemonic", DEFAULT_USE_MNEMONIC) &&
+       !GetBoolArg("-disablewallet", false) &&
        GetArg("-mnemonic", "").empty() &&
        GetArg("-hdseed", "not hex")=="not hex"){
         if(!Recover::askRecover(newWallet))

--- a/src/qt/lelantusmodel.cpp
+++ b/src/qt/lelantusmodel.cpp
@@ -70,6 +70,9 @@ std::pair<CAmount, CAmount> LelantusModel::getPrivateBalance(size_t &confirmed, 
 
     auto zwallet = pwalletMain->zwallet.get();
 
+    if(!zwallet)
+        return balance;
+
     auto coins = zwallet->GetTracker().ListLelantusMints(true, false, false);
     for (auto const &c : coins) {
 

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -89,9 +89,6 @@ SendCoinsDialog::SendCoinsDialog(const PlatformStyle *_platformStyle, QWidget *p
     ui->labelCoinControlLowOutput->addAction(clipboardLowOutputAction);
     ui->labelCoinControlChange->addAction(clipboardChangeAction);
 
-    darkerColor = QColor(0xe0, 0xe0, 0xe0);
-    defaultColor = palette().color(QPalette::Background);
-
     ui->frameCoinControl->setAutoFillBackground(true);
     ui->scrollArea->setAutoFillBackground(true);
     ui->frameFee->setAutoFillBackground(true);
@@ -718,7 +715,6 @@ void SendCoinsDialog::setAnonymizeMode(bool enableAnonymizeMode)
 {
     fAnonymousMode = enableAnonymizeMode;
 
-    QColor bgColor;
     if (fAnonymousMode) {
         ui->switchFundButton->setText(QString("Use Transparent Balance"));
         ui->label->setText(QString("Private Balance"));
@@ -726,7 +722,6 @@ void SendCoinsDialog::setAnonymizeMode(bool enableAnonymizeMode)
         ui->checkBoxCoinControlChange->setEnabled(false);
         ui->lineEditCoinControlChange->setEnabled(false);
 
-        bgColor = darkerColor;
     } else {
         ui->switchFundButton->setText(QString("Use Private Balance"));
         ui->label->setText(QString("Transparent Balance"));
@@ -736,21 +731,7 @@ void SendCoinsDialog::setAnonymizeMode(bool enableAnonymizeMode)
             ui->lineEditCoinControlChange->setEnabled(true);
         }
 
-        bgColor = defaultColor;
     }
-
-    QPalette pal;
-    pal = ui->frameCoinControl->palette();
-    pal.setColor(QPalette::Background, bgColor);
-    ui->frameCoinControl->setPalette(pal);
-
-    pal = ui->scrollArea->palette();
-    pal.setColor(QPalette::Background, bgColor);
-    ui->scrollArea->setPalette(pal);
-
-    pal = ui->frameFee->palette();
-    pal.setColor(QPalette::Background, bgColor);
-    ui->frameFee->setPalette(pal);
 
     if (model) {
         setBalance(model->getBalance(), 0, 0, 0, 0, 0, model->getLelantusModel()->getPrivateBalance().first, 0, 0);

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -66,9 +66,6 @@ private:
     bool fAnonymousMode;
     const PlatformStyle *platformStyle;
 
-    QColor darkerColor;
-    QColor defaultColor;
-
     // Process WalletModel::SendCoinsReturn and generate a pair consisting
     // of a message and message flags for use in Q_EMIT message().
     // Additional parameter msgArg can be used via .arg(msgArg).

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -563,7 +563,7 @@ WalletModel::SendCoinsReturn WalletModel::prepareMintTransactions(
     std::vector<CHDMint> &mints,
     const CCoinControl *coinControl)
 {
-    if (amount < 0) {
+    if (amount <= 0) {
         return InvalidAmount;
     }
 
@@ -577,8 +577,15 @@ WalletModel::SendCoinsReturn WalletModel::prepareMintTransactions(
     int changePos = -1;
     std::string failReason;
 
-    auto success = wallet->CreateLelantusMintTransactions(
-        amount, wtxAndFees, allFee, mints, reserveKeys, changePos, failReason, coinControl);
+    bool success = false;
+    try {
+        success = wallet->CreateLelantusMintTransactions(
+                amount, wtxAndFees, allFee, mints, reserveKeys, changePos, failReason, coinControl);
+
+    } catch (std::runtime_error const &e) {
+        return SendCoinsReturn(TransactionCreationFailed, e.what());
+    }
+
 
     transactions.clear();
     transactions.reserve(wtxAndFees.size());

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -178,6 +178,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "listsigmaspends", 1 },
     { "listlelantusjoinsplits", 0 },
     { "listlelantusjoinsplits", 1 },
+    { "joinsplit", 0 },
+    { "joinsplit", 2 },
     { "spendallzerocoin", 0 },
     { "remintzerocointosigma", 0 },
     { "getanonymityset", 0},

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -113,7 +113,7 @@ bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, vector<vector<unsi
     if (scriptPubKey.IsLelantusJMint())
     {
         typeRet = TX_LELANTUSJMINT;
-        if (scriptPubKey.size() != 82) return false;
+        if (scriptPubKey.size() != 83) return false;
         vSolutionsRet.emplace_back(scriptPubKey.begin() + 1, scriptPubKey.end());
         return true;
     }

--- a/src/test/fixtures.cpp
+++ b/src/test/fixtures.cpp
@@ -225,9 +225,6 @@ LelantusTestingSetup::LelantusTestingSetup() :
 }
 
 CBlockIndex* LelantusTestingSetup::GenerateBlock(std::vector<CMutableTransaction> const &txns, CScript *script) {
-    // NOTE: work around for deadlock problem, remove this when resolved
-    LOCK2(cs_main, pwalletMain->cs_wallet);
-    LOCK(mempool.cs);
     auto last = chainActive.Tip();
 
     CreateAndProcessBlock(txns, script ? *script : this->script);

--- a/src/test/fixtures.cpp
+++ b/src/test/fixtures.cpp
@@ -241,7 +241,7 @@ CBlockIndex* LelantusTestingSetup::GenerateBlock(std::vector<CMutableTransaction
 }
 
 void LelantusTestingSetup::GenerateBlocks(size_t blocks, CScript *script) {
-    while (--blocks) {
+    while (blocks--) {
         GenerateBlock({}, script);
     }
 }
@@ -298,10 +298,10 @@ std::vector<CHDMint> LelantusTestingSetup::GenerateMints(
             throw std::runtime_error(_("Fail to generate mints, ") + result);
         }
 
-        txs.emplace_back(wtxAndFee.front().first);
+        for(auto itr : wtxAndFee)
+            txs.emplace_back(itr.first);
 
         hdMints.insert(hdMints.end(), mints.begin(), mints.end());
-        pwalletMain->zwallet->GetTracker().AddLelantus(walletdb, hdMints.back(), true);
     }
 
     return hdMints;

--- a/src/test/lelantus_mintspend_test.cpp
+++ b/src/test/lelantus_mintspend_test.cpp
@@ -1,0 +1,173 @@
+#include "util.h"
+
+#include <stdint.h>
+#include <vector>
+
+#include "chainparams.h"
+#include "key.h"
+#include "validation.h"
+#include "pubkey.h"
+#include "txdb.h"
+#include "txmempool.h"
+#include "lelantus.h"
+
+#include "test/fixtures.h"
+#include "test/testutil.h"
+
+#include "wallet/db.h"
+#include "wallet/wallet.h"
+#include "wallet/walletexcept.h"
+
+#include <boost/filesystem.hpp>
+#include <boost/test/unit_test.hpp>
+#include <boost/thread.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(lelantus_mintspend, LelantusTestingSetup)
+
+BOOST_AUTO_TEST_CASE(lelantus_mintspend_test)
+{
+    GenerateBlocks(1000);
+
+    lelantus::CLelantusState *lelantusState = lelantus::CLelantusState::GetState();
+
+    // Make sure that transactions get to mempool
+    pwalletMain->SetBroadcastTransactions(true);
+
+    std::vector<CMutableTransaction> mintTxs;
+    auto hdMints = GenerateMints({50 * COIN, 60 * COIN}, mintTxs);
+
+    // Verify Mint gets in the mempool
+    BOOST_CHECK_MESSAGE(mempool.size() == hdMints.size(), "Mints were not added to mempool");
+
+    int previousHeight = chainActive.Height();
+    auto blockIdx1 = GenerateBlock(mintTxs);
+    BOOST_CHECK(blockIdx1);
+
+    BOOST_CHECK_MESSAGE(previousHeight + 1 == chainActive.Height(), "Block not added to chain");
+    BOOST_CHECK_MESSAGE(mempool.size() == 0, "Mints were not removed from mempool");
+    previousHeight = chainActive.Height();
+
+    // Generate address
+    CPubKey newKey;
+    BOOST_CHECK_MESSAGE(pwalletMain->GetKeyFromPool(newKey), "Fail to get new address");
+
+    const CBitcoinAddress randomAddr(newKey.GetID());
+    std::vector<CRecipient> recipients = {
+        {GetScriptForDestination(randomAddr.Get()), 30 * COIN, true},
+    };
+
+    // Add 5 more blocks and verify that Mint can not be spent until 6 blocks verification
+    for (int i = 0; i < 5; i++)
+    {
+        {
+            CWalletTx wtx;
+            BOOST_CHECK_THROW(pwalletMain->JoinSplitLelantus(recipients, {}, wtx), WalletError); //this must throw as it has to have at least two mint coins with at least 6 confirmation
+        }
+
+        GenerateBlock({});
+    }
+
+    BOOST_CHECK_MESSAGE(previousHeight + 5 == chainActive.Height(), "Block not added to chain");
+    BOOST_CHECK_MESSAGE(mempool.size() == 0, "Mempool must be empty");
+
+    CWalletTx wtx;
+    {
+        BOOST_CHECK_NO_THROW(pwalletMain->JoinSplitLelantus(recipients, {}, wtx)); //this must pass
+    }
+    BOOST_CHECK_MESSAGE(mempool.size() == 1, "JoinSplit is not added into mempool");
+
+    previousHeight = chainActive.Height();
+    GenerateBlock({CMutableTransaction(*wtx.tx)});
+    BOOST_CHECK_MESSAGE(previousHeight + 1 == chainActive.Height(), "Block not added to chain");
+    BOOST_CHECK_MESSAGE(mempool.size() == 0, "JoinSplit is not removed from mempool");
+    GenerateBlocks(6);
+    std::vector<CLelantusEntry> spendCoins; //spends
+    CWalletTx result;
+    {
+        std::vector<CHDMint> mintCoins; // new mints
+        CAmount fee;
+        result = pwalletMain->CreateLelantusJoinSplitTransaction(recipients, fee, {}, spendCoins, mintCoins);
+        pwalletMain->CommitLelantusTransaction(result, spendCoins, mintCoins);
+    }
+    BOOST_CHECK_MESSAGE(mempool.size() == 1, "Joinsplit was not added to mempool");
+
+    //Set mints unused, and try to spend again
+    for(auto mint : spendCoins)
+        pwalletMain->zwallet->GetTracker().SetLelantusPubcoinNotUsed(primitives::GetPubCoinValueHash(mint.value));
+
+    wtx.Init(NULL);
+    //try double spend
+    BOOST_CHECK_NO_THROW(pwalletMain->JoinSplitLelantus(recipients, {}, wtx));
+    //Verify spend got into mempool
+    BOOST_CHECK_MESSAGE(mempool.size() == 1, "Double spend was added into mempool, but was not supposed");
+
+    previousHeight = chainActive.Height();
+    GenerateBlock({CMutableTransaction(*result.tx)});
+    BOOST_CHECK_MESSAGE(previousHeight + 1 == chainActive.Height(), "Block not added to chain");
+    BOOST_CHECK_MESSAGE(mempool.size() == 0, "Mempool not cleared");
+    GenerateBlocks(6);
+    for(auto mint : spendCoins)
+        pwalletMain->zwallet->GetTracker().SetLelantusPubcoinUsed(primitives::GetPubCoinValueHash(mint.value), uint256());
+
+    spendCoins.clear(); //spends
+    result.Init(NULL);
+    {
+        std::vector<CHDMint> mintCoins; // new mints
+        CAmount fee;
+        result = pwalletMain->CreateLelantusJoinSplitTransaction(recipients, fee, {}, spendCoins, mintCoins);
+        pwalletMain->CommitLelantusTransaction(result, spendCoins, mintCoins);
+    }
+
+    //Verify spend got into mempool
+    BOOST_CHECK_MESSAGE(mempool.size() == 1, "Spend was not added to mempool");
+
+    previousHeight = chainActive.Height();
+    GenerateBlock({CMutableTransaction(*result.tx)});
+    BOOST_CHECK_MESSAGE(previousHeight + 1 == chainActive.Height(), "Block not added to chain");
+    BOOST_CHECK_MESSAGE(mempool.size() == 0, "Mempool not cleared");
+    GenerateBlocks(6);
+
+    //Set mints unused, and try to spend again
+    for(auto mint : spendCoins)
+        pwalletMain->zwallet->GetTracker().SetLelantusPubcoinNotUsed(primitives::GetPubCoinValueHash(mint.value));
+    //try double spend
+    wtx.Init(NULL);
+
+    BOOST_CHECK_NO_THROW(pwalletMain->JoinSplitLelantus(recipients, {}, wtx));
+    BOOST_CHECK_MESSAGE(mempool.size() == 0, "Mempool not empty although mempool should reject double spend");
+
+    //Temporary disable usedCoinSerials check to force double spend in mempool
+    auto tempSerials = lelantusState->containers.usedCoinSerials;
+    lelantusState->containers.usedCoinSerials.clear();
+
+    {
+        //Set mints unused, and try to spend again
+        for(auto mint : spendCoins)
+            pwalletMain->zwallet->GetTracker().SetLelantusPubcoinNotUsed(primitives::GetPubCoinValueHash(mint.value));
+        wtx.Init(NULL);
+        BOOST_CHECK_NO_THROW(pwalletMain->JoinSplitLelantus(recipients, {}, wtx));
+        BOOST_CHECK_MESSAGE(mempool.size() == 1, "Spend was not added to mempool");
+    }
+
+    lelantusState->containers.usedCoinSerials = tempSerials;
+
+    BOOST_CHECK_EXCEPTION(CreateBlock({CMutableTransaction(*wtx.tx)}, script), std::runtime_error, no_check);
+    BOOST_CHECK_MESSAGE(mempool.size() == 1, "Mempool not set");
+    tempSerials = lelantusState->containers.usedCoinSerials;
+    lelantusState->containers.usedCoinSerials.clear();
+    CBlock b = CreateBlock({CMutableTransaction(*wtx.tx)}, script);
+
+    lelantusState->containers.usedCoinSerials = tempSerials;
+
+    mempool.clear();
+    previousHeight = chainActive.Height();
+
+    const CChainParams& chainparams = Params();
+    BOOST_CHECK_MESSAGE(ProcessNewBlock(chainparams, std::make_shared<const CBlock>(b), true, NULL), "ProcessBlock failed");
+    //This test confirms that a block containing a double spend is rejected and not added in the chain
+    BOOST_CHECK_MESSAGE(previousHeight == chainActive.Height(), "Double spend - Block added to chain even though same spend in previous block");
+
+    mempool.clear();
+    lelantusState->Reset();
+}
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/lelantus_state_tests.cpp
+++ b/src/test/lelantus_state_tests.cpp
@@ -326,6 +326,8 @@ BOOST_AUTO_TEST_CASE(add_remove_block)
     BOOST_CHECK(lelantusState->IsUsedCoinSerial(serial1));
     BOOST_CHECK(lelantusState->IsUsedCoinSerial(serial2));
     BOOST_CHECK(!lelantusState->IsUsedCoinSerial(serial3));
+
+    lelantusState->Reset();
 }
 
 BOOST_AUTO_TEST_CASE(get_coin_group)
@@ -493,6 +495,8 @@ BOOST_AUTO_TEST_CASE(get_coin_group)
     lelantusState->RemoveBlock(indexes[5]);
     verifyGroup(2, 6, indexes[2], indexes[4]);
     verifyGroup(1, 6, indexes[0], indexes[2], 1);
+
+    lelantusState->Reset();
 }
 
 // Surge condition testing

--- a/src/test/lelantus_tests.cpp
+++ b/src/test/lelantus_tests.cpp
@@ -19,7 +19,7 @@ struct JoinSplitScriptGenerator {
     CAmount vout;
     std::vector<PrivateCoin> coinsOut;
     CAmount fee;
-    std::vector<uint256> groupBlockHashes;
+    std::map<uint32_t, uint256> groupBlockHashes;
     uint256 txHash;
 
     std::pair<CScript, JoinSplit> Get() {
@@ -98,7 +98,7 @@ public:
 
     void PopulateLelantusTxInfo(
         CBlock &block,
-        std::vector<std::pair<secp_primitives::GroupElement, int64_t>> const &mints,
+        std::vector<std::pair<lelantus::PublicCoin, std::pair<uint64_t, uint256>>> const &mints,
         std::vector<std::pair<Scalar, int>> const &serials) {
         block.lelantusTxInfo = std::make_shared<lelantus::CLelantusTxInfo>();
         block.lelantusTxInfo->mints.insert(block.lelantusTxInfo->mints.end(), mints.begin(), mints.end());
@@ -198,7 +198,8 @@ BOOST_AUTO_TEST_CASE(parse_lelantus_mintscript)
     BOOST_CHECK(pub.getValue() == parsedCoin);
 
     SchnorrProof proof;
-    ParseLelantusMintScript(script, parsedCoin, proof);
+    uint256 mintTag;
+    ParseLelantusMintScript(script, parsedCoin, proof, mintTag);
 
     BOOST_CHECK(pub.getValue() == parsedCoin);
     BOOST_CHECK(VerifyMintSchnorrProof(1, parsedCoin, proof));
@@ -214,7 +215,7 @@ BOOST_AUTO_TEST_CASE(parse_lelantus_mintscript)
     BOOST_CHECK(pub.getValue() == parsedCoin2);
 
     script.resize(script.size() - 1);
-    BOOST_CHECK_THROW(ParseLelantusMintScript(script, parsedCoin, proof), std::invalid_argument);
+    BOOST_CHECK_THROW(ParseLelantusMintScript(script, parsedCoin, proof, mintTag), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(parse_lelantus_jmint)
@@ -274,7 +275,7 @@ BOOST_AUTO_TEST_CASE(get_outpoint)
     BOOST_CHECK(ReadBlockFromDisk(block, blockIdx, ::Params().GetConsensus()));
 
     block.lelantusTxInfo = std::make_shared<lelantus::CLelantusTxInfo>();
-    block.lelantusTxInfo->mints.emplace_back(mint.GetPubcoinValue(), mint.GetAmount());
+    block.lelantusTxInfo->mints.emplace_back(std::make_pair(mint.GetPubcoinValue(), std::make_pair(mint.GetAmount(), uint256())));
 
     lelantusState->AddMintsToStateAndBlockIndex(blockIdx, &block);
     lelantusState->AddBlock(blockIdx);
@@ -331,10 +332,10 @@ BOOST_AUTO_TEST_CASE(build_lelantus_state)
     block1.lelantusTxInfo = std::make_shared<lelantus::CLelantusTxInfo>();
     block2.lelantusTxInfo = std::make_shared<lelantus::CLelantusTxInfo>();
 
-    block1.lelantusTxInfo->mints.emplace_back(mints[0].GetPubcoinValue(), mints[0].GetAmount());
-    block1.lelantusTxInfo->mints.emplace_back(mints[1].GetPubcoinValue(), mints[1].GetAmount());
-    block2.lelantusTxInfo->mints.emplace_back(mints[2].GetPubcoinValue(), mints[2].GetAmount());
-    block2.lelantusTxInfo->mints.emplace_back(mints[3].GetPubcoinValue(), mints[3].GetAmount());
+    block1.lelantusTxInfo->mints.emplace_back(std::make_pair(mints[0].GetPubcoinValue(), std::make_pair(mints[0].GetAmount(), uint256())));
+    block1.lelantusTxInfo->mints.emplace_back(std::make_pair(mints[1].GetPubcoinValue(), std::make_pair(mints[1].GetAmount(), uint256())));
+    block1.lelantusTxInfo->mints.emplace_back(std::make_pair(mints[2].GetPubcoinValue(), std::make_pair(mints[2].GetAmount(), uint256())));
+    block1.lelantusTxInfo->mints.emplace_back(std::make_pair(mints[3].GetPubcoinValue(), std::make_pair(mints[3].GetAmount(), uint256())));
 
     lelantusState->AddMintsToStateAndBlockIndex(blockIdx1, &block1);
     lelantusState->AddMintsToStateAndBlockIndex(blockIdx2, &block2);
@@ -444,20 +445,19 @@ BOOST_AUTO_TEST_CASE(connect_and_disconnect_block)
     // Update isused status
     {
         auto mint = hdMints[0];
-        auto pubCoin = mint.GetPubcoinValue()
-            + lelantus::Params::get_default()->get_h1() * Scalar(mint.GetAmount()).negate();
-        auto hash = primitives::GetPubCoinValueHash(pubCoin);
+        auto hash = primitives::GetPubCoinValueHash(mint.GetPubcoinValue());
 
         CLelantusMintMeta meta;
-        BOOST_CHECK(zwalletMain->GetTracker()
+        BOOST_CHECK(pwalletMain->zwallet->GetTracker()
             .GetLelantusMetaFromPubcoin(hash, meta));
+        
         BOOST_CHECK(meta.isUsed);
 
         meta.isUsed = false;
-        BOOST_CHECK(zwalletMain->GetTracker().UpdateState(meta));
+        BOOST_CHECK(pwalletMain->zwallet->GetTracker().UpdateState(meta));
 
         meta = CLelantusMintMeta();
-        BOOST_CHECK(zwalletMain->GetTracker()
+        BOOST_CHECK(pwalletMain->zwallet->GetTracker()
             .GetLelantusMetaFromPubcoin(hash, meta));
         BOOST_CHECK(!meta.isUsed);
     }
@@ -557,7 +557,7 @@ BOOST_AUTO_TEST_CASE(checktransaction)
     BOOST_CHECK(CheckLelantusTransaction(
         txs[0], state, tx.GetHash(), true, chainActive.Height(), true, true, NULL, &info));
 
-    std::vector<std::pair<PublicCoin, uint64_t>> expectedCoins = {{mints[0].GetPubcoinValue(), 1 * CENT}};
+    std::vector<std::pair<PublicCoin, std::pair<uint64_t, uint256>>> expectedCoins = {{mints[0].GetPubcoinValue(), {1 * CENT, uint256()}}};
     BOOST_CHECK(expectedCoins == info.mints);
 
     // join split
@@ -621,13 +621,13 @@ BOOST_AUTO_TEST_CASE(spend_limitation_per_tx)
     invalidG.fee = 0;
     invalidG.vout = 0;
     invalidG.coinsOut = {coinOut};
-    invalidG.groupBlockHashes = {ArithToUint256(0)};
+    invalidG.groupBlockHashes[1] = {ArithToUint256(0)};
     invalidG.txHash = ArithToUint256(0);
 
     validG.fee = 0;
     validG.vout = 0;
     validG.coinsOut = {coinOut};
-    validG.groupBlockHashes = {ArithToUint256(0)};
+    validG.groupBlockHashes[1] = ArithToUint256(0);
     validG.txHash = ArithToUint256(0);
 
     for (size_t i = 0; i != consensus.nMaxLelantusInputPerTransaction + 1; i++) {
@@ -676,7 +676,7 @@ BOOST_AUTO_TEST_CASE(spend_limitation_per_block)
             spends++;
         }
 
-        g.groupBlockHashes = {ArithToUint256(i)};
+        g.groupBlockHashes[1] = ArithToUint256(i);
         g.txHash = ArithToUint256(i);
 
         CMutableTransaction tx;
@@ -717,7 +717,8 @@ BOOST_AUTO_TEST_CASE(parse_joinsplit)
     g.vout = 11 * COIN - CENT;
     g.coinsOut.push_back(coins[3]);
     g.fee = CENT;
-    g.groupBlockHashes = {ArithToUint256(1), ArithToUint256(2)};
+    g.groupBlockHashes[1] = ArithToUint256(1);
+    g.groupBlockHashes[2] = ArithToUint256(2);
     g.txHash = ArithToUint256(3);
 
     auto gs = g.Get();

--- a/src/test/lelantus_tests.cpp
+++ b/src/test/lelantus_tests.cpp
@@ -351,8 +351,7 @@ BOOST_AUTO_TEST_CASE(connect_and_disconnect_block)
 {
     // util function
     auto reconnect = [](CBlock const &block) {
-        LOCK2(cs_main, pwalletMain->cs_wallet);
-        LOCK(mempool.cs);
+        LOCK(cs_main);
 
         std::shared_ptr<CBlock const> sharedBlock =
         std::make_shared<CBlock const>(block);

--- a/src/test/lelantus_tests.cpp
+++ b/src/test/lelantus_tests.cpp
@@ -397,7 +397,6 @@ BOOST_AUTO_TEST_CASE(connect_and_disconnect_block)
 
             CLelantusState::LelantusCoinGroupInfo group;
             state->GetCoinGroupInfo(retrievedId, group);
-
             BOOST_CHECK_EQUAL(lastId, retrievedId);
             BOOST_CHECK_EQUAL(first, group.firstBlock);
             BOOST_CHECK_EQUAL(last, group.lastBlock);
@@ -450,7 +449,7 @@ BOOST_AUTO_TEST_CASE(connect_and_disconnect_block)
         CLelantusMintMeta meta;
         BOOST_CHECK(pwalletMain->zwallet->GetTracker()
             .GetLelantusMetaFromPubcoin(hash, meta));
-        
+
         BOOST_CHECK(meta.isUsed);
 
         meta.isUsed = false;
@@ -541,6 +540,8 @@ BOOST_AUTO_TEST_CASE(connect_and_disconnect_block)
     auto currentBlock = chainActive.Tip()->nHeight;
     BOOST_CHECK(!GenerateBlock({dupJsTx1}));
     BOOST_CHECK_EQUAL(currentBlock, chainActive.Tip()->nHeight);
+    mempool.clear();
+    lelantusState->Reset();
 }
 
 BOOST_AUTO_TEST_CASE(checktransaction)
@@ -557,7 +558,8 @@ BOOST_AUTO_TEST_CASE(checktransaction)
     BOOST_CHECK(CheckLelantusTransaction(
         txs[0], state, tx.GetHash(), true, chainActive.Height(), true, true, NULL, &info));
 
-    std::vector<std::pair<PublicCoin, std::pair<uint64_t, uint256>>> expectedCoins = {{mints[0].GetPubcoinValue(), {1 * CENT, uint256()}}};
+    std::vector<std::pair<PublicCoin, std::pair<uint64_t, uint256>>> expectedCoins = {{mints[0].GetPubcoinValue(), {1 * CENT, info.mints[0].second.second}}};
+
     BOOST_CHECK(expectedCoins == info.mints);
 
     // join split

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -254,14 +254,14 @@ BOOST_AUTO_TEST_CASE(rpc_ban)
     ar = r.get_array();
     BOOST_CHECK_EQUAL(ar.size(), 0);
 
-    BOOST_CHECK_NO_THROW(r = CallRPC(std::string("setban 127.0.0.0/24 add 1607731200 true")));
+    BOOST_CHECK_NO_THROW(r = CallRPC(std::string("setban 127.0.0.0/24 add 9907731200 true")));
     BOOST_CHECK_NO_THROW(r = CallRPC(std::string("listbanned")));
     ar = r.get_array();
     o1 = ar[0].get_obj();
     adr = find_value(o1, "address");
     UniValue banned_until = find_value(o1, "banned_until");
     BOOST_CHECK_EQUAL(adr.get_str(), "127.0.0.0/24");
-    BOOST_CHECK_EQUAL(banned_until.get_int64(), 1607731200); // absolute time check
+    BOOST_CHECK_EQUAL(banned_until.get_int64(), 9907731200); // absolute time check
 
     BOOST_CHECK_NO_THROW(CallRPC(std::string("clearbanned")));
 

--- a/src/test/sigma_lelantus_transition.cpp
+++ b/src/test/sigma_lelantus_transition.cpp
@@ -1,0 +1,140 @@
+
+#include <stdint.h>
+#include <vector>
+
+#include "key.h"
+#include "validation.h"
+#include "pubkey.h"
+#include "txmempool.h"
+#include "sigma.h"
+#include "lelantus.h"
+
+#include "test/fixtures.h"
+#include "test/testutil.h"
+
+#include "wallet/db.h"
+#include "wallet/wallet.h"
+#include "wallet/walletexcept.h"
+
+#include <boost/filesystem.hpp>
+#include <boost/test/unit_test.hpp>
+#include <boost/thread.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(sigma_lelantus_transition, LelantusTestingSetup)
+
+BOOST_AUTO_TEST_CASE(sigma_lelantus_transition_test)
+{
+    GenerateBlocks(400);
+
+    pwalletMain->SetBroadcastTransactions(true);
+    string stringError;
+
+    string denomination;
+    std::vector<string> denominations = {"0.05", "0.1", "0.5", "1", "10", "25", "100"};
+    vector <CHDMint> vDMints;
+    // foreach denom from denominations
+    for(auto denomination : denominations)
+    {
+        sigma::CoinDenomination denom;
+        BOOST_CHECK_MESSAGE(StringToDenomination(denomination, denom), "Unable to convert denomination string to value.");
+
+        // Verify Mint is successful
+        std::vector <sigma::PrivateCoin> privCoins;
+        const auto &sigmaParams = sigma::Params::get_default();
+        privCoins.push_back(sigma::PrivateCoin(sigmaParams, denom));
+        privCoins.push_back(sigma::PrivateCoin(sigmaParams, denom));
+
+        vDMints.clear();
+        auto vecSend = CWallet::CreateSigmaMintRecipients(privCoins, vDMints);
+        CWalletTx wtx;
+        stringError = pwalletMain->MintAndStoreSigma(vecSend, privCoins, vDMints, wtx);
+
+        BOOST_CHECK_MESSAGE(stringError == "", "Create Mint Failed");
+
+        // Verify Mint gets in the mempool
+        BOOST_CHECK_MESSAGE(mempool.size() == 1, "Mint was not added to mempool");
+
+        int previousHeight = chainActive.Height();
+        GenerateBlock({CMutableTransaction(*wtx.tx)});
+        BOOST_CHECK_MESSAGE(previousHeight + 1 == chainActive.Height(), "Block not added to chain");
+        GenerateBlocks(6);
+    }
+
+    std::list<CSigmaEntry> coins = pwalletMain->GetAvailableCoins(nullptr, false);
+    BOOST_CHECK_MESSAGE(coins.size() == denominations.size() * 2, "Wrong number of available sigma coins");
+
+    GenerateBlocks(600);
+
+    // Generate address
+    CPubKey newKey;
+    BOOST_CHECK_MESSAGE(pwalletMain->GetKeyFromPool(newKey), "Fail to get new address");
+    const CBitcoinAddress randomAddr(newKey.GetID());
+    std::vector<CRecipient> recipients = {
+        {GetScriptForDestination(randomAddr.Get()), 200 * COIN, true},
+    };
+
+    CWalletTx wtx;
+    {
+        BOOST_CHECK_NO_THROW(pwalletMain->JoinSplitLelantus(recipients, {}, wtx));
+    }
+    BOOST_CHECK_MESSAGE(mempool.size() == 1, "JoinSplit is not added into mempool");
+
+    int previousHeight = chainActive.Height();
+    GenerateBlock({CMutableTransaction(*wtx.tx)});
+    BOOST_CHECK_MESSAGE(previousHeight + 1 == chainActive.Height(), "Block not added to chain");
+    BOOST_CHECK_MESSAGE(mempool.size() == 0, "JoinSplit is not removed from mempool");
+    coins = pwalletMain->GetAvailableCoins(nullptr, false);
+    BOOST_CHECK_MESSAGE(coins.size() == denominations.size() * 2 - 2, "Spent sigma coins are not set as used");
+
+    for(auto mint : vDMints)
+        pwalletMain->zwallet->GetTracker().SetPubcoinNotUsed(primitives::GetPubCoinValueHash(mint.GetPubcoinValue()));
+
+    wtx.Init(NULL);
+    BOOST_CHECK_NO_THROW(pwalletMain->JoinSplitLelantus(recipients, {}, wtx));
+    BOOST_CHECK_MESSAGE(mempool.size() == 0, "Mempool not empty although mempool should reject double spend");
+
+    //roll back mints used
+    for(auto mint : vDMints)
+        pwalletMain->zwallet->GetTracker().SetPubcoinUsed(primitives::GetPubCoinValueHash(mint.GetPubcoinValue()), uint256());
+
+    std::vector<CMutableTransaction> mintTxs;
+    vDMints = GenerateMints({20 * COIN, 30 * COIN}, mintTxs);
+
+    // Verify Mint gets in the mempool
+    BOOST_CHECK_MESSAGE(mempool.size() == vDMints.size(), "Mints were not added to mempool");
+
+    previousHeight = chainActive.Height();
+    GenerateBlock(mintTxs);
+    BOOST_CHECK_MESSAGE(previousHeight + 1 == chainActive.Height(), "Block not added to chain");
+    BOOST_CHECK_MESSAGE(mempool.size() == 0, "Mints were not removed from mempool");
+    GenerateBlocks(6);
+    recipients = {
+        {GetScriptForDestination(randomAddr.Get()), 100 * COIN, true},
+    };
+    wtx.Init(NULL);
+    BOOST_CHECK_NO_THROW(pwalletMain->JoinSplitLelantus(recipients, {}, wtx));
+    BOOST_CHECK_MESSAGE(mempool.size() == 1, "JoinSplit is not added into mempool");
+
+    previousHeight = chainActive.Height();
+    GenerateBlock({CMutableTransaction(*wtx.tx)});
+    BOOST_CHECK_MESSAGE(previousHeight + 1 == chainActive.Height(), "Block not added to chain");
+    BOOST_CHECK_MESSAGE(mempool.size() == 0, "JoinSplit is not removed from mempool");
+
+    coins = pwalletMain->GetAvailableCoins(nullptr, false);
+    BOOST_CHECK_MESSAGE(coins.size() == 0, "All sigma coins should be marked used, but something went wrong");
+
+    auto lelantusCoins = pwalletMain->GetAvailableLelantusCoins(nullptr, false);
+    BOOST_CHECK_MESSAGE(lelantusCoins.size() < vDMints.size(), "Some of lelantus coins should be marked used, but something went wrong");
+
+    previousHeight = chainActive.Height();
+    GenerateBlocks(6);
+
+    auto currentLelantusCoins = pwalletMain->GetAvailableLelantusCoins(nullptr, false);
+    BOOST_CHECK_MESSAGE(currentLelantusCoins.size() > lelantusCoins.size(), "Newly created jmint should be marked as spendable, but something went wrong");
+
+    mempool.clear();
+    sigma::CSigmaState::GetState()->Reset();
+    lelantus::CLelantusState::GetState()->Reset();
+
+}
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/lelantusjoinsplitbuilder.cpp
+++ b/src/wallet/lelantusjoinsplitbuilder.cpp
@@ -369,9 +369,7 @@ void LelantusJoinSplitBuilder::GenerateMints(const std::vector<CAmount>& newMint
         std::vector<unsigned char> vch = pubCoin.getValue().getvch();
         scriptSerializedCoin.insert(scriptSerializedCoin.end(), vch.begin(), vch.end());
 
-        LOCK(pwalletMain->cs_wallet);
         std::vector<unsigned char> encryptedValue = pwalletMain->EncryptMintAmount(mintVal, pubCoin.getValue());
-
         scriptSerializedCoin.insert(scriptSerializedCoin.end(), encryptedValue.begin(), encryptedValue.end());
 
         auto pubcoin = hdMint.GetPubcoinValue() + lelantus::Params::get_default()->get_h1() * Scalar(hdMint.GetAmount()).negate();

--- a/src/wallet/lelantusjoinsplitbuilder.cpp
+++ b/src/wallet/lelantusjoinsplitbuilder.cpp
@@ -228,7 +228,7 @@ CWalletTx LelantusJoinSplitBuilder::Build(
             input += spend.amount;
         }
 
-        changeToMint += (input - currentVout - fee - changeToMint);
+        changeToMint += (input - currentVout - fee - changeToMint - mint);
 
         if(changeToMint > consensusParams.nMaxValueLelantusMint) {
             throw std::invalid_argument(

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2032,11 +2032,10 @@ UniValue gettransaction(const JSONRPCRequest& request)
     CAmount nDebit = wtx.GetDebit(filter);
     CAmount nNet = nCredit - nDebit;
     CAmount nFee = (wtx.IsFromMe(filter) ? wtx.tx->GetValueOut() - nDebit : 0);
+    if (wtx.tx->vin[0].IsLelantusJoinSplit())
+        nFee = (0 - lelantus::ParseLelantusJoinSplit(wtx.tx->vin[0])->getFee());
 
     entry.push_back(Pair("amount", ValueFromAmount(nNet - nFee)));
-
-    if (wtx.tx->vin[0].IsLelantusJoinSplit())
-        nFee = lelantus::ParseLelantusJoinSplit(wtx.tx->vin[0])->getFee();
 
     if (wtx.IsFromMe(filter))
         entry.push_back(Pair("fee", ValueFromAmount(nFee)));

--- a/src/wallet/test/lelantus_tests.cpp
+++ b/src/wallet/test/lelantus_tests.cpp
@@ -165,7 +165,12 @@ BOOST_AUTO_TEST_CASE(mintlelantus_and_mint_all)
         LOCK2(cs_main, pwalletMain->cs_wallet);
         std::vector<CScript> scripts;
         while (blocks != 0) {
-            auto key = pwalletMain->GenerateNewKey();
+
+            CPubKey key;
+            {
+                LOCK(pwalletMain->cs_wallet);
+                key = pwalletMain->GenerateNewKey();
+            }
             scripts.push_back(GetScriptForDestination(key.GetID()));
 
             auto blockCount = std::min(blocksPerScript, blocks);
@@ -261,7 +266,12 @@ BOOST_AUTO_TEST_CASE(spend)
 
     CWalletTx tx;
     std::vector<CRecipient> recipients;
-    auto pub = pwalletMain->GenerateNewKey();
+
+    CPubKey pub;
+    {
+        LOCK(pwalletMain->cs_wallet);
+        pub = pwalletMain->GenerateNewKey();
+    }
     recipients.push_back(CRecipient{
         .scriptPubKey = GetScriptForDestination(pub.GetID()),
         .nAmount = 5 * COIN,

--- a/src/wallet/test/lelantus_tests.cpp
+++ b/src/wallet/test/lelantus_tests.cpp
@@ -1,6 +1,8 @@
 #include "../../test/fixtures.h"
 #include "../../validation.h"
 #include "../../lelantus.h"
+#include "../walletexcept.h"
+#include <exception>
 
 #include "../wallet.h"
 
@@ -238,6 +240,51 @@ BOOST_AUTO_TEST_CASE(mintlelantus_and_mint_all)
             }
         }
     }
+}
+
+BOOST_AUTO_TEST_CASE(spend)
+{
+    fRequireStandard = true; // to verify mainnet can accept lelantus mint
+    pwalletMain->SetBroadcastTransactions(true);
+    GenerateBlocks(910);
+
+    std::vector<std::pair<CWalletTx, CAmount>> wtxAndFee;
+    std::vector<CHDMint> mints;
+    auto result = pwalletMain->MintAndStoreLelantus(10 * COIN, wtxAndFee, mints);
+    BOOST_CHECK_EQUAL("", result);
+    CMutableTransaction mutableTx(*(wtxAndFee[0].first.tx));
+    GenerateBlock({mutableTx}, &script);
+    GenerateBlocks(5);
+    BOOST_CHECK_EQUAL(1, wtxAndFee.size());
+    wtxAndFee.clear();
+    mints.clear();
+
+    CWalletTx tx;
+    std::vector<CRecipient> recipients;
+    auto pub = pwalletMain->GenerateNewKey();
+    recipients.push_back(CRecipient{
+        .scriptPubKey = GetScriptForDestination(pub.GetID()),
+        .nAmount = 5 * COIN,
+        .fSubtractFeeFromAmount = false
+    });
+
+    BOOST_CHECK_EXCEPTION(
+        pwalletMain->JoinSplitLelantus(recipients, {0}, tx),
+        InsufficientFunds,
+        [](const InsufficientFunds& e) { return e.what() == std::string("Insufficient funds"); });
+
+    result = pwalletMain->MintAndStoreLelantus(10 * COIN, wtxAndFee, mints);
+    BOOST_CHECK_EQUAL("", result);
+    mutableTx = (*(wtxAndFee[0].first.tx));
+    GenerateBlock({mutableTx}, &script);
+    GenerateBlocks(6);
+    BOOST_CHECK_EQUAL(1, wtxAndFee.size());
+    wtxAndFee.clear();
+    mints.clear();
+
+    BOOST_CHECK_NO_THROW(pwalletMain->JoinSplitLelantus(recipients, {0}, tx));
+
+    lelantus::CLelantusState::GetState()->Reset();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3202,18 +3202,17 @@ bool CWallet::GetCoinsToJoinSplit(
     }
 
     if(!coinControlUsed) {
-
-        auto itr = coins.begin();
         while (spend_val < required) {
-            if(itr == coins.end())
+            if(coins.empty())
                 break;
 
             CLelantusEntry choosen;
             CAmount need = required - spend_val;
 
+            auto itr = coins.begin();
             if(need >= itr->amount) {
                 choosen = *itr;
-                itr++;
+                coins.erase(itr);
             } else {
                 for (auto coinIt = coins.rbegin(); coinIt != coins.rend(); coinIt++) {
                     auto nextItr = coinIt;
@@ -3221,6 +3220,7 @@ bool CWallet::GetCoinsToJoinSplit(
 
                     if (coinIt->amount >= need && (nextItr == coins.rend() || nextItr->amount != coinIt->amount)) {
                         choosen = *coinIt;
+                        coins.erase(std::next(coinIt).base());
                         break;
                     }
                 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -6955,7 +6955,7 @@ bool CWallet::CommitLelantusTransaction(CWalletTx& wtxNew, std::vector<CLelantus
         }
 
         //Set spent mint as used in memory
-        uint256 hashPubcoin = primitives::GetPubCoinValueHash(coin.value + lelantus::Params::get_default()->get_h1() * Scalar(coin.amount).negate());
+        uint256 hashPubcoin = primitives::GetPubCoinValueHash(coin.value);
         zwallet->GetTracker().SetLelantusPubcoinUsed(hashPubcoin, wtxNew.GetHash());
         CLelantusMintMeta metaCheck;
         zwallet->GetTracker().GetLelantusMetaFromPubcoin(hashPubcoin, metaCheck);

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -956,8 +956,8 @@ DBErrors CWalletDB::LoadWallet(CWallet* pwallet)
     bool fNoncriticalErrors = false;
     DBErrors result = DB_LOAD_OK;
 
+    LOCK2(cs_main, pwallet->cs_wallet);
     try {
-        LOCK2(cs_main, pwallet->cs_wallet);
         int nMinVersion = 0;
         if (Read((string)"minversion", nMinVersion))
         {


### PR DESCRIPTION
What brings this PR

1. Fixing and adding unit tests
2. Fixing bug at coin choosing algorithm
3. Fixing bug resulting wrong debug log at joinsplit creation
4. Fixing minor bug at joinsplit creation (our implementation was not resulting it, but in unit tests we have such case)
5. Fixing crashes when upgrading with non-hd wallet
6. Fixing issues and crashes when -disablewallet arg used, #939 
7. Removed wrong background color when dark mode is used.
8. Fixes #946, the reason was incorrect mutex locks.
9. Fixed crash after try to create lelantus mint when wallet not yet synced, Prevented 0 mint creation at Ui level.