### PR TITLE
Implemented special handling for -nodebug flag

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1206,8 +1206,10 @@ bool AppInitParameterInteraction()
     // Special-case: if -debug=0/-nodebug is set, turn off debugging messages
     if (fDebug) {
         const std::vector<std::string>& categories = mapMultiArgs.at("-debug");
-        if (GetBoolArg("-nodebug", false) || find(categories.begin(), categories.end(), std::string("0")) != categories.end())
+        if (GetBoolArg("-nodebug", false) || find(categories.begin(), categories.end(), std::string("0")) != categories.end()) {
             fDebug = false;
+            fNoDebug = true;
+        }
     }
 
     // Check for -debugnet

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -121,6 +121,7 @@ const map<string, vector<string> >& mapMultiArgs = _mapMultiArgs;
 bool fDebug = false;
 bool fPrintToConsole = false;
 bool fPrintToDebugLog = true;
+bool fNoDebug = false; //A temporary fix for https://github.com/firoorg/firo/issues/1011
 
 bool fLogTimestamps = DEFAULT_LOGTIMESTAMPS;
 bool fLogTimeMicros = DEFAULT_LOGTIMEMICROS;
@@ -307,6 +308,14 @@ static std::string LogTimestampStr(const std::string &str, std::atomic_bool *fSt
 
 int LogPrintStr(const std::string &str)
 {
+    //A temporary fix for https://github.com/firoorg/firo/issues/1011
+    if (fNoDebug) {
+        if (str.size() < 6)
+            return 0;
+        else if (strncmp(str.data(), "ERROR:", 6) != 0)
+            return 0;
+    }
+
     int ret = 0; // Returns total number of characters written
     static std::atomic_bool fStartedNewLine(true);
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -309,12 +309,8 @@ static std::string LogTimestampStr(const std::string &str, std::atomic_bool *fSt
 int LogPrintStr(const std::string &str)
 {
     //A temporary fix for https://github.com/firoorg/firo/issues/1011
-    if (fNoDebug) {
-        if (str.size() < 6)
-            return 0;
-        else if (strncmp(str.data(), "ERROR:", 6) != 0)
-            return 0;
-    }
+    if (fNoDebug && str.compare(0, 6, "ERROR:", 0, 6) != 0)
+        return 0;
 
     int ret = 0; // Returns total number of characters written
     static std::atomic_bool fStartedNewLine(true);

--- a/src/util.h
+++ b/src/util.h
@@ -56,6 +56,7 @@ extern const std::map<std::string, std::vector<std::string> >& mapMultiArgs;
 extern bool fDebug;
 extern bool fPrintToConsole;
 extern bool fPrintToDebugLog;
+extern bool fNoDebug;
 
 extern bool fLogTimestamps;
 extern bool fLogTimeMicros;


### PR DESCRIPTION
## PR intention
Suppress all the log messages except those start with "ERROR:". 

## Code changes brief
Added a temporary flag fNoDebug. Bitcoin 0.17 introduces a redesign which have this logic fixed.
