### PR TITLE
Fixing the wallet load livelock

### DIFF
--- a/src/hdmint/wallet.cpp
+++ b/src/hdmint/wallet.cpp
@@ -146,6 +146,8 @@ void CHDMintWallet::GenerateMintPool(CWalletDB& walletdb, int32_t nIndex)
         return;
     }
 
+    LOCK(pwalletMain->cs_wallet);
+
     int32_t nLastCount = nCountNextGenerate;
     int32_t nStop = nLastCount + 20;
     if(nIndex > 0 && nIndex >= nLastCount)


### PR DESCRIPTION
## PR intention
Fixes a livelock on the wallet sync primitives when some wallet function like EncryptWallet is called in the middle of HDMint generation

## Code changes brief
Protected the whole HDMint generation with cs_wallet
