### PR TITLE
Update reversed instruction in build-windows.md

### DIFF
--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -79,7 +79,7 @@ To build executables for Windows 32-bit:
     make HOST=i686-w64-mingw32 -j`nproc`
     cd ..
     ./autogen.sh # not required when building from tarball
-    CONFIG_SITE=$PWD/depends/x86_64-w64-mingw32/share/config.site ./configure --prefix=/
+    CONFIG_SITE=$PWD/depends/i686-w64-mingw32/share/config.site ./configure --prefix=/
     make
 
 To build executables for Windows 64-bit:
@@ -89,7 +89,7 @@ To build executables for Windows 64-bit:
     make HOST=x86_64-w64-mingw32 -j`nproc`
     cd ..
     ./autogen.sh # not required when building from tarball
-    CONFIG_SITE=$PWD/depends/i686-w64-mingw32/share/config.site ./configure --prefix=/
+    CONFIG_SITE=$PWD/depends/x86_64-w64-mingw32/share/config.site ./configure --prefix=/
     make
 
 ## Depends system


### PR DESCRIPTION
Instructions for 32/64 bit are reversed.
