### PR TITLE
Fix listransactions performance

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -993,7 +993,7 @@ bool CDeterministicMNManager::IsDIP3Enforced(int nHeight)
 
 void CDeterministicMNManager::CleanupCache(int nHeight)
 {
-    LOCK(cs);
+    AssertLockHeld(cs);
 
     std::vector<uint256> toDelete;
     for (const auto& p : mnListsCache) {

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -664,7 +664,7 @@ public:
     void UpgradeDBIfNeeded();
     static bool IsDIP3Active(int height);
 
-public:
+private:
     void CleanupCache(int nHeight);
 };
 

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -247,14 +247,6 @@ bool CMasternodePayments::GetBlockTxOuts(int nBlockHeight, CAmount blockReward, 
     return true;
 }
 
-bool CMasternodePayments::GetBlockTxOutsWipeCache(int nBlockHeight, CAmount blockReward, std::vector<CTxOut>& voutMasternodePaymentsRet) const
-{
-    bool result = GetBlockTxOuts(nBlockHeight, blockReward, voutMasternodePaymentsRet);
-    AssertLockHeld(cs_main);
-    deterministicMNManager->CleanupCache(chainActive.Height());
-    return result;
-}
-
 // Is this masternode scheduled to get paid soon?
 // -- Only look ahead up to 8 blocks to allow for propagation of the latest 2 blocks of votes
 bool CMasternodePayments::IsScheduled(const CDeterministicMNCPtr& dmnIn, int nNotBlockHeight) const

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -32,7 +32,6 @@ class CMasternodePayments
 {
 public:
     bool GetBlockTxOuts(int nBlockHeight, CAmount blockReward, std::vector<CTxOut>& voutMasternodePaymentsRet) const;
-    bool GetBlockTxOutsWipeCache(int nBlockHeight, CAmount blockReward, std::vector<CTxOut>& voutMasternodePaymentsRet) const;
     bool IsTransactionValid(const CTransaction& txNew, int nBlockHeight, CAmount blockReward) const;
     bool IsScheduled(const CDeterministicMNCPtr& dmn, int nNotBlockHeight) const;
 

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -68,7 +68,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "listtransactions", 1, "count" },
     { "listtransactions", 2, "skip" },
     { "listtransactions", 3, "include_watchonly" },
-    { "listtransactions", 4, "omit_mnpayments" },
+    { "listtransactions", 4, "skip_mnout_check" },
     { "listaccounts", 0, "minconf" },
     { "listaccounts", 1, "include_watchonly" },
     { "walletpassphrase", 1, "timeout" },

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -68,6 +68,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "listtransactions", 1, "count" },
     { "listtransactions", 2, "skip" },
     { "listtransactions", 3, "include_watchonly" },
+    { "listtransactions", 4, "omit_mnpayments" },
     { "listaccounts", 0, "minconf" },
     { "listaccounts", 1, "include_watchonly" },
     { "walletpassphrase", 1, "timeout" },

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1627,7 +1627,7 @@ UniValue listtransactions(const JSONRPCRequest& request)
             "2. count          (numeric, optional, default=10) The number of transactions to return\n"
             "3. skip           (numeric, optional, default=0) The number of transactions to skip\n"
             "4. include_watchonly (bool, optional, default=false) Include transactions to watch-only addresses (see 'importaddress')\n"
