### PR TITLE
Masternode cache fix

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -518,7 +518,7 @@ bool CDeterministicMNManager::ProcessBlock(const CBlock& block, const CBlockInde
 
     int nHeight = pindex->nHeight;
 
-    {
+    try {
         LOCK(cs);
 
         if (!BuildNewListFromBlock(block, pindex->pprev, _state, newList, true)) {
@@ -539,11 +539,18 @@ bool CDeterministicMNManager::ProcessBlock(const CBlock& block, const CBlockInde
         diff = oldList.BuildDiff(newList);
 
         evoDb.Write(std::make_pair(DB_LIST_DIFF, newList.GetBlockHash()), diff);
-        if ((nHeight % SNAPSHOT_LIST_PERIOD) == 0 || oldList.GetHeight() == -1) {
+        if ((nHeight % DISK_SNAPSHOT_PERIOD) == 0 || oldList.GetHeight() == -1) {
             evoDb.Write(std::make_pair(DB_LIST_SNAPSHOT, newList.GetBlockHash()), newList);
+            mnListsCache.emplace(newList.GetBlockHash(), newList);
             LogPrintf("CDeterministicMNManager::%s -- Wrote snapshot. nHeight=%d, mapCurMNs.allMNsCount=%d\n",
                 __func__, nHeight, newList.GetAllMNsCount());
         }
+
+        diff.nHeight = pindex->nHeight;
+        mnListDiffsCache.emplace(pindex->GetBlockHash(), diff);
+    } catch (const std::exception& e) {
+        LogPrintf("CDeterministicMNManager::%s -- internal error: %s\n", __func__, e.what());
+        return _state.DoS(100, false, REJECT_INVALID, "failed-dmn-block");
     }
 
     // Don't hold cs while calling signals
@@ -589,6 +596,7 @@ bool CDeterministicMNManager::UndoBlock(const CBlock& block, const CBlockIndex* 
         evoDb.Erase(std::make_pair(DB_LIST_SNAPSHOT, blockHash));
 
         mnListsCache.erase(blockHash);
+        mnListDiffsCache.erase(blockHash);
     }
 
     if (diff.HasChanges()) {
@@ -899,13 +907,13 @@ CDeterministicMNList CDeterministicMNManager::GetListForBlock(const CBlockIndex*
     LOCK(cs);
 
     CDeterministicMNList snapshot;
-    std::list<std::pair<const CBlockIndex*, CDeterministicMNListDiff>> listDiff;
+    std::list<const CBlockIndex*> listDiffIndexes;
 
     while (true) {
         // try using cache before reading from disk
-        auto it = mnListsCache.find(pindex->GetBlockHash());
-        if (it != mnListsCache.end()) {
-            snapshot = it->second;
+        auto itLists = mnListsCache.find(pindex->GetBlockHash());
+        if (itLists != mnListsCache.end()) {
+            snapshot = itLists->second;
             break;
         }
 
@@ -914,28 +922,51 @@ CDeterministicMNList CDeterministicMNManager::GetListForBlock(const CBlockIndex*
             break;
         }
 
+        // no snapshot found yet, check diffs
+        auto itDiffs = mnListDiffsCache.find(pindex->GetBlockHash());
+        if (itDiffs != mnListDiffsCache.end()) {
+            listDiffIndexes.emplace_front(pindex);
+            pindex = pindex->pprev;
+            continue;
+        }
+
         CDeterministicMNListDiff diff;
         if (!evoDb.Read(std::make_pair(DB_LIST_DIFF, pindex->GetBlockHash()), diff)) {
+            // no snapshot and no diff on disk means that it's the initial snapshot
             snapshot = CDeterministicMNList(pindex->GetBlockHash(), -1, 0);
             mnListsCache.emplace(pindex->GetBlockHash(), snapshot);
             break;
         }
 
-        listDiff.emplace_front(pindex, std::move(diff));
+        diff.nHeight = pindex->nHeight;
+        mnListDiffsCache.emplace(pindex->GetBlockHash(), std::move(diff));
+        listDiffIndexes.emplace_front(pindex);
         pindex = pindex->pprev;
     }
 
-    for (const auto& p : listDiff) {
-        auto diffIndex = p.first;
-        auto& diff = p.second;
+    for (const auto& diffIndex : listDiffIndexes) {
+        const auto& diff = mnListDiffsCache.at(diffIndex->GetBlockHash());
         if (diff.HasChanges()) {
             snapshot = snapshot.ApplyDiff(diffIndex, diff);
         } else {
             snapshot.SetBlockHash(diffIndex->GetBlockHash());
             snapshot.SetHeight(diffIndex->nHeight);
         }
+    }
 
-        mnListsCache.emplace(diffIndex->GetBlockHash(), snapshot);
+    if (tipIndex) {
+        // always keep a snapshot for the tip
+        if (snapshot.GetBlockHash() == tipIndex->GetBlockHash()) {
+            mnListsCache.emplace(snapshot.GetBlockHash(), snapshot);
+        } else {
+            // keep snapshots for yet alive quorums
+            for (auto& p_llmq : Params().GetConsensus().llmqs) {
+                if ((snapshot.GetHeight() % p_llmq.second.dkgInterval == 0) && (snapshot.GetHeight() + p_llmq.second.dkgInterval * (p_llmq.second.keepOldConnections + 1) >= tipIndex->nHeight)) {
+                    mnListsCache.emplace(snapshot.GetBlockHash(), snapshot);
+                    break;
+                }
+            }
+        }
     }
 
     return snapshot;
@@ -990,14 +1021,46 @@ void CDeterministicMNManager::CleanupCache(int nHeight)
 {
     AssertLockHeld(cs);
 
-    std::vector<uint256> toDelete;
+    std::vector<uint256> toDeleteLists;
+    std::vector<uint256> toDeleteDiffs;
     for (const auto& p : mnListsCache) {
-        if (p.second.GetHeight() + LISTS_CACHE_SIZE < nHeight) {
-            toDelete.emplace_back(p.first);
+        if (p.second.GetHeight() + LIST_DIFFS_CACHE_SIZE < nHeight) {
+            toDeleteLists.emplace_back(p.first);
+            continue;
+        }
+        bool fQuorumCache{false};
+        for (auto& p_llmq : Params().GetConsensus().llmqs) {
+            if ((p.second.GetHeight() % p_llmq.second.dkgInterval == 0) && (p.second.GetHeight() + p_llmq.second.dkgInterval * (p_llmq.second.keepOldConnections + 1) >= nHeight)) {
+                fQuorumCache = true;
+                break;
+            }
+        }
+        if (fQuorumCache) {
+            // at least one quorum could be using it, keep it
+            continue;
+        }
+        // no alive quorums using it, see if it was a cache for the tip or for a now outdated quorum
+        if (tipIndex && tipIndex->pprev && (p.first == tipIndex->pprev->GetBlockHash())) {
+            toDeleteLists.emplace_back(p.first);
+        } else {
+            for (auto& p_llmq : Params().GetConsensus().llmqs) {
+                if (p.second.GetHeight() % p_llmq.second.dkgInterval == 0) {
+                    toDeleteLists.emplace_back(p.first);
+                    break;
+                }
+            }
         }
     }
-    for (const auto& h : toDelete) {
+    for (const auto& h : toDeleteLists) {
         mnListsCache.erase(h);
+    }
+    for (const auto& p : mnListDiffsCache) {
+        if (p.second.nHeight + LIST_DIFFS_CACHE_SIZE < nHeight) {
+            toDeleteDiffs.emplace_back(p.first);
+        }
+    }
+    for (const auto& h : toDeleteDiffs) {
+        mnListDiffsCache.erase(h);
     }
 }
 
@@ -1092,7 +1155,7 @@ void CDeterministicMNManager::UpgradeDBIfNeeded()
         CDeterministicMNList newMNList;
         UpgradeDiff(batch, pindex, curMNList, newMNList);
 
-        if ((nHeight % SNAPSHOT_LIST_PERIOD) == 0) {
+        if ((nHeight % DISK_SNAPSHOT_PERIOD) == 0) {
             batch.Write(std::make_pair(DB_LIST_SNAPSHOT, pindex->GetBlockHash()), newMNList);
             evoDb.GetRawDB().WriteBatch(batch);
             batch.Clear();

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -518,7 +518,7 @@ bool CDeterministicMNManager::ProcessBlock(const CBlock& block, const CBlockInde
 
     int nHeight = pindex->nHeight;
 
-    try {
+    {
         LOCK(cs);
 
         if (!BuildNewListFromBlock(block, pindex->pprev, _state, newList, true)) {
@@ -539,18 +539,11 @@ bool CDeterministicMNManager::ProcessBlock(const CBlock& block, const CBlockInde
         diff = oldList.BuildDiff(newList);
 
         evoDb.Write(std::make_pair(DB_LIST_DIFF, newList.GetBlockHash()), diff);
-        if ((nHeight % DISK_SNAPSHOT_PERIOD) == 0 || oldList.GetHeight() == -1) {
+        if ((nHeight % SNAPSHOT_LIST_PERIOD) == 0 || oldList.GetHeight() == -1) {
             evoDb.Write(std::make_pair(DB_LIST_SNAPSHOT, newList.GetBlockHash()), newList);
-            mnListsCache.emplace(newList.GetBlockHash(), newList);
             LogPrintf("CDeterministicMNManager::%s -- Wrote snapshot. nHeight=%d, mapCurMNs.allMNsCount=%d\n",
                 __func__, nHeight, newList.GetAllMNsCount());
         }
-
-        diff.nHeight = pindex->nHeight;
-        mnListDiffsCache.emplace(pindex->GetBlockHash(), diff);
-    } catch (const std::exception& e) {
-        LogPrintf("CDeterministicMNManager::%s -- internal error: %s\n", __func__, e.what());
-        return _state.DoS(100, false, REJECT_INVALID, "failed-dmn-block");
     }
 
     // Don't hold cs while calling signals
@@ -596,7 +589,6 @@ bool CDeterministicMNManager::UndoBlock(const CBlock& block, const CBlockIndex* 
         evoDb.Erase(std::make_pair(DB_LIST_SNAPSHOT, blockHash));
 
         mnListsCache.erase(blockHash);
-        mnListDiffsCache.erase(blockHash);
     }
 
     if (diff.HasChanges()) {
@@ -907,13 +899,13 @@ CDeterministicMNList CDeterministicMNManager::GetListForBlock(const CBlockIndex*
     LOCK(cs);
 
     CDeterministicMNList snapshot;
-    std::list<const CBlockIndex*> listDiffIndexes;
+    std::list<std::pair<const CBlockIndex*, CDeterministicMNListDiff>> listDiff;
 
     while (true) {
         // try using cache before reading from disk
-        auto itLists = mnListsCache.find(pindex->GetBlockHash());
-        if (itLists != mnListsCache.end()) {
-            snapshot = itLists->second;
+        auto it = mnListsCache.find(pindex->GetBlockHash());
+        if (it != mnListsCache.end()) {
+            snapshot = it->second;
             break;
         }
 
@@ -922,51 +914,28 @@ CDeterministicMNList CDeterministicMNManager::GetListForBlock(const CBlockIndex*
             break;
         }
 
-        // no snapshot found yet, check diffs
-        auto itDiffs = mnListDiffsCache.find(pindex->GetBlockHash());
-        if (itDiffs != mnListDiffsCache.end()) {
-            listDiffIndexes.emplace_front(pindex);
-            pindex = pindex->pprev;
-            continue;
-        }
-
         CDeterministicMNListDiff diff;
         if (!evoDb.Read(std::make_pair(DB_LIST_DIFF, pindex->GetBlockHash()), diff)) {
-            // no snapshot and no diff on disk means that it's the initial snapshot
             snapshot = CDeterministicMNList(pindex->GetBlockHash(), -1, 0);
             mnListsCache.emplace(pindex->GetBlockHash(), snapshot);
             break;
         }
 
-        diff.nHeight = pindex->nHeight;
-        mnListDiffsCache.emplace(pindex->GetBlockHash(), std::move(diff));
-        listDiffIndexes.emplace_front(pindex);
+        listDiff.emplace_front(pindex, std::move(diff));
         pindex = pindex->pprev;
     }
 
-    for (const auto& diffIndex : listDiffIndexes) {
-        const auto& diff = mnListDiffsCache.at(diffIndex->GetBlockHash());
+    for (const auto& p : listDiff) {
+        auto diffIndex = p.first;
+        auto& diff = p.second;
         if (diff.HasChanges()) {
             snapshot = snapshot.ApplyDiff(diffIndex, diff);
         } else {
             snapshot.SetBlockHash(diffIndex->GetBlockHash());
             snapshot.SetHeight(diffIndex->nHeight);
         }
-    }
 
-    if (tipIndex) {
-        // always keep a snapshot for the tip
-        if (snapshot.GetBlockHash() == tipIndex->GetBlockHash()) {
-            mnListsCache.emplace(snapshot.GetBlockHash(), snapshot);
-        } else {
-            // keep snapshots for yet alive quorums
-            for (auto& p_llmq : Params().GetConsensus().llmqs) {
-                if ((snapshot.GetHeight() % p_llmq.second.dkgInterval == 0) && (snapshot.GetHeight() + p_llmq.second.dkgInterval * (p_llmq.second.keepOldConnections + 1) >= tipIndex->nHeight)) {
-                    mnListsCache.emplace(snapshot.GetBlockHash(), snapshot);
-                    break;
-                }
-            }
-        }
+        mnListsCache.emplace(diffIndex->GetBlockHash(), snapshot);
     }
 
     return snapshot;
@@ -1021,46 +990,14 @@ void CDeterministicMNManager::CleanupCache(int nHeight)
 {
     LOCK(cs);
 
-    std::vector<uint256> toDeleteLists;
-    std::vector<uint256> toDeleteDiffs;
+    std::vector<uint256> toDelete;
     for (const auto& p : mnListsCache) {
-        if (p.second.GetHeight() + LIST_DIFFS_CACHE_SIZE < nHeight) {
-            toDeleteLists.emplace_back(p.first);
-            continue;
-        }
-        bool fQuorumCache{false};
-        for (auto& p_llmq : Params().GetConsensus().llmqs) {
-            if ((p.second.GetHeight() % p_llmq.second.dkgInterval == 0) && (p.second.GetHeight() + p_llmq.second.dkgInterval * (p_llmq.second.keepOldConnections + 1) >= nHeight)) {
-                fQuorumCache = true;
-                break;
-            }
-        }
-        if (fQuorumCache) {
-            // at least one quorum could be using it, keep it
-            continue;
-        }
-        // no alive quorums using it, see if it was a cache for the tip or for a now outdated quorum
-        if (tipIndex && tipIndex->pprev && (p.first == tipIndex->pprev->GetBlockHash())) {
-            toDeleteLists.emplace_back(p.first);
-        } else {
-            for (auto& p_llmq : Params().GetConsensus().llmqs) {
-                if (p.second.GetHeight() % p_llmq.second.dkgInterval == 0) {
-                    toDeleteLists.emplace_back(p.first);
-                    break;
-                }
-            }
+        if (p.second.GetHeight() + LISTS_CACHE_SIZE < nHeight) {
+            toDelete.emplace_back(p.first);
         }
     }
-    for (const auto& h : toDeleteLists) {
+    for (const auto& h : toDelete) {
         mnListsCache.erase(h);
-    }
-    for (const auto& p : mnListDiffsCache) {
-        if (p.second.nHeight + LIST_DIFFS_CACHE_SIZE < nHeight) {
-            toDeleteDiffs.emplace_back(p.first);
-        }
-    }
-    for (const auto& h : toDeleteDiffs) {
-        mnListDiffsCache.erase(h);
     }
 }
 
@@ -1155,7 +1092,7 @@ void CDeterministicMNManager::UpgradeDBIfNeeded()
         CDeterministicMNList newMNList;
         UpgradeDiff(batch, pindex, curMNList, newMNList);
 
-        if ((nHeight % DISK_SNAPSHOT_PERIOD) == 0) {
+        if ((nHeight % SNAPSHOT_LIST_PERIOD) == 0) {
             batch.Write(std::make_pair(DB_LIST_SNAPSHOT, pindex->GetBlockHash()), newMNList);
             evoDb.GetRawDB().WriteBatch(batch);
             batch.Clear();

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -1019,7 +1019,7 @@ bool CDeterministicMNManager::IsDIP3Enforced(int nHeight)
 
 void CDeterministicMNManager::CleanupCache(int nHeight)
 {
-    AssertLockHeld(cs);
+    LOCK(cs);
 
     std::vector<uint256> toDeleteLists;
     std::vector<uint256> toDeleteDiffs;

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -5,18 +5,19 @@
 #ifndef DASH_DETERMINISTICMNS_H
 #define DASH_DETERMINISTICMNS_H
 
-#include "arith_uint256.h"
-#include "bls/bls.h"
-#include "dbwrapper.h"
-#include "evodb.h"
-#include "providertx.h"
-#include "simplifiedmns.h"
-#include "sync.h"
+#include <arith_uint256.h>
+#include <bls/bls.h>
+#include <dbwrapper.h>
+#include <evo/evodb.h>
+#include <evo/providertx.h>
+#include <evo/simplifiedmns.h>
+#include <saltedhasher.h>
+#include <sync.h>
 
 #include "immer/map.hpp"
 #include "immer/map_transient.hpp"
 
-#include <map>
+#include <unordered_map>
 
 class CBlock;
 class CBlockIndex;
@@ -541,6 +542,8 @@ private:
 class CDeterministicMNListDiff
 {
 public:
+    int nHeight{-1}; //memory only
+
     std::vector<CDeterministicMNCPtr> addedMNs;
     // keys are all relating to the internalId of MNs
     std::map<uint64_t, CDeterministicMNStateDiff> updatedMNs;
@@ -625,8 +628,9 @@ public:
 
 class CDeterministicMNManager
 {
-    static const int SNAPSHOT_LIST_PERIOD = 576; // once per day
-    static const int LISTS_CACHE_SIZE = 576;
+    static const int DISK_SNAPSHOT_PERIOD = 576; // once per day
+    static const int DISK_SNAPSHOTS = 3; // keep cache for 3 disk snapshots to have 2 full days covered
+    static const int LIST_DIFFS_CACHE_SIZE = DISK_SNAPSHOT_PERIOD * DISK_SNAPSHOTS;
 
 public:
     CCriticalSection cs;
@@ -634,7 +638,8 @@ public:
 private:
     CEvoDB& evoDb;
 
-    std::map<uint256, CDeterministicMNList> mnListsCache;
+    std::unordered_map<uint256, CDeterministicMNList, StaticSaltedHasher> mnListsCache;
+    std::unordered_map<uint256, CDeterministicMNListDiff, StaticSaltedHasher> mnListDiffsCache;
     const CBlockIndex* tipIndex{nullptr};
 
 public:

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -5,19 +5,18 @@
 #ifndef DASH_DETERMINISTICMNS_H
 #define DASH_DETERMINISTICMNS_H
 
-#include <arith_uint256.h>
-#include <bls/bls.h>
-#include <dbwrapper.h>
-#include <evo/evodb.h>
-#include <evo/providertx.h>
-#include <evo/simplifiedmns.h>
-#include <saltedhasher.h>
-#include <sync.h>
+#include "arith_uint256.h"
+#include "bls/bls.h"
+#include "dbwrapper.h"
+#include "evodb.h"
+#include "providertx.h"
+#include "simplifiedmns.h"
+#include "sync.h"
 
 #include "immer/map.hpp"
 #include "immer/map_transient.hpp"
 
-#include <unordered_map>
+#include <map>
 
 class CBlock;
 class CBlockIndex;
@@ -542,8 +541,6 @@ private:
 class CDeterministicMNListDiff
 {
 public:
-    int nHeight{-1}; //memory only
-
     std::vector<CDeterministicMNCPtr> addedMNs;
     // keys are all relating to the internalId of MNs
     std::map<uint64_t, CDeterministicMNStateDiff> updatedMNs;
@@ -628,9 +625,8 @@ public:
 
 class CDeterministicMNManager
 {
-    static const int DISK_SNAPSHOT_PERIOD = 576; // once per day
-    static const int DISK_SNAPSHOTS = 3; // keep cache for 3 disk snapshots to have 2 full days covered
-    static const int LIST_DIFFS_CACHE_SIZE = DISK_SNAPSHOT_PERIOD * DISK_SNAPSHOTS;
+    static const int SNAPSHOT_LIST_PERIOD = 576; // once per day
+    static const int LISTS_CACHE_SIZE = 576;
 
 public:
     CCriticalSection cs;
@@ -638,8 +634,7 @@ public:
 private:
     CEvoDB& evoDb;
 
-    std::unordered_map<uint256, CDeterministicMNList, StaticSaltedHasher> mnListsCache;
-    std::unordered_map<uint256, CDeterministicMNListDiff, StaticSaltedHasher> mnListDiffsCache;
+    std::map<uint256, CDeterministicMNList> mnListsCache;
     const CBlockIndex* tipIndex{nullptr};
 
 public:

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -669,7 +669,7 @@ public:
     void UpgradeDBIfNeeded();
     static bool IsDIP3Active(int height);
 
-private:
+public:
     void CleanupCache(int nHeight);
 };
 

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -247,6 +247,14 @@ bool CMasternodePayments::GetBlockTxOuts(int nBlockHeight, CAmount blockReward, 
     return true;
 }
 
+bool CMasternodePayments::GetBlockTxOutsWipeCache(int nBlockHeight, CAmount blockReward, std::vector<CTxOut>& voutMasternodePaymentsRet) const
+{
+    bool result = GetBlockTxOuts(nBlockHeight, blockReward, voutMasternodePaymentsRet);
+    AssertLockHeld(cs_main);
+    deterministicMNManager->CleanupCache(chainActive.Height());
+    return result;
+}
+
 // Is this masternode scheduled to get paid soon?
 // -- Only look ahead up to 8 blocks to allow for propagation of the latest 2 blocks of votes
 bool CMasternodePayments::IsScheduled(const CDeterministicMNCPtr& dmnIn, int nNotBlockHeight) const

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -32,6 +32,7 @@ class CMasternodePayments
 {
 public:
     bool GetBlockTxOuts(int nBlockHeight, CAmount blockReward, std::vector<CTxOut>& voutMasternodePaymentsRet) const;
+    bool GetBlockTxOutsWipeCache(int nBlockHeight, CAmount blockReward, std::vector<CTxOut>& voutMasternodePaymentsRet) const;
     bool IsTransactionValid(const CTransaction& txNew, int nBlockHeight, CAmount blockReward) const;
     bool IsScheduled(const CDeterministicMNCPtr& dmn, int nNotBlockHeight) const;
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1553,7 +1553,7 @@ void ListTransactions(CWallet * const pwallet, const CWalletTx& wtx, const strin
                     int txHeight = chainActive.Height() - wtx.GetDepthInMainChain();
 
                     std::vector<CTxOut> voutMasternodePaymentsRet;
-                    mnpayments.GetBlockTxOuts(txHeight, CAmount(), voutMasternodePaymentsRet);
+                    mnpayments.GetBlockTxOutsWipeCache(txHeight, CAmount(), voutMasternodePaymentsRet);
                     //compare address of payee to addr.
 
                     bool its_znode_payment = false;


### PR DESCRIPTION
## PR intention
Fixes the memory blow up when calling listtransactions for different blocks. 

## Code changes brief
Clean up the cache after each listtransaction call.
