### PR TITLE
Range proof batch verification

### DIFF
--- a/src/liblelantus/innerproduct_proof_verifier.cpp
+++ b/src/liblelantus/innerproduct_proof_verifier.cpp
@@ -64,14 +64,14 @@ bool InnerProductProofVerifier::verify_util(
     return InnerProductProofVerifier(g_p, h_p, u_, p_p, version_).verify_util(proof, itr_l + 1, itr_r + 1, challengeGenerator);
 }
 
-bool InnerProductProofVerifier::verify_fast(uint64_t n, const Scalar& x, const InnerProductProof& proof, std::unique_ptr<ChallengeGenerator>& challengeGenerator) {
+bool InnerProductProofVerifier::verify_fast(std::size_t n, const Scalar& x, const InnerProductProof& proof, unique_ptr<ChallengeGenerator>& challengeGenerator) {
     u_  *= x;
     P_ += u_ * proof.c_;
     return verify_fast_util(n, proof, challengeGenerator);
 }
 
 bool InnerProductProofVerifier::verify_fast_util(
-        uint64_t n,
+        std::size_t n,
         const InnerProductProof& proof,
         std::unique_ptr<ChallengeGenerator>& challengeGenerator){
     std::size_t log_n = proof.L_.size();

--- a/src/liblelantus/innerproduct_proof_verifier.cpp
+++ b/src/liblelantus/innerproduct_proof_verifier.cpp
@@ -64,7 +64,7 @@ bool InnerProductProofVerifier::verify_util(
     return InnerProductProofVerifier(g_p, h_p, u_, p_p, version_).verify_util(proof, itr_l + 1, itr_r + 1, challengeGenerator);
 }
 
-bool InnerProductProofVerifier::verify_fast(std::size_t n, const Scalar& x, const InnerProductProof& proof, unique_ptr<ChallengeGenerator>& challengeGenerator) {
+bool InnerProductProofVerifier::verify_fast(std::size_t n, const Scalar& x, const InnerProductProof& proof, std::unique_ptr<ChallengeGenerator>& challengeGenerator) {
     u_  *= x;
     P_ += u_ * proof.c_;
     return verify_fast_util(n, proof, challengeGenerator);

--- a/src/liblelantus/innerproduct_proof_verifier.h
+++ b/src/liblelantus/innerproduct_proof_verifier.h
@@ -17,8 +17,8 @@ public:
             const GroupElement& P,
             int version); // if(version >= 2) we should pass CHash256 in verify
 
-    bool verify(const Scalar& x, const InnerProductProof& proof, std::unique_ptr<ChallengeGenerator>& challengeGenerator);
-    bool verify_fast(uint64_t n, const Scalar& x, const InnerProductProof& proof, std::unique_ptr<ChallengeGenerator>& challengeGenerator);
+    bool verify(const Scalar& x, const InnerProductProof& proof, unique_ptr<ChallengeGenerator>& challengeGenerator);
+    bool verify_fast(std::size_t n, const Scalar& x, const InnerProductProof& proof, unique_ptr<ChallengeGenerator>& challengeGenerator);
 
 private:
     bool verify_util(
@@ -27,7 +27,7 @@ private:
             typename std::vector<GroupElement>::const_iterator itr_r,
             std::unique_ptr<ChallengeGenerator>& challengeGenerator);
 
-    bool verify_fast_util(uint64_t n, const InnerProductProof& proof, std::unique_ptr<ChallengeGenerator>& challengeGenerator);
+    bool verify_fast_util(std::size_t n, const InnerProductProof& proof, unique_ptr<ChallengeGenerator>& challengeGenerator);
 
 private:
     const std::vector<GroupElement>& g_;

--- a/src/liblelantus/innerproduct_proof_verifier.h
+++ b/src/liblelantus/innerproduct_proof_verifier.h
@@ -17,8 +17,8 @@ public:
             const GroupElement& P,
             int version); // if(version >= 2) we should pass CHash256 in verify
 
-    bool verify(const Scalar& x, const InnerProductProof& proof, unique_ptr<ChallengeGenerator>& challengeGenerator);
-    bool verify_fast(std::size_t n, const Scalar& x, const InnerProductProof& proof, unique_ptr<ChallengeGenerator>& challengeGenerator);
+    bool verify(const Scalar& x, const InnerProductProof& proof, std::unique_ptr<ChallengeGenerator>& challengeGenerator);
+    bool verify_fast(std::size_t n, const Scalar& x, const InnerProductProof& proof, std::unique_ptr<ChallengeGenerator>& challengeGenerator);
 
 private:
     bool verify_util(
@@ -27,7 +27,7 @@ private:
             typename std::vector<GroupElement>::const_iterator itr_r,
             std::unique_ptr<ChallengeGenerator>& challengeGenerator);
 
-    bool verify_fast_util(std::size_t n, const InnerProductProof& proof, unique_ptr<ChallengeGenerator>& challengeGenerator);
+    bool verify_fast_util(std::size_t n, const InnerProductProof& proof, std::unique_ptr<ChallengeGenerator>& challengeGenerator);
 
 private:
     const std::vector<GroupElement>& g_;

--- a/src/liblelantus/lelantus_primitives.cpp
+++ b/src/liblelantus/lelantus_primitives.cpp
@@ -4,6 +4,37 @@
 namespace lelantus {
 
 static std::string lts("LELANTUS_SIGMA");
+
+// Invert a vector of scalars
+//
+// This _requires_ that all scalars be nonzero!
+std::vector<Scalar> LelantusPrimitives::invert(const std::vector<Scalar>& scalars) {
+    std::size_t n = scalars.size();
+
+    std::vector<Scalar> result;
+    result.reserve(n);
+    result.resize(n);
+    std::vector<Scalar> scratch;
+    scratch.reserve(n);
+    Scalar acc(uint64_t(1));
+    Scalar temp;
+
+    for (std::size_t i = 0; i < n; i++) {
+        if (scalars[i] == Scalar(uint64_t(0))) {
+            throw std::runtime_error("Cannot invert a zero scalar");
+        }
+        scratch.emplace_back(acc);
+        acc *= scalars[i];
+    }
+    acc = acc.inverse();
+    for (std::size_t i = n; i > 0; i--) {
+        temp = acc * scalars[i - 1];
+        result[i - 1] = acc * scratch[i - 1];
+        acc = temp;
+    }
+
+    return result;
+}
     
 void LelantusPrimitives::generate_challenge(
         const std::vector<GroupElement>& group_elements,
@@ -212,7 +243,7 @@ GroupElement LelantusPrimitives::p_prime(
     return L * x_square + P_ + R * (x_square.inverse());
 }
 
-Scalar LelantusPrimitives::delta(const Scalar& y, const Scalar& z, uint64_t n,  uint64_t m){
+Scalar LelantusPrimitives::delta(const Scalar& y, const Scalar& z, std::size_t n, std::size_t m){
     Scalar y_;
     Scalar two_;
     NthPower y_n(y);

--- a/src/liblelantus/lelantus_primitives.h
+++ b/src/liblelantus/lelantus_primitives.h
@@ -38,6 +38,8 @@ class LelantusPrimitives {
 
 public:
 ////common functions
+    static std::vector<Scalar> invert(const std::vector<Scalar>& scalars);
+
     static void generate_challenge(
             const std::vector<GroupElement>& group_elements,
             const std::string& domain_separator,
@@ -112,7 +114,7 @@ public:
             const GroupElement& R,
             const Scalar& x);
 
-    static Scalar delta(const Scalar& y, const Scalar& z, uint64_t n, uint64_t m);
+    static Scalar delta(const Scalar& y, const Scalar& z, std::size_t n, std::size_t m);
 
 };
 

--- a/src/liblelantus/lelantus_prover.cpp
+++ b/src/liblelantus/lelantus_prover.cpp
@@ -203,11 +203,13 @@ void LelantusProver::generate_bulletproofs(
     v_s.reserve(m);
     serials.reserve(m);
     randoms.reserve(m);
+    // NOTE: this prepends zero-value group elements, apparently as an earlier coding error
+    // This doesn't hurt anything, and so is retained here for compatibility reasons
     std::vector<GroupElement> commitments(Cout.size());
     for (std::size_t i = 0; i < Cout.size(); ++i)
     {
-        v_s.push_back(Cout[i].getV());
-        v_s.push_back(Cout[i].getVScalar() +  params->get_limit_range());
+        v_s.push_back(Cout[i].getV()); // Ensure that v >= 0
+        v_s.push_back(Cout[i].getVScalar() +  params->get_limit_range()); // Ensure that v <= ZC_LELANTUS_MAX_MINT
         serials.insert(serials.end(), 2, Cout[i].getSerialNumber());
         randoms.insert(randoms.end(), 2, Cout[i].getRandomness());
         commitments.emplace_back(Cout[i].getPublicCoin().getValue());
@@ -226,7 +228,7 @@ void LelantusProver::generate_bulletproofs(
     h_.insert(h_.end(), params->get_bulletproofs_h().begin(), params->get_bulletproofs_h().begin() + (n * m));
 
     RangeProver rangeProver(params->get_h1(), params->get_h0(), params->get_g(), g_, h_, n, version);
-    rangeProver.batch_proof(v_s, serials, randoms, commitments, bulletproofs);
+    rangeProver.proof(v_s, serials, randoms, commitments, bulletproofs);
 
 }
 

--- a/src/liblelantus/lelantus_verifier.cpp
+++ b/src/liblelantus/lelantus_verifier.cpp
@@ -213,7 +213,7 @@ bool LelantusVerifier::verify_rangeproof(
         commitments[0].emplace_back(Cout[i].getValue());
     }
 
-    std:vector<RangeProof> proofs;
+    std::vector<RangeProof> proofs;
     proofs.reserve(1); // size of batch
     proofs.emplace_back(bulletproof);
 

--- a/src/liblelantus/range_prover.cpp
+++ b/src/liblelantus/range_prover.cpp
@@ -9,7 +9,7 @@ RangeProver::RangeProver(
         const GroupElement& h2,
         const std::vector<GroupElement>& g_vector,
         const std::vector<GroupElement>& h_vector,
-        uint64_t n,
+        std::size_t n,
         unsigned int v)
         : g (g)
         , h1 (h1)
@@ -20,13 +20,27 @@ RangeProver::RangeProver(
         , version (v)
 {}
 
-void RangeProver::batch_proof(
+void RangeProver::proof(
         const std::vector<Scalar>& v,
         const std::vector<Scalar>& serialNumbers,
         const std::vector<Scalar>& randomness,
         const std::vector<GroupElement>& commitments,
         RangeProof& proof_out) {
+    // Size checks
     std::size_t m = v.size();
+    if (m == 0) {
+        throw std::invalid_argument("Range proof cannot use zero inputs");
+    }
+    if ((m & (m - 1)) != 0) {
+        throw std::invalid_argument("Range proof requires a power-of-two number of aggregated inputs");
+    }
+    if (v.size() != serialNumbers.size() || v.size() != randomness.size()) {
+        throw std::invalid_argument("Range proof input vector sizes do not match");
+    }
+    if (g_.size() != n * m || h_.size() != n * m) {
+        throw std::invalid_argument("Range proof generator vector has incorrect size");
+    }
+
     std::vector<std::vector<bool>> bits;
     bits.resize(m);
     for (std::size_t i = 0; i < v.size(); i++)
@@ -90,7 +104,7 @@ void RangeProver::batch_proof(
     NthPower two_n_(uint64_t(2));
     std::vector<Scalar> two_n;
     two_n.reserve(n);
-    for (uint64_t k = 0; k < n; ++k)
+    for (std::size_t k = 0; k < n; ++k)
     {
         two_n.emplace_back(two_n_.pow);
         two_n_.go_next();

--- a/src/liblelantus/range_prover.h
+++ b/src/liblelantus/range_prover.h
@@ -13,11 +13,11 @@ public:
             , const GroupElement& h2
             , const std::vector<GroupElement>& g_vector
             , const std::vector<GroupElement>& h_vector
-            , uint64_t n
+            , std::size_t n
             , unsigned int v);
 
     // commitments are included into transcript if version >= LELANTUS_TX_VERSION_4_5
-    void batch_proof(
+    void proof(
             const std::vector<Scalar>& v
             , const std::vector<Scalar>& serialNumbers
             , const std::vector<Scalar>& randomness
@@ -30,7 +30,7 @@ private:
     GroupElement h2;
     std::vector<GroupElement> g_;
     std::vector<GroupElement> h_;
-    uint64_t n;
+    std::size_t n;
     unsigned int version;
 
 };

--- a/src/liblelantus/range_verifier.cpp
+++ b/src/liblelantus/range_verifier.cpp
@@ -106,7 +106,6 @@ bool RangeVerifier::verify(const std::vector<std::vector<GroupElement> >& V, con
         w2.randomize();
 
         // Reconstruct all challenges from this proof
-        // NOTE: This does _not_ properly account for all inner product statement parameters! These need to be accounted for prior to deploying
         Scalar x, x_u, y, z;
         std::unique_ptr<ChallengeGenerator> challengeGenerator;
 

--- a/src/liblelantus/range_verifier.cpp
+++ b/src/liblelantus/range_verifier.cpp
@@ -262,6 +262,7 @@ bool RangeVerifier::verify(const std::vector<std::vector<GroupElement> >& V, con
     return true;
 }
 
+// Note: the infinity/zero checks are not required by the protocol; they are only included for historical implementation reasons
 bool RangeVerifier::membership_checks(const RangeProof& proof) {
     if(!(proof.A.isMember()
          && proof.S.isMember()
@@ -272,12 +273,23 @@ bool RangeVerifier::membership_checks(const RangeProof& proof) {
          && proof.u.isMember()
          && proof.innerProductProof.a_.isMember()
          && proof.innerProductProof.b_.isMember()
-         && proof.innerProductProof.c_.isMember()))
+         && proof.innerProductProof.c_.isMember())
+         || proof.A.isInfinity()
+         || proof.S.isInfinity()
+         || proof.T1.isInfinity()
+         || proof.T2.isInfinity()
+         || proof.T_x1.isZero()
+         || proof.T_x2.isZero()
+         || proof.u.isZero()
+         || proof.innerProductProof.a_.isZero()
+         || proof.innerProductProof.b_.isZero()
+         || proof.innerProductProof.c_.isZero())
         return false;
 
     for (std::size_t i = 0; i < proof.innerProductProof.L_.size(); ++i)
     {
-        if (!(proof.innerProductProof.L_[i].isMember() && proof.innerProductProof.R_[i].isMember())) {
+        if (!(proof.innerProductProof.L_[i].isMember() && proof.innerProductProof.R_[i].isMember())
+            || proof.innerProductProof.L_[i].isInfinity() || proof.innerProductProof.R_[i].isInfinity()) {
             return false;
         }
     }

--- a/src/liblelantus/range_verifier.h
+++ b/src/liblelantus/range_verifier.h
@@ -14,11 +14,12 @@ public:
             , const GroupElement& h2
             , const std::vector<GroupElement>& g_vector
             , const std::vector<GroupElement>& h_vector
-            , uint64_t n
+            , std::size_t n
             , unsigned int v);
 
     // commitments are included into transcript if version >= LELANTUS_TX_VERSION_4_5
-    bool verify_batch(const std::vector<GroupElement>& V, const std::vector<GroupElement>& commitments, const RangeProof& proof);
+    bool verify(const std::vector<GroupElement>& V, const std::vector<GroupElement>& commitments, const RangeProof& proof); // single proof
+    bool verify(const std::vector<std::vector<GroupElement> >& V, const std::vector<std::vector<GroupElement> >& commitments, const std::vector<RangeProof>& proof); // batch of proofs
 
 private:
     bool membership_checks(const RangeProof& proof);
@@ -29,7 +30,7 @@ private:
     GroupElement h2;
     const std::vector<GroupElement>& g_;
     const std::vector<GroupElement>& h_;
-    uint64_t n;
+    std::size_t n;
     unsigned int version;
 };
 

--- a/src/liblelantus/test/range_proof_test.cpp
+++ b/src/liblelantus/test/range_proof_test.cpp
@@ -7,6 +7,16 @@
 
 namespace lelantus {
 
+// All versions to be tested
+unsigned int test_versions[] = {
+    LELANTUS_TX_VERSION_4,
+    SIGMA_TO_LELANTUS_JOINSPLIT,
+    LELANTUS_TX_VERSION_4_5,
+    SIGMA_TO_LELANTUS_JOINSPLIT_FIXED,
+    LELANTUS_TX_TPAYLOAD,
+    SIGMA_TO_LELANTUS_TX_TPAYLOAD
+};
+
 BOOST_FIXTURE_TEST_SUITE(lelantus_range_proof_tests, LelantusTestingSetup)
 
 // A single valid aggregated range proof
@@ -50,7 +60,7 @@ BOOST_AUTO_TEST_CASE(prove_verify_single)
     // Test powers of 2
     std::size_t i = 1;
     while (i <= max_m) {
-        for (auto version : {LELANTUS_TX_VERSION_4, LELANTUS_TX_VERSION_4_5, LELANTUS_TX_TPAYLOAD})
+        for (auto version : test_versions) 
             prove_verify(i, version);
         i *= 2;
     }
@@ -73,7 +83,7 @@ BOOST_AUTO_TEST_CASE(prove_verify_batch)
     auto g_ = RandomizeGroupElements(n * max_m);
     auto h_ = RandomizeGroupElements(n * max_m);
 
-    for (auto version : {LELANTUS_TX_VERSION_4, LELANTUS_TX_VERSION_4_5, LELANTUS_TX_TPAYLOAD})
+    for (auto version : test_versions)
     {
         // Proofs
         std::vector<std::vector<GroupElement> > V_batch;
@@ -140,7 +150,7 @@ BOOST_AUTO_TEST_CASE(out_of_range_single_proof)
         BOOST_CHECK(!rangeVerifier.verify(V, V, proof));
     };
 
-    for (auto version : {LELANTUS_TX_VERSION_4, LELANTUS_TX_VERSION_4_5, LELANTUS_TX_TPAYLOAD})
+    for (auto version : test_versions)
     {
         // All values are out of range
         std::vector<Scalar> vs;
@@ -189,7 +199,7 @@ BOOST_AUTO_TEST_CASE(invalid_elements)
         V.push_back(g_gen * v_s.back() +  h_gen1 * randoms[i] + h_gen2 * serials[i]);
     }
 
-    for (auto version : {LELANTUS_TX_VERSION_4, LELANTUS_TX_VERSION_4_5, LELANTUS_TX_TPAYLOAD})
+    for (auto version : test_versions)
     {
         // Initial correctness check
         RangeProver rangeProver(g_gen, h_gen1, h_gen2, g_, h_, n, version);
@@ -294,7 +304,7 @@ BOOST_AUTO_TEST_CASE(invalid_batch)
     auto g_ = RandomizeGroupElements(n * max_m);
     auto h_ = RandomizeGroupElements(n * max_m);
 
-    for (auto version : {LELANTUS_TX_VERSION_4, LELANTUS_TX_VERSION_4_5, LELANTUS_TX_TPAYLOAD})
+    for (auto version : test_versions)
     {
         // Proofs
         std::vector<std::vector<GroupElement> > V_batch;

--- a/src/liblelantus/test/range_proof_test.cpp
+++ b/src/liblelantus/test/range_proof_test.cpp
@@ -9,71 +9,137 @@ namespace lelantus {
 
 BOOST_FIXTURE_TEST_SUITE(lelantus_range_proof_tests, LelantusTestingSetup)
 
-BOOST_AUTO_TEST_CASE(prove_verify)
+// A single valid aggregated range proof
+BOOST_AUTO_TEST_CASE(prove_verify_single)
 {
-    uint64_t n = 64;
-    uint64_t m = 4;
+    // Parameters
+    std::size_t n = 64;
+    std::size_t max_m = 8;
+
+    // Generators
     secp_primitives::GroupElement g_gen, h_gen1, h_gen2;
     g_gen.randomize();
     h_gen1.randomize();
     h_gen2.randomize();
 
-    //creating generators g, h vectors
-    auto g_ = RandomizeGroupElements(n * m);
-    auto h_ = RandomizeGroupElements(n * m);
+    auto prove_verify = [&] (std::size_t m) {
+        auto g_ = RandomizeGroupElements(n * m);
+        auto h_ = RandomizeGroupElements(n * m);
 
-    auto serials = RandomizeScalars(m);
-    auto randoms = RandomizeScalars(m);
+        // Input data
+        auto serials = RandomizeScalars(m);
+        auto randoms = RandomizeScalars(m);
 
-    std::vector<secp_primitives::Scalar> v_s;
-    std::vector<secp_primitives::GroupElement> V;
-    for(uint64_t i = 0; i < m; ++i){
-        v_s.emplace_back(701 + i);
-        V.push_back(g_gen * v_s.back() +  h_gen1 * randoms[i] + h_gen2 * serials[i]);
+        std::vector<secp_primitives::Scalar> v_s;
+        std::vector<secp_primitives::GroupElement> V;
+        for (std::size_t i = 0; i < m; ++i){
+            v_s.emplace_back(i);
+            V.push_back(g_gen * v_s.back() +  h_gen1 * randoms[i] + h_gen2 * serials[i]);
+        }
+
+        // Prove
+        RangeProver rangeProver(g_gen, h_gen1, h_gen2, g_, h_, n, LELANTUS_TX_VERSION_4_5);
+        RangeProof proof;
+        rangeProver.proof(v_s, serials, randoms, V, proof);
+
+        // Verify
+        RangeVerifier rangeVerifier(g_gen, h_gen1, h_gen2, g_, h_, n, LELANTUS_TX_VERSION_4_5);
+        BOOST_CHECK(rangeVerifier.verify(V, V, proof));
+    };
+
+    // Test powers of 2
+    std::size_t i = 1;
+    while (i <= max_m) {
+        prove_verify(i);
+        i *= 2;
     }
 
-    RangeProver rangeProver(g_gen, h_gen1, h_gen2, g_, h_, n, LELANTUS_TX_VERSION_4_5);
-    RangeProof proof;
-    rangeProver.batch_proof(v_s, serials, randoms, V, proof);
-
-    RangeVerifier rangeVerifier(g_gen, h_gen1, h_gen2, g_, h_, n, LELANTUS_TX_VERSION_4_5);
-    BOOST_CHECK(rangeVerifier.verify_batch(V, V, proof));
 }
 
-BOOST_AUTO_TEST_CASE(out_of_range_notVerify)
+// A batch of valid aggregated range proofs of different size
+BOOST_AUTO_TEST_CASE(prove_verify_batch)
 {
-    uint64_t n = 4;
-    uint64_t m = 4;
+    // Parameters
+    const std::size_t n = 64;
+    const std::vector<std::size_t> m = {1,2,4,8};
+
+    // Generators
     secp_primitives::GroupElement g_gen, h_gen1, h_gen2;
     g_gen.randomize();
     h_gen1.randomize();
     h_gen2.randomize();
+    std::size_t max_m = *std::max_element(m.begin(), m.end());
+    auto g_ = RandomizeGroupElements(n * max_m);
+    auto h_ = RandomizeGroupElements(n * max_m);
 
-    //creating generators g, h vectors
+    // Proofs
+    std::vector<std::vector<GroupElement> > V_batch;
+    V_batch.reserve(m.size());
+    std::vector<RangeProof> proof_batch;
+    proof_batch.reserve(m.size());
+    for (std::size_t i = 0; i < m.size(); i++) {
+        RangeProver rangeProver(g_gen, h_gen1, h_gen2, std::vector<GroupElement>(g_.begin(), g_.begin() + n * m[i]), std::vector<GroupElement>(h_.begin(), h_.begin() + n * m[i]), n, LELANTUS_TX_VERSION_4_5);
+
+        // Input data
+        auto serials = RandomizeScalars(m[i]);
+        auto randoms = RandomizeScalars(m[i]);
+
+        std::vector<secp_primitives::Scalar> v_s;
+        std::vector<secp_primitives::GroupElement> V;
+        for (std::size_t j = 0; j < m[i]; ++j){
+            v_s.emplace_back(j);
+            V.push_back(g_gen * v_s.back() +  h_gen1 * randoms[j] + h_gen2 * serials[j]);
+        }
+
+        // Prove
+        RangeProof proof;
+        rangeProver.proof(v_s, serials, randoms, V, proof);
+        V_batch.emplace_back(V);
+        proof_batch.emplace_back(proof);
+    }
+
+    // Verify
+    RangeVerifier rangeVerifier(g_gen, h_gen1, h_gen2, g_, h_, n, LELANTUS_TX_VERSION_4_5);
+    BOOST_CHECK(rangeVerifier.verify(V_batch, V_batch, proof_batch));
+}
+
+// A single out-of-range aggregated range proof
+BOOST_AUTO_TEST_CASE(out_of_range_single_proof)
+{
+    // Parameters
+    std::size_t n = 4;
+    std::size_t m = 4;
+
+    // Generators
+    secp_primitives::GroupElement g_gen, h_gen1, h_gen2;
+    g_gen.randomize();
+    h_gen1.randomize();
+    h_gen2.randomize();
     auto g_ = RandomizeGroupElements(n * m);
     auto h_ = RandomizeGroupElements(n * m);
 
+    // Input data
     auto randoms = RandomizeScalars(m);
     auto serials = RandomizeScalars(m);
 
     auto testF = [&] (std::vector<Scalar> const v_s) {
         std::vector<GroupElement> V;
-        for (uint64_t i = 0; i < m; ++i) {
+        for (std::size_t i = 0; i < m; ++i) {
             V.push_back(g_gen * v_s[i] +  h_gen1 * randoms[i] + h_gen2 * serials[i]);
         }
 
         lelantus::RangeProver rangeProver(g_gen, h_gen1, h_gen2, g_, h_, n, LELANTUS_TX_VERSION_4_5);
         lelantus::RangeProof proof;
-        rangeProver.batch_proof(v_s, serials, randoms, V, proof );
+        rangeProver.proof(v_s, serials, randoms, V, proof );
 
         lelantus::RangeVerifier rangeVerifier(g_gen, h_gen1, h_gen2, g_, h_, n, LELANTUS_TX_VERSION_4_5);
-        BOOST_CHECK(!rangeVerifier.verify_batch(V, V, proof));
+        BOOST_CHECK(!rangeVerifier.verify(V, V, proof));
     };
 
     // All values are out of range
     std::vector<Scalar> vs;
-    for(uint64_t i = 0; i < m; ++i){
-        vs.emplace_back(17 + i);
+    for(std::size_t i = 0; i < m; ++i){
+        vs.emplace_back((1 << n) + i);
     }
     testF(vs);
 
@@ -87,6 +153,169 @@ BOOST_AUTO_TEST_CASE(out_of_range_notVerify)
 
     vs = {l - 1, l, r - 1, r};
     testF(vs);
+}
+
+// A single aggreated range proof, with successively invalid proof elements
+BOOST_AUTO_TEST_CASE(invalid_elements)
+{
+    // Parameters
+    std::size_t n = 64;
+    std::size_t m = 4;
+
+    // Generators
+    secp_primitives::GroupElement g_gen, h_gen1, h_gen2;
+    g_gen.randomize();
+    h_gen1.randomize();
+    h_gen2.randomize();
+    auto g_ = RandomizeGroupElements(n * m);
+    auto h_ = RandomizeGroupElements(n * m);
+
+    // Inputs
+    auto randoms = RandomizeScalars(m);
+    auto serials = RandomizeScalars(m);
+
+    // Set up valid proof
+    std::vector<secp_primitives::Scalar> v_s;
+    std::vector<secp_primitives::GroupElement> V;
+    for(std::size_t i = 0; i < m; ++i){
+        v_s.emplace_back(i);
+        V.push_back(g_gen * v_s.back() +  h_gen1 * randoms[i] + h_gen2 * serials[i]);
+    }
+
+    // Initial correctness check
+    RangeProver rangeProver(g_gen, h_gen1, h_gen2, g_, h_, n, LELANTUS_TX_VERSION_4_5);
+    RangeProof proof;
+    rangeProver.proof(v_s, serials, randoms, V, proof);
+    RangeVerifier rangeVerifier(g_gen, h_gen1, h_gen2, g_, h_, n, LELANTUS_TX_VERSION_4_5);
+    BOOST_CHECK(rangeVerifier.verify(V, V, proof));
+
+    // Invalidate successive values and then restore them
+    GroupElement group;
+    Scalar scalar;
+
+    group = GroupElement(proof.A);
+    proof.A.randomize();
+    BOOST_CHECK(!rangeVerifier.verify(V, V, proof));
+    proof.A = GroupElement(group);
+    BOOST_CHECK(rangeVerifier.verify(V, V, proof));
+
+    group = GroupElement(proof.S);
+    proof.S.randomize();
+    BOOST_CHECK(!rangeVerifier.verify(V, V, proof));
+    proof.S = GroupElement(group);
+    BOOST_CHECK(rangeVerifier.verify(V, V, proof));
+
+    group = GroupElement(proof.T1);
+    proof.T1.randomize();
+    BOOST_CHECK(!rangeVerifier.verify(V, V, proof));
+    proof.T1 = GroupElement(group);
+    BOOST_CHECK(rangeVerifier.verify(V, V, proof));
+
+    group = GroupElement(proof.T2);
+    proof.T2.randomize();
+    BOOST_CHECK(!rangeVerifier.verify(V, V, proof));
+    proof.T2 = GroupElement(group);
+    BOOST_CHECK(rangeVerifier.verify(V, V, proof));
+
+    for (std::size_t j = 0; j < proof.innerProductProof.L_.size(); j++) {
+        group = GroupElement(proof.innerProductProof.L_[j]);
+        proof.innerProductProof.L_[j].randomize();
+        BOOST_CHECK(!rangeVerifier.verify(V, V, proof));
+        proof.innerProductProof.L_[j] = GroupElement(group);
+        BOOST_CHECK(rangeVerifier.verify(V, V, proof));
+
+        group = GroupElement(proof.innerProductProof.R_[j]);
+        proof.innerProductProof.R_[j].randomize();
+        BOOST_CHECK(!rangeVerifier.verify(V, V, proof));
+        proof.innerProductProof.R_[j] = GroupElement(group);
+        BOOST_CHECK(rangeVerifier.verify(V, V, proof));
+    }
+
+    scalar = Scalar(proof.T_x1);
+    proof.T_x1.randomize();
+    BOOST_CHECK(!rangeVerifier.verify(V, V, proof));
+    proof.T_x1 = Scalar(scalar);
+    BOOST_CHECK(rangeVerifier.verify(V, V, proof));
+
+    scalar = Scalar(proof.T_x2);
+    proof.T_x2.randomize();
+    BOOST_CHECK(!rangeVerifier.verify(V, V, proof));
+    proof.T_x2 = Scalar(scalar);
+    BOOST_CHECK(rangeVerifier.verify(V, V, proof));
+
+    scalar = Scalar(proof.u);
+    proof.u.randomize();
+    BOOST_CHECK(!rangeVerifier.verify(V, V, proof));
+    proof.u = Scalar(scalar);
+    BOOST_CHECK(rangeVerifier.verify(V, V, proof));
+
+    scalar = Scalar(proof.innerProductProof.a_);
+    proof.innerProductProof.a_.randomize();
+    BOOST_CHECK(!rangeVerifier.verify(V, V, proof));
+    proof.innerProductProof.a_ = Scalar(scalar);
+    BOOST_CHECK(rangeVerifier.verify(V, V, proof));
+
+    scalar = Scalar(proof.innerProductProof.b_);
+    proof.innerProductProof.b_.randomize();
+    BOOST_CHECK(!rangeVerifier.verify(V, V, proof));
+    proof.innerProductProof.b_ = Scalar(scalar);
+    BOOST_CHECK(rangeVerifier.verify(V, V, proof));
+
+    scalar = Scalar(proof.innerProductProof.c_);
+    proof.innerProductProof.c_.randomize();
+    BOOST_CHECK(!rangeVerifier.verify(V, V, proof));
+    proof.innerProductProof.c_ = Scalar(scalar);
+    BOOST_CHECK(rangeVerifier.verify(V, V, proof));
+}
+
+// A batch of range proofs, one of which is invalid
+BOOST_AUTO_TEST_CASE(invalid_batch)
+{
+    // Parameters
+    const std::size_t n = 64;
+    const std::vector<std::size_t> m = {1,2,4,8};
+
+    // Generators
+    secp_primitives::GroupElement g_gen, h_gen1, h_gen2;
+    g_gen.randomize();
+    h_gen1.randomize();
+    h_gen2.randomize();
+    std::size_t max_m = *std::max_element(m.begin(), m.end());
+    auto g_ = RandomizeGroupElements(n * max_m);
+    auto h_ = RandomizeGroupElements(n * max_m);
+
+    // Proofs
+    std::vector<std::vector<GroupElement> > V_batch;
+    V_batch.reserve(m.size());
+    std::vector<RangeProof> proof_batch;
+    proof_batch.reserve(m.size());
+    for (std::size_t i = 0; i < m.size(); i++) {
+        RangeProver rangeProver(g_gen, h_gen1, h_gen2, std::vector<GroupElement>(g_.begin(), g_.begin() + n * m[i]), std::vector<GroupElement>(h_.begin(), h_.begin() + n * m[i]), n, LELANTUS_TX_VERSION_4_5);
+
+        // Input data
+        auto serials = RandomizeScalars(m[i]);
+        auto randoms = RandomizeScalars(m[i]);
+
+        std::vector<secp_primitives::Scalar> v_s;
+        std::vector<secp_primitives::GroupElement> V;
+        for (std::size_t j = 0; j < m[i]; ++j){
+            v_s.emplace_back(j);
+            V.push_back(g_gen * v_s.back() +  h_gen1 * randoms[j] + h_gen2 * serials[j]);
+        }
+
+        // Prove
+        RangeProof proof;
+        rangeProver.proof(v_s, serials, randoms, V, proof);
+        V_batch.emplace_back(V);
+        proof_batch.emplace_back(proof);
+    }
+
+    // Invalidate one of the proofs
+    proof_batch[0].A.randomize();
+
+    // Verify
+    RangeVerifier rangeVerifier(g_gen, h_gen1, h_gen2, g_, h_, n, LELANTUS_TX_VERSION_4_5);
+    BOOST_CHECK(!rangeVerifier.verify(V_batch, V_batch, proof_batch));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Adds support for batch verification of range proofs. Updates tests. Retains compatibility with existing function calls for verification of single proofs.

This code does _not_ directly support batch verification of actual transactions, only the plumbing necessary to add this functionality later.

Review requested.