### PR TITLE
Receive addresses recovery fixed

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -6621,6 +6621,26 @@ CWallet* CWallet::CreateWalletFromFile(const std::string walletFile)
             }
         }
     }
+
+    // recover addressbook
+    if (fFirstRun)
+    {
+        for (map<uint256, CWalletTx>::iterator it = walletInstance->mapWallet.begin(); it != walletInstance->mapWallet.end(); ++it) {
+            for (uint32_t i = 0; i < (*it).second.tx->vout.size(); i++) {
+                const auto& txout = (*it).second.tx->vout[i];
+                if(txout.scriptPubKey.IsMint() || (*it).second.changes.count(i))
+                    continue;
+                if (!walletInstance->IsMine(txout))
+                    continue;
+                CTxDestination addr;
+                if(!ExtractDestination(txout.scriptPubKey, addr))
+                    continue;
+                if (walletInstance->mapAddressBook.count(addr) == 0)
+                    walletInstance->SetAddressBook(addr, "", "receive");
+            }
+        }
+    }
+
     walletInstance->SetBroadcastTransactions(GetBoolArg("-walletbroadcast", DEFAULT_WALLETBROADCAST));
 
     {


### PR DESCRIPTION
After recovering from mnemoics, wallet scans all wallet transactions, recognizes used addresses and adds them into addressbook.
The new code works as follows.
1. If it is first run go inside if
2. It iterates on wallet transactions
3. For each output is checked if it is your's
4. if not -> skip, if yes go and extract the address form the output,
5. add the address into addressbook  