### PR TITLE
Fixing Reindex Lelantus

### DIFF
--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -164,12 +164,12 @@
            </widget>
           </item>
           <item>
-           <widget class="QCheckBox" name="reindexSigma">
+           <widget class="QCheckBox" name="reindexLelantus">
             <property name="toolTip">
-             <string>Restore all Sigma transactions following a reindex.</string>
+             <string>Restore all Lelantus transactions following a reindex.</string>
             </property>
             <property name="text">
-             <string>&amp;Reindex Sigma</string>
+             <string>&amp;Reindex Lelantus</string>
             </property>
            </widget>
           </item>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -164,7 +164,7 @@ void OptionsDialog::setModel(OptionsModel *_model)
     connect(ui->threadsScriptVerif, SIGNAL(valueChanged(int)), this, SLOT(showRestartWarning()));
     /* Wallet */
     connect(ui->spendZeroConfChange, SIGNAL(clicked(bool)), this, SLOT(showRestartWarning()));
-    connect(ui->reindexSigma, SIGNAL(clicked(bool)), this, SLOT(handleEnabledZapChanged()));
+    connect(ui->reindexLelantus, SIGNAL(clicked(bool)), this, SLOT(handleEnabledZapChanged()));
     /* Network */
     connect(ui->allowIncoming, SIGNAL(clicked(bool)), this, SLOT(showRestartWarning()));
     connect(ui->connectSocks, SIGNAL(clicked(bool)), this, SLOT(showRestartWarning()));
@@ -183,7 +183,7 @@ void OptionsDialog::setMapper()
 
     /* Wallet */
     mapper->addMapping(ui->spendZeroConfChange, OptionsModel::SpendZeroConfChange);
-    mapper->addMapping(ui->reindexSigma, OptionsModel::ReindexSigma);
+    mapper->addMapping(ui->reindexLelantus, OptionsModel::ReindexLelantus);
     mapper->addMapping(ui->coinControlFeatures, OptionsModel::CoinControlFeatures);
 
     /* Lelantus */
@@ -265,13 +265,13 @@ void OptionsDialog::on_hideTrayIcon_stateChanged(int fState)
 void OptionsDialog::handleEnabledZapChanged(){
 	QMessageBox msgBox;
 
-	if(ui->reindexSigma->isChecked()){
-        QMessageBox::StandardButton retval = QMessageBox::warning(this, tr("Confirm Reindex Sigma"),
+	if(ui->reindexLelantus->isChecked()){
+        QMessageBox::StandardButton retval = QMessageBox::warning(this, tr("Confirm Reindex Lelantus"),
                      tr("Warning: On restart, this setting will wipe your transaction list, reindex the blockchain, and restore the list from the seed in your wallet. This will likely take a few hours. Are you sure?"),
                      QMessageBox::Yes|QMessageBox::Cancel,
                      QMessageBox::Cancel);
         if(retval == QMessageBox::Cancel) {
-            ui->reindexSigma->setChecked(false);
+            ui->reindexLelantus->setChecked(false);
         }else {
             showRestartWarning();
         }

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -119,13 +119,20 @@ void OptionsModel::Init(bool resetSettings)
     if (!SoftSetBoolArg("-spendzeroconfchange", settings.value("bSpendZeroConfChange").toBool()))
         addOverriddenOption("-spendzeroconfchange");
 
-    if (!settings.contains("bReindexSigma"))
-        settings.setValue("bReindexSigma", DEFAULT_ZAP_WALLET);
-    if (!SoftSetBoolArg("-zapwalletmints", settings.value("bReindexSigma").toBool())) {
-        addOverriddenOption("-zapwalletmints");
-    } else {
-        settings.setValue("bReindexSigma", false);
+    if (!settings.contains("bReindexLelantus"))
+        settings.setValue("bReindexLelantus", DEFAULT_ZAP_WALLET);
+    bool reindexLelantus = settings.value("bReindexLelantus").toBool();
+    if (reindexLelantus) {
+        if (!SoftSetBoolArg("-zapwalletmints", true))
+            addOverriddenOption("-zapwalletmints");
+        if (!SoftSetBoolArg("-reindex", true))
+            addOverriddenOption("-reindex");
+        if (!SoftSetArg("-zapwallettxes", std::string("1")))
+            addOverriddenOption("-zapwallettxes");
     }
+
+    // Reset the flag to prevent unneeded reindex,
+    settings.setValue("bReindexLelantus", false);
 
 #endif
 
@@ -259,8 +266,8 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
         case SpendZeroConfChange:
             return settings.value("bSpendZeroConfChange");
 
-        case ReindexSigma:
-            return settings.value("bReindexSigma");
+        case ReindexLelantus:
+            return settings.value("bReindexLelantus");
 #endif
         case DisplayUnit:
             return nDisplayUnit;
@@ -389,9 +396,9 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             }
             break;
 
-        case ReindexSigma:
-            if (settings.value("bReindexSigma") != value) {
-                settings.setValue("bReindexSigma", value);
+        case ReindexLelantus:
+            if (settings.value("bReindexLelantus") != value) {
+                settings.setValue("bReindexLelantus", value);
                 setRestartRequired(true);
             }
             break;

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -45,7 +45,7 @@ public:
         ThreadsScriptVerif,     // int
         DatabaseCache,          // int
         SpendZeroConfChange,    // bool
-        ReindexSigma,           // bool
+        ReindexLelantus,        // bool
         Listen,                 // bool
         TorSetup,               // bool
         AutoAnonymize,          // bool


### PR DESCRIPTION
- Renaming "Reindex Sigma" to "Reindex Lelantus" , 
- Setting `reindex`,` zapwallettxes=1` when Reindex Lelantus is activated 
- Setting false  `bReindexLelantus` after restart, for preventing unneeded reindex if user forgot to remove flag from checkbox. 