### PR TITLE
Fixing Insufficient Funds error when minting big amounts

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3731,7 +3731,7 @@ bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, const int nConfMin
 
         const CWalletTx *pcoin = output.tx;
 
-        if (output.nDepth < (pcoin->IsFromMe(ISMINE_ALL) ? nConfMine : nConfTheirs))
+        if (output.nDepth < ((pcoin->IsFromMe(ISMINE_ALL) || pcoin->tx->IsLelantusMint()) ? nConfMine : nConfTheirs))
             continue;
 
         if (!mempool.TransactionWithinChainLimit(pcoin->GetHash(), nMaxAncestors))

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5298,8 +5298,8 @@ bool CWallet::CreateLelantusMintTransactions(
                 auto itr = valueAndUTXO.begin();
 
                 CAmount valueToMintInTx = std::min(
-                    ::Params().GetConsensus().nMaxValueLelantusMint,
-                    itr->first);
+                        ::Params().GetConsensus().nMaxValueLelantusMint,
+                        itr->first);
 
                 if (!autoMintAll) {
                     valueToMintInTx = std::min(valueToMintInTx, valueToMint);
@@ -5307,8 +5307,8 @@ bool CWallet::CreateLelantusMintTransactions(
 
                 CAmount nValueToSelect, mintedValue;
 
-                std::set<std::pair<const CWalletTx*, unsigned int>> setCoins;
-
+                std::set<std::pair<const CWalletTx *, unsigned int>> setCoins;
+                bool skipIfNegative = false;
                 // Start with no fee and loop until there is enough fee
                 while (true) {
                     mintedValue = valueToMintInTx;
@@ -5318,6 +5318,12 @@ bool CWallet::CreateLelantusMintTransactions(
                     if (nValueToSelect > itr->first) {
                         mintedValue -= nFeeRet;
                         nValueToSelect = mintedValue + nFeeRet;
+                    }
+
+                    if (!MoneyRange(mintedValue) || mintedValue == 0) {
+                        valueAndUTXO.erase(itr);
+                        skipIfNegative = true;
+                        break;
                     }
 
                     nChangePosInOut = nChangePosRequest;
@@ -5366,7 +5372,7 @@ bool CWallet::CreateLelantusMintTransactions(
                         assert(age >= 0);
                         if (age != 0)
                             age += 1;
-                        dPriority += (double)nCredit * age;
+                        dPriority += (double) nCredit * age;
                     }
 
                     CAmount nChange = nValueIn - nValueToSelect;
@@ -5381,9 +5387,10 @@ bool CWallet::CreateLelantusMintTransactions(
                         if (coinControl && !boost::get<CNoDestination>(&coinControl->destChange))
                             scriptChange = GetScriptForDestination(coinControl->destChange);
 
-                        // send change to one of the specified change addresses
+                            // send change to one of the specified change addresses
                         else if (IsArgSet("-change") && mapMultiArgs.at("-change").size() > 0) {
-                            CBitcoinAddress address(mapMultiArgs.at("change")[GetRandInt(mapMultiArgs.at("-change").size())]);
+                            CBitcoinAddress address(
+                                    mapMultiArgs.at("change")[GetRandInt(mapMultiArgs.at("-change").size())]);
                             CKeyID keyID;
                             if (!address.GetKeyID(keyID)) {
                                 strFailReason = _("Bad change address");
@@ -5392,7 +5399,7 @@ bool CWallet::CreateLelantusMintTransactions(
                             scriptChange = GetScriptForDestination(keyID);
                         }
 
-                        // no coin control: send change to newly generated address
+                            // no coin control: send change to newly generated address
                         else {
                             // Note: We use a new key here to keep it from being obvious which side is the change.
                             //  The drawback is that by not reusing a previous key, the change may be lost if a
@@ -5405,8 +5412,7 @@ bool CWallet::CreateLelantusMintTransactions(
                             CPubKey vchPubKey;
                             bool ret;
                             ret = reservekey.GetReservedKey(vchPubKey);
-                            if (!ret)
-                            {
+                            if (!ret) {
                                 strFailReason = _("Keypool ran out, please call keypoolrefill first");
                                 return false;
                             }
@@ -5428,7 +5434,7 @@ bool CWallet::CreateLelantusMintTransactions(
 
                                 // Insert change txn at random position:
                                 nChangePosInOut = GetRandInt(tx.vout.size() + 1);
-                            } else if ((unsigned int)nChangePosInOut > tx.vout.size()) {
+                            } else if ((unsigned int) nChangePosInOut > tx.vout.size()) {
 
                                 strFailReason = _("Change index out of range");
                                 return false;
@@ -5446,12 +5452,12 @@ bool CWallet::CreateLelantusMintTransactions(
                     //
                     // Note how the sequence number is set to max()-1 so that the
                     // nLockTime set above actually works.
-                    for (const auto& coin : setCoins) {
+                    for (const auto &coin : setCoins) {
                         tx.vin.push_back(CTxIn(
-                            coin.first->GetHash(),
-                            coin.second,
-                            CScript(),
-                            std::numeric_limits<unsigned int>::max() - 1));
+                                coin.first->GetHash(),
+                                coin.second,
+                                CScript(),
+                                std::numeric_limits<unsigned int>::max() - 1));
                     }
 
                     // Fill in dummy signatures for fee calculation.
@@ -5501,9 +5507,9 @@ bool CWallet::CreateLelantusMintTransactions(
                     }
 
                     if (nFeeRet >= nFeeNeeded) {
-                        for(auto& usedCoin : setCoins) {
-                            for(auto coin = itr->second.begin(); coin != itr->second.end(); coin++) {
-                                if(usedCoin.first == coin->tx && usedCoin.second == coin->i) {
+                        for (auto &usedCoin : setCoins) {
+                            for (auto coin = itr->second.begin(); coin != itr->second.end(); coin++) {
+                                if (usedCoin.first == coin->tx && usedCoin.second == coin->i) {
                                     itr->first -= coin->tx->tx->vout[coin->i].nValue;
                                     itr->second.erase(coin);
                                     break;
@@ -5511,7 +5517,7 @@ bool CWallet::CreateLelantusMintTransactions(
                             }
                         }
 
-                        if(itr->second.empty()) {
+                        if (itr->second.empty()) {
                             valueAndUTXO.erase(itr);
                         }
 
@@ -5536,79 +5542,85 @@ bool CWallet::CreateLelantusMintTransactions(
                     continue;
                 }
 
-                if (GetBoolArg("-walletrejectlongchains", DEFAULT_WALLET_REJECT_LONG_CHAINS)) {
-                    // Lastly, ensure this tx will pass the mempool's chain limits
-                    LockPoints lp;
-                    CTxMemPoolEntry entry(MakeTransactionRef(tx), 0, 0, 0, 0, false, 0, lp);
-                    CTxMemPool::setEntries setAncestors;
-                    size_t nLimitAncestors = GetArg("-limitancestorcount", DEFAULT_ANCESTOR_LIMIT);
-                    size_t nLimitAncestorSize = GetArg("-limitancestorsize", DEFAULT_ANCESTOR_SIZE_LIMIT) * 1000;
-                    size_t nLimitDescendants = GetArg("-limitdescendantcount", DEFAULT_DESCENDANT_LIMIT);
-                    size_t nLimitDescendantSize = GetArg("-limitdescendantsize", DEFAULT_DESCENDANT_SIZE_LIMIT) * 1000;
-                    std::string errString;
-                    if (!mempool.CalculateMemPoolAncestors(entry, setAncestors, nLimitAncestors, nLimitAncestorSize,
-                                                           nLimitDescendants, nLimitDescendantSize, errString)) {
-                        strFailReason = _("Transaction has too long of a mempool chain");
-                        return false;
-                    }
-                }
+                if(!skipIfNegative) {
 
-                // Sign
-                int nIn = 0;
-                CTransaction txNewConst(tx);
-                for (const auto& coin : setCoins) {
-                    bool signSuccess = false;
-                    const CScript& scriptPubKey = coin.first->tx->vout[coin.second].scriptPubKey;
-                    SignatureData sigdata;
-                    if (sign)
-                        signSuccess = ProduceSignature(TransactionSignatureCreator(this, &txNewConst, nIn, coin.first->tx->vout[coin.second].nValue, SIGHASH_ALL), scriptPubKey, sigdata);
-                    else
-                        signSuccess = ProduceSignature(DummySignatureCreator(this), scriptPubKey, sigdata);
-
-                    if (!signSuccess)
-                    {
-                        strFailReason = _("Signing transaction failed");
-                        return false;
-                    } else {
-                        UpdateTransaction(tx, nIn, sigdata);
-                    }
-                    nIn++;
-                }
-
-                wtx.SetTx(MakeTransactionRef(std::move(tx)));
-
-                wtxAndFee.push_back(std::make_pair(wtx, nFeeRet));
-
-                if (nChangePosInOut >= 0) {
-                    // Cache wtx to somewhere because COutput use pointer of it.
-                    cacheWtxs.push_back(wtx);
-                    auto &wtx = cacheWtxs.back();
-
-                    COutput out(&wtx, nChangePosInOut, wtx.GetDepthInMainChain(false), true, true);
-                    auto val = wtx.tx->vout[nChangePosInOut].nValue;
-
-                    bool added = false;
-                    for (auto &utxos : valueAndUTXO) {
-                        auto const &o = utxos.second.front();
-                        if (o.tx->tx->vout[o.i].scriptPubKey == wtx.tx->vout[nChangePosInOut].scriptPubKey) {
-                            utxos.first += val;
-                            utxos.second.push_back(out);
-
-                            added = true;
+                    if (GetBoolArg("-walletrejectlongchains", DEFAULT_WALLET_REJECT_LONG_CHAINS)) {
+                        // Lastly, ensure this tx will pass the mempool's chain limits
+                        LockPoints lp;
+                        CTxMemPoolEntry entry(MakeTransactionRef(tx), 0, 0, 0, 0, false, 0, lp);
+                        CTxMemPool::setEntries setAncestors;
+                        size_t nLimitAncestors = GetArg("-limitancestorcount", DEFAULT_ANCESTOR_LIMIT);
+                        size_t nLimitAncestorSize = GetArg("-limitancestorsize", DEFAULT_ANCESTOR_SIZE_LIMIT) * 1000;
+                        size_t nLimitDescendants = GetArg("-limitdescendantcount", DEFAULT_DESCENDANT_LIMIT);
+                        size_t nLimitDescendantSize =
+                                GetArg("-limitdescendantsize", DEFAULT_DESCENDANT_SIZE_LIMIT) * 1000;
+                        std::string errString;
+                        if (!mempool.CalculateMemPoolAncestors(entry, setAncestors, nLimitAncestors, nLimitAncestorSize,
+                                                               nLimitDescendants, nLimitDescendantSize, errString)) {
+                            strFailReason = _("Transaction has too long of a mempool chain");
+                            return false;
                         }
                     }
 
-                    if (!added) {
-                        valueAndUTXO.push_back({val, {out}});
-                    }
-                }
+                    // Sign
+                    int nIn = 0;
+                    CTransaction txNewConst(tx);
+                    for (const auto &coin : setCoins) {
+                        bool signSuccess = false;
+                        const CScript &scriptPubKey = coin.first->tx->vout[coin.second].scriptPubKey;
+                        SignatureData sigdata;
+                        if (sign)
+                            signSuccess = ProduceSignature(TransactionSignatureCreator(this, &txNewConst, nIn,
+                                                                                       coin.first->tx->vout[coin.second].nValue,
+                                                                                       SIGHASH_ALL), scriptPubKey,
+                                                           sigdata);
+                        else
+                            signSuccess = ProduceSignature(DummySignatureCreator(this), scriptPubKey, sigdata);
 
-                nAllFeeRet += nFeeRet;
-                dMints.push_back(dMint);
-                if(!autoMintAll) {
-                    valueToMint -= mintedValue;
-                    if (valueToMint == 0)
-                        break;
+                        if (!signSuccess) {
+                            strFailReason = _("Signing transaction failed");
+                            return false;
+                        } else {
+                            UpdateTransaction(tx, nIn, sigdata);
+                        }
+                        nIn++;
+                    }
+
+                    wtx.SetTx(MakeTransactionRef(std::move(tx)));
+
+                    wtxAndFee.push_back(std::make_pair(wtx, nFeeRet));
+
+                    if (nChangePosInOut >= 0) {
+                        // Cache wtx to somewhere because COutput use pointer of it.
+                        cacheWtxs.push_back(wtx);
+                        auto &wtx = cacheWtxs.back();
+
+                        COutput out(&wtx, nChangePosInOut, wtx.GetDepthInMainChain(false), true, true);
+                        auto val = wtx.tx->vout[nChangePosInOut].nValue;
+
+                        bool added = false;
+                        for (auto &utxos : valueAndUTXO) {
+                            auto const &o = utxos.second.front();
+                            if (o.tx->tx->vout[o.i].scriptPubKey == wtx.tx->vout[nChangePosInOut].scriptPubKey) {
+                                utxos.first += val;
+                                utxos.second.push_back(out);
+
+                                added = true;
+                            }
+                        }
+
+                        if (!added) {
+                            valueAndUTXO.push_back({val, {out}});
+                        }
+                    }
+
+                    nAllFeeRet += nFeeRet;
+                    dMints.push_back(dMint);
+                    if (!autoMintAll) {
+                        valueToMint -= mintedValue;
+                        if (valueToMint <= 0)
+                            break;
+                    }
                 }
             }
         }


### PR DESCRIPTION
- Fixes a corner case issue, when you had balance on a single address bigger then mint limit and you was trying to mint such amount that the change from first mint will be used for second mint, for example you have 7k on one address and no other utxo and you try to mint 6k, 
The reason is that during coin selection it calls GetCredit() function for transaction, which utxo is trying to use, as it is mint transaction, it is trying to read HDMint from db, but as it is not broadcasted yet, it is not added into db, so it is not recognized yours, the simple fix is this 5a77ae1d5b3075e8f0d5e3ed2b2eb42d58c9ea51

- Second issue was, that when you had very small utxo, which is a single one for and address, less then min transaction fee, it was trying to create mint with negative value and during broadcast  it was throwing and exception, the fix is to skip such utxo's during minting, 