### PR TITLE
Fixing a build error with Werror=return-type and --enable-crash-hooks

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
                 sh 'mkdir -p dist'
                 sh 'tar -C dist --strip-components=1 -xzf firo-*.tar.gz'
                 dir('dist') {
-                    sh './configure --enable-elysium --enable-tests'
+                    sh './configure --enable-elysium --enable-tests --enable-crash-hooks'
                     sh 'make -j6'
                 }
             }

--- a/src/stacktraces.cpp
+++ b/src/stacktraces.cpp
@@ -256,7 +256,7 @@ static uint64_t GetBaseAddress()
     return vmoffset;
 }
 #else
-static int dl_iterate_callback(struct dl_phdr_info* info, size_t s, void* data)
+static void dl_iterate_callback(struct dl_phdr_info* info, size_t s, void* data)
 {
     uint64_t* p = (uint64_t*)data;
     if (info->dlpi_name == nullptr || info->dlpi_name[0] == '\0') {

--- a/src/stacktraces.cpp
+++ b/src/stacktraces.cpp
@@ -256,12 +256,13 @@ static uint64_t GetBaseAddress()
     return vmoffset;
 }
 #else
-static void dl_iterate_callback(struct dl_phdr_info* info, size_t s, void* data)
+static int dl_iterate_callback(struct dl_phdr_info* info, size_t s, void* data)
 {
     uint64_t* p = (uint64_t*)data;
     if (info->dlpi_name == nullptr || info->dlpi_name[0] == '\0') {
         *p = info->dlpi_addr;
     }
+    return 0;
 }
 
 static uint64_t GetBaseAddress()


### PR DESCRIPTION
## PR intention
Fixing a build error with Werror=return-type and --enable-crash-hooks

## Code changes brief
Added the return value, added --enable-crash-hooks to CI