-            "5. omit_mnpayments   (bool, optional, default=false) Do not handle masternode outputs (improves performance)\n"
+            "5. skip_mnout_check  (bool, optional, default=false) Skip checking for masternode payment txout (improves performance)\n"
             "\nResult:\n"
             "[\n"
             "  {\n"

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1556,7 +1556,7 @@ void ListTransactions(CWallet * const pwallet, const CWalletTx& wtx, const strin
 
                     if (!omitNmPayments) {
                         std::vector<CTxOut> voutMasternodePaymentsRet;
-                        mnpayments.GetBlockTxOutsWipeCache(txHeight, CAmount(), voutMasternodePaymentsRet);
+                        mnpayments.GetBlockTxOuts(txHeight, CAmount(), voutMasternodePaymentsRet);
                         //compare address of payee to addr.
                         for(CTxOut const & out : voutMasternodePaymentsRet) {
                             CTxDestination payeeDest;
@@ -1618,7 +1618,7 @@ UniValue listtransactions(const JSONRPCRequest& request)
         return NullUniValue;
     }
 
-    if (request.fHelp || request.params.size() > 4)
+    if (request.fHelp || request.params.size() > 5)
         throw runtime_error(
             "listtransactions ( \"account\" count skip include_watchonly)\n"
             "\nReturns up to 'count' most recent transactions skipping the first 'from' transactions for account 'account'.\n"

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1485,7 +1485,7 @@ static void MaybePushAddress(UniValue & entry, const CTxDestination &dest, CBitc
         entry.push_back(Pair("address", addr.ToString()));
 }
 
-void ListTransactions(CWallet * const pwallet, const CWalletTx& wtx, const string& strAccount, int nMinDepth, bool fLong, UniValue& ret, const isminefilter& filter)
+void ListTransactions(CWallet * const pwallet, const CWalletTx& wtx, const string& strAccount, int nMinDepth, bool fLong, UniValue& ret, const isminefilter& filter, bool omitNmPayments)
 {
     CAmount nFee;
     string strSentAccount;
@@ -1552,18 +1552,20 @@ void ListTransactions(CWallet * const pwallet, const CWalletTx& wtx, const strin
                 {
                     int txHeight = chainActive.Height() - wtx.GetDepthInMainChain();
 
-                    std::vector<CTxOut> voutMasternodePaymentsRet;
-                    mnpayments.GetBlockTxOutsWipeCache(txHeight, CAmount(), voutMasternodePaymentsRet);
-                    //compare address of payee to addr.
-
                     bool its_znode_payment = false;
-                    for(CTxOut const & out : voutMasternodePaymentsRet) {
-                        CTxDestination payeeDest;
-                        ExtractDestination(out.scriptPubKey, payeeDest);
-                        CBitcoinAddress payeeAddr(payeeDest);
 
-                        if(addr.ToString() == payeeAddr.ToString()) {
-                            its_znode_payment = true;
+                    if (!omitNmPayments) {
+                        std::vector<CTxOut> voutMasternodePaymentsRet;
+                        mnpayments.GetBlockTxOutsWipeCache(txHeight, CAmount(), voutMasternodePaymentsRet);
+                        //compare address of payee to addr.
+                        for(CTxOut const & out : voutMasternodePaymentsRet) {
+                            CTxDestination payeeDest;
+                            ExtractDestination(out.scriptPubKey, payeeDest);
+                            CBitcoinAddress payeeAddr(payeeDest);
+
+                            if(addr.ToString() == payeeAddr.ToString()) {
+                                its_znode_payment = true;
+                            }
                         }
                     }
                     if(its_znode_payment){
@@ -1625,6 +1627,7 @@ UniValue listtransactions(const JSONRPCRequest& request)
             "2. count          (numeric, optional, default=10) The number of transactions to return\n"
             "3. skip           (numeric, optional, default=0) The number of transactions to skip\n"
             "4. include_watchonly (bool, optional, default=false) Include transactions to watch-only addresses (see 'importaddress')\n"
+            "5. omit_mnpayments   (bool, optional, default=false) Do not handle masternode outputs (improves performance)\n"
             "\nResult:\n"
             "[\n"
             "  {\n"
@@ -1691,6 +1694,9 @@ UniValue listtransactions(const JSONRPCRequest& request)
     if(request.params.size() > 3)
         if(request.params[3].get_bool())
             filter = filter | ISMINE_WATCH_ONLY;
+    bool omitNmPayments = false;
+    if(request.params.size() > 4)
+        omitNmPayments = request.params[4].get_bool();
 
     if (nCount < 0)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Negative count");
@@ -1706,7 +1712,7 @@ UniValue listtransactions(const JSONRPCRequest& request)
     {
         CWalletTx *const pwtx = (*it).second.first;
         if (pwtx != 0)
-            ListTransactions(pwallet, *pwtx, strAccount, 0, true, ret, filter);
+            ListTransactions(pwallet, *pwtx, strAccount, 0, true, ret, filter, omitNmPayments);
         CAccountingEntry *const pacentry = (*it).second.second;
         if (pacentry != 0)
             AcentryToJSON(*pacentry, strAccount, ret);
@@ -1915,7 +1921,7 @@ UniValue listsinceblock(const JSONRPCRequest& request)
         CWalletTx tx = pairWtx.second;
 
         if (depth == -1 || tx.GetDepthInMainChain() < depth)
-            ListTransactions(pwallet, tx, "*", 0, true, transactions, filter);
+            ListTransactions(pwallet, tx, "*", 0, true, transactions, filter, false);
     }
 
     CBlockIndex *pblockLast = chainActive[chainActive.Height() + 1 - target_confirms];
@@ -2011,7 +2017,7 @@ UniValue gettransaction(const JSONRPCRequest& request)
     WalletTxToJSON(wtx, entry);
 
     UniValue details(UniValue::VARR);
-    ListTransactions(pwallet, wtx, "*", 0, false, details, filter);
+    ListTransactions(pwallet, wtx, "*", 0, false, details, filter, false);
     entry.push_back(Pair("details", details));
 
     string strHex = EncodeHexTx(static_cast<CTransaction>(wtx), RPCSerializationFlags());


### PR DESCRIPTION
## PR intention
Improves performance of listtransaction calls when users don't need the tx to be marked as masternode output

## Code changes brief
Added an additional flag to listtransactions and switched back to the caching schema.
