### PR TITLE
Remove unnecessary zero checks from Lelantus protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ firo.creator
 firo.creator.user
 firo.files
 firo.includes
+
+# Backups
+*.backup

--- a/src/liblelantus/range_verifier.cpp
+++ b/src/liblelantus/range_verifier.cpp
@@ -184,23 +184,12 @@ bool RangeVerifier::membership_checks(const RangeProof& proof) {
          && proof.u.isMember()
          && proof.innerProductProof.a_.isMember()
          && proof.innerProductProof.b_.isMember()
-         && proof.innerProductProof.c_.isMember())
-         || proof.A.isInfinity()
-         || proof.S.isInfinity()
-         || proof.T1.isInfinity()
-         || proof.T2.isInfinity()
-         || proof.T_x1.isZero()
-         || proof.T_x2.isZero()
-         || proof.u.isZero()
-         || proof.innerProductProof.a_.isZero()
-         || proof.innerProductProof.b_.isZero()
-         || proof.innerProductProof.c_.isZero())
-        return false;
+         && proof.innerProductProof.c_.isMember()))
+         return false;
 
     for (std::size_t i = 0; i < proof.innerProductProof.L_.size(); ++i)
     {
-        if (!(proof.innerProductProof.L_[i].isMember() && proof.innerProductProof.R_[i].isMember())
-           || proof.innerProductProof.L_[i].isInfinity() || proof.innerProductProof.R_[i].isInfinity())
+        if (!(proof.innerProductProof.L_[i].isMember() && proof.innerProductProof.R_[i].isMember()))
             return false;
     }
     return true;

--- a/src/liblelantus/sigmaextended_verifier.cpp
+++ b/src/liblelantus/sigmaextended_verifier.cpp
@@ -263,11 +263,7 @@ bool SigmaExtendedVerifier::membership_checks(const SigmaExtendedProof& proof) c
     if (!(proof.A_.isMember() &&
          proof.B_.isMember() &&
          proof.C_.isMember() &&
-         proof.D_.isMember()) ||
-        (proof.A_.isInfinity() ||
-         proof.B_.isInfinity() ||
-         proof.C_.isInfinity() ||
-         proof.D_.isInfinity()))
+         proof.D_.isMember()))
         return false;
 
     for (std::size_t i = 0; i < proof.f_.size(); i++)
@@ -279,18 +275,13 @@ bool SigmaExtendedVerifier::membership_checks(const SigmaExtendedProof& proof) c
     const std::vector <GroupElement>& Qk = proof.Qk;
     for (std::size_t k = 0; k < m; ++k)
     {
-        if (!(Gk[k].isMember() && Qk[k].isMember())
-           || Gk[k].isInfinity() || Qk[k].isInfinity())
+        if (!(Gk[k].isMember() && Qk[k].isMember()))
             return false;
     }
     if(!(proof.ZA_.isMember() &&
          proof.ZC_.isMember() &&
          proof.zV_.isMember() &&
-         proof.zR_.isMember()) ||
-        (proof.ZA_.isZero() ||
-         proof.ZC_.isZero() ||
-         proof.zV_.isZero() ||
-         proof.zR_.isZero()))
+         proof.zR_.isMember()))
         return false;
     return true;
 }


### PR DESCRIPTION
Removes unnecessary zero checks from range and one-of-many proof verifiers.