### PR TITLE
To support multiple inputs in Lelantus spend tx in Elysium

### DIFF
--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -27,7 +27,7 @@ public:
     CScriptID(const uint160& in) : uint160(in) {}
 };
 
-static const unsigned int MAX_OP_RETURN_RELAY = 4096;
+static const unsigned int MAX_OP_RETURN_RELAY = 16384;
 extern bool fAcceptDatacarrier;
 extern unsigned nMaxDatacarrierBytes;
 


### PR DESCRIPTION
Increase to support multiple inputs in Lelantus spend tx in Elysium layer, due to with 4k, it will support only one spend input, which impractical to support multiple spend input in a spend tx.

