### PR TITLE
Remove unnecessary mempool lock (same changes as bitcoin #11870)

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2233,8 +2233,6 @@ void CWallet::ReacceptWalletTransactions()
     BOOST_FOREACH(PAIRTYPE(const int64_t, CWalletTx*)& item, mapSorted)
     {
         CWalletTx& wtx = *(item.second);
-
-        LOCK(mempool.cs);
         CValidationState state;
         // the app was closed and re-opened, do NOT check their
         // serial numbers, and DO NOT try to mark their serial numbers


### PR DESCRIPTION
## PR intention
Fix dandelion deadlock

## Code changes brief
Removed `mempool.cs` lock
