### PR TITLE
Fix for coin not found issue.

### DIFF
--- a/src/hdmint/hdmint.h
+++ b/src/hdmint/hdmint.h
@@ -45,9 +45,9 @@ public:
     uint256 GetPubCoinHash() const { return primitives::GetPubCoinValueHash(pubCoinValue); }
     uint256 GetTxHash() const { return txid; }
     bool IsUsed() const { return isUsed; }
-    void SetAmount(const int64_t& amount) { this->amount = amount; }
-    void SetHeight(const int& nHeight) { this->nHeight = nHeight; }
-    void SetId(const int& nId) { this->nId = nId; }
+    void SetAmount(int64_t amount) { this->amount = amount; }
+    void SetHeight(int nHeight) { this->nHeight = nHeight; }
+    void SetId(int nId) { this->nId = nId; }
     void SetNull();
     void SetTxHash(const uint256& txid) { this->txid = txid; }
     void SetUsed(const bool isUsed) { this->isUsed = isUsed; }

--- a/src/hdmint/wallet.cpp
+++ b/src/hdmint/wallet.cpp
@@ -487,12 +487,17 @@ bool CHDMintWallet::SetMintSeedSeen(CWalletDB& walletdb, std::pair<uint256,MintP
     }
 
     LogPrintf("%s: Creating mint object.. \n", __func__);
+
+    int id;
+    std::tie(std::ignore, id) = sigma::CSigmaState::GetState()->GetMintedCoinHeightAndId(sigma::PublicCoin(bnValue, denom));
+
     // Create mint object
     CHDMint dMint(mintCount, seedId, hashSerial, bnValue);
     int64_t amount;
     DenominationToInteger(denom, amount);
     dMint.SetAmount(amount);
     dMint.SetHeight(nHeight);
+    dMint.SetId(id);
 
     // Check if this is also already spent
     int nHeightTx;

