### PR TITLE
Fixed recovery from mnemonic GUI when -wallet argument is specified

### DIFF
--- a/src/hdmint/wallet.cpp
+++ b/src/hdmint/wallet.cpp
@@ -117,7 +117,6 @@ std::pair<uint256,uint256> CHDMintWallet::RegenerateMintPoolEntry(CWalletDB& wal
     mintPool.Add(make_pair(hashPubcoin, mintPoolEntry));
     walletdb.WritePubcoin(hashSerial, commitmentValue);
     walletdb.WriteMintPoolPair(hashPubcoin, mintPoolEntry);
-    LogPrintf("%s : hashSeedMaster=%s hashPubcoin=%s seedId=%s\n count=%d\n", __func__, hashSeedMaster.GetHex(), hashPubcoin.GetHex(), seedId.GetHex(), nCount);
 
     nIndexes.first = hashPubcoin;
     nIndexes.second = hashSerial;
@@ -172,7 +171,6 @@ void CHDMintWallet::GenerateMintPool(CWalletDB& walletdb, int32_t nIndex)
         mintPool.Add(make_pair(hashPubcoin, mintPoolEntry));
         walletdb.WritePubcoin(primitives::GetSerialHash(coin.getSerialNumber()), commitmentValue);
         walletdb.WriteMintPoolPair(hashPubcoin, mintPoolEntry);
-        LogPrintf("%s : hashSeedMaster=%s hashPubcoin=%s seedId=%d count=%d\n", __func__, hashSeedMaster.GetHex(), hashPubcoin.GetHex(), seedId.GetHex(), nLastCount);
     }
 
     // write hdchain back to database

--- a/src/hdmint/wallet.cpp
+++ b/src/hdmint/wallet.cpp
@@ -40,7 +40,7 @@ CHDMintWallet::CHDMintWallet(const std::string& strWalletFile, bool resetCount) 
     uint160 hashSeedMaster = pwalletMain->GetHDChain().masterKeyID;
 
     if (!SetupWallet(hashSeedMaster, resetCount)) {
-        LogPrintf("%s: failed to save deterministic seed for hashseed %s\n", __func__, hashSeedMaster.GetHex());
+        LogPrintf("%s: failed to save deterministic seed\n", __func__);
         return;
     }
 }
@@ -195,8 +195,6 @@ bool CHDMintWallet::LoadMintPoolFromDB()
     vector<std::pair<uint256, MintPoolEntry>> listMintPool = walletdb.ListMintPool();
 
     for (auto& mintPoolPair : listMintPool){
-        LogPrintf("LoadMintPoolFromDB: hashPubcoin: %d hashSeedMaster: %d seedId: %d nCount: %s\n",
-            mintPoolPair.first.GetHex(), get<0>(mintPoolPair.second).GetHex(), get<1>(mintPoolPair.second).GetHex(), get<2>(mintPoolPair.second));
         mintPool.Add(mintPoolPair);
     }
 
@@ -926,10 +924,6 @@ bool CHDMintWallet::GenerateMint(CWalletDB& walletdb, const sigma::CoinDenominat
     DenominationToInteger(denom, amount);
     dMint.SetAmount(amount);
 
-    LogPrintf("GenerateMint: hashPubcoin: %s hashSeedMaster: %s seedId: %s nCount: %d\n",
-             dMint.GetPubCoinHash().ToString(),
-             get<0>(mintPoolEntry.get()).GetHex(), get<1>(mintPoolEntry.get()).GetHex(), get<2>(mintPoolEntry.get()));
-
     return true;
 }
 
@@ -981,11 +975,6 @@ bool CHDMintWallet::GenerateLelantusMint(CWalletDB& walletdb, lelantus::PrivateC
     }
 
     dMint.SetAmount(coin.getV());
-
-    LogPrintf("GenerateMint: hashPubcoin: %s hashSeedMaster: %s seedId: %s nCount: %d\n",
-              dMint.GetPubCoinHash().ToString(),
-              get<0>(mintPoolEntry.get()).GetHex(), get<1>(mintPoolEntry.get()).GetHex(), get<2>(mintPoolEntry.get()));
-
     return true;
 }
 

--- a/src/hdmint/wallet.cpp
+++ b/src/hdmint/wallet.cpp
@@ -38,7 +38,6 @@ CHDMintWallet::CHDMintWallet(const std::string& strWalletFile, bool resetCount) 
 
     // Use MasterKeyId from HDChain as index for mintpool
     uint160 hashSeedMaster = pwalletMain->GetHDChain().masterKeyID;
-    LogPrintf("hashSeedMaster: %d\n", hashSeedMaster.GetHex());
 
     if (!SetupWallet(hashSeedMaster, resetCount)) {
         LogPrintf("%s: failed to save deterministic seed for hashseed %s\n", __func__, hashSeedMaster.GetHex());

--- a/src/qt/recover.cpp
+++ b/src/qt/recover.cpp
@@ -5,6 +5,7 @@
 
 #include "util.h"
 
+#include "../wallet/wallet.h"
 #include "../wallet/bip39.h"
 #include "support/allocators/secure.h"
 
@@ -76,23 +77,9 @@ void Recover::on_usePassphrase_clicked()
 bool Recover::askRecover(bool& newWallet)
 {
     namespace fs = boost::filesystem;
-    std::string dataDir = GetDataDir(false).string();
-    if(dataDir.empty())
-        throw std::runtime_error("Can't get data directory");
+    fs::path walletFile = GetDataDir(true) / GetArg("-wallet", DEFAULT_WALLET_DAT);
 
-    boost::optional<bool> regTest = GetOptBoolArg("-regtest")
-    , testNet = GetOptBoolArg("-testnet");
-
-    if (testNet && regTest && *testNet && *regTest)
-        throw std::runtime_error("Invalid combination of -regtest and -testnet.");
-    if (regTest && *regTest)
-        dataDir += "/regtest";
-    if (testNet && *testNet)
-        dataDir += "/testnet3";
-
-    dataDir += "/wallet.dat";
-
-    if(!fs::exists(GUIUtil::qstringToBoostPath(QString::fromStdString(dataDir))))
+    if (!fs::exists(walletFile))
     {
         newWallet = true;
         Recover recover;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2968,9 +2968,6 @@ UniValue regeneratemintpool(const JSONRPCRequest& request) {
     bool reindexRequired = false;
 
     for (auto& mintPoolPair : listMintPool){
-        LogPrintf("regeneratemintpool: hashPubcoin: %d hashSeedMaster: %d seedId: %d nCount: %s\n",
-            mintPoolPair.first.GetHex(), get<0>(mintPoolPair.second).GetHex(), get<1>(mintPoolPair.second).GetHex(), get<2>(mintPoolPair.second));
-
         oldHashPubcoin = mintPoolPair.first;
         bool hasSerial = pwallet->zwallet->GetSerialForPubcoin(serialPubcoinPairs, oldHashPubcoin, oldHashSerial);
 


### PR DESCRIPTION
## PR intention
Recovery dialog was shown when not needed in case of `-wallet=` argument set when running Qt client