--- a/src/hdmint/wallet.cpp
+++ b/src/hdmint/wallet.cpp
@@ -446,7 +446,7 @@ void CHDMintWallet::SyncWithChain(bool fGenerateMintPool, boost::optional<std::l
  * @param txid mint txid height
  * @param denom mint denomination
  */
-bool CHDMintWallet::SetMintSeedSeen(CWalletDB& walletdb, std::pair<uint256,MintPoolEntry> mintPoolEntryPair, const int& nHeight, const uint256& txid, const sigma::CoinDenomination& denom)
+bool CHDMintWallet::SetMintSeedSeen(CWalletDB& walletdb, std::pair<uint256,MintPoolEntry> mintPoolEntryPair, int nHeight, const uint256& txid, const sigma::CoinDenomination& denom)
 {
     // Regenerate the mint
     uint256 hashPubcoin = mintPoolEntryPair.first;
@@ -524,7 +524,7 @@ bool CHDMintWallet::SetMintSeedSeen(CWalletDB& walletdb, std::pair<uint256,MintP
     return true;
 }
 
-bool CHDMintWallet::SetLelantusMintSeedSeen(CWalletDB& walletdb, std::pair<uint256,MintPoolEntry> mintPoolEntryPair, const int& nHeight, const uint256& txid, const uint64_t amount)
+bool CHDMintWallet::SetLelantusMintSeedSeen(CWalletDB& walletdb, std::pair<uint256,MintPoolEntry> mintPoolEntryPair, int nHeight, const uint256& txid, uint64_t amount)
 {
     // Regenerate the mint
     uint256 hashPubcoin = mintPoolEntryPair.first;

--- a/src/hdmint/wallet.h
+++ b/src/hdmint/wallet.h
@@ -45,8 +45,8 @@ public:
     bool TxOutToPublicCoin(const CTxOut& txout, sigma::PublicCoin& pubCoin, CValidationState& state);
     std::pair<uint256,uint256> RegenerateMintPoolEntry(CWalletDB& walletdb, const uint160& mintHashSeedMaster, CKeyID& seedId, const int32_t& nCount);
     void GenerateMintPool(CWalletDB& walletdb, int32_t nIndex = 0);
-    bool SetMintSeedSeen(CWalletDB& walletdb, std::pair<uint256,MintPoolEntry> mintPoolEntryPair, const int& nHeight, const uint256& txid, const sigma::CoinDenomination& denom);
-    bool SetLelantusMintSeedSeen(CWalletDB& walletdb, std::pair<uint256,MintPoolEntry> mintPoolEntryPair, const int& nHeight, const uint256& txid, const uint64_t amount);
+    bool SetMintSeedSeen(CWalletDB& walletdb, std::pair<uint256,MintPoolEntry> mintPoolEntryPair, int nHeight, const uint256& txid, const sigma::CoinDenomination& denom);
+    bool SetLelantusMintSeedSeen(CWalletDB& walletdb, std::pair<uint256,MintPoolEntry> mintPoolEntryPair, int nHeight, const uint256& txid, uint64_t amount);
     bool SeedToMint(const uint512& mintSeed, GroupElement& bnValue, sigma::PrivateCoin& coin);
     bool SeedToLelantusMint(const uint512& mintSeed, lelantus::PrivateCoin& coin);
 

--- a/src/wallet/lelantusjoinsplitbuilder.cpp
+++ b/src/wallet/lelantusjoinsplitbuilder.cpp
@@ -426,7 +426,7 @@ void LelantusJoinSplitBuilder::CreateJoinSplit(
         std::tie(std::ignore, groupId) = state->GetMintedCoinHeightAndId(pub);
 
         if (groupId < 0) {
-            throw std::runtime_error(_("One of minted coin does not found in the chain"));
+            throw std::runtime_error(_("One of the lelantus coins has not been found in the chain!"));
         }
 
         coins.emplace_back(make_pair(priv, groupId));
@@ -469,7 +469,7 @@ void LelantusJoinSplitBuilder::CreateJoinSplit(
         std::tie(std::ignore, groupId) = sigmaState->GetMintedCoinHeightAndId(pub);
 
         if (groupId < 0) {
-            throw std::runtime_error(_("One of minted coin does not found in the chain"));
+            throw std::runtime_error(_("One of the sigma coins has not been found in the chain!"));
         }
 
         //this way we are remembering denomination and group id in one field as we have no demomination in Lelantus

--- a/src/wallet/lelantusjoinsplitbuilder.cpp
+++ b/src/wallet/lelantusjoinsplitbuilder.cpp
@@ -468,7 +468,7 @@ void LelantusJoinSplitBuilder::CreateJoinSplit(
 
         std::tie(std::ignore, groupId) = sigmaState->GetMintedCoinHeightAndId(pub);
 
-        if (groupId < 0 || groupId != spend.id) {
+        if (groupId < 0) {
             throw std::runtime_error(_("One of minted coin does not found in the chain"));
         }
 

--- a/src/wallet/sigmaspendbuilder.cpp
+++ b/src/wallet/sigmaspendbuilder.cpp
@@ -88,7 +88,7 @@ static std::unique_ptr<SigmaSpendSigner> CreateSigner(const CSigmaEntry& coin)
     std::tie(std::ignore, groupId) = state->GetMintedCoinHeightAndId(pub);
 
     if (groupId < 0) {
-        throw std::runtime_error(_("One of minted coin does not found in the chain"));
+        throw std::runtime_error(_("One of the sigma coins has not been found in the chain!"));
     }
 
     signer->output.n = static_cast<uint32_t>(groupId);


### PR DESCRIPTION
- Fix for sigma hd mint bug, where coin group id is not being set, it results an coin not found in chin issue during Lelantus joinsplit creation, The reason wast that, setting group id in SetMintSeedSeen() was missing, and it was remaining -1 in sum circumstances, the code is adding that,   
- Making error messages more accurate.