### PR TITLE
Spend creation improved

### DIFF
--- a/src/test/sigma_mintspend_numinputs.cpp
+++ b/src/test/sigma_mintspend_numinputs.cpp
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_CASE(sigma_mintspend_numinputs)
             };
 
     // Check that the tx creation fails.
-    BOOST_CHECK_THROW(pwalletMain->SpendSigma(recipients, wtx), std::runtime_error);
+    BOOST_CHECK_THROW(pwalletMain->SpendSigma(recipients, wtx), std::exception);
     
     sigma::DenominationToInteger(sigma::CoinDenomination::SIGMA_DENOM_0_1, nAmount);
     recipients = {

--- a/src/wallet/lelantusjoinsplitbuilder.cpp
+++ b/src/wallet/lelantusjoinsplitbuilder.cpp
@@ -119,9 +119,9 @@ CWalletTx LelantusJoinSplitBuilder::Build(
         nCountNextUse = pwalletMain->zwallet->GetCount();
     }
 
-    std::tie(fee, std::ignore) = wallet.EstimateJoinSplitFee(vOut + mint, recipientsToSubtractFee, coinControl);
     std::list<CSigmaEntry> sigmaCoins = pwalletMain->GetAvailableCoins(coinControl);
     std::list<CLelantusEntry> coins = pwalletMain->GetAvailableLelantusCoins(coinControl);
+    std::tie(fee, std::ignore) = wallet.EstimateJoinSplitFee(vOut + mint, recipientsToSubtractFee, sigmaCoins, coins, coinControl);
 
     for (;;) {
         // In case of not enough fee, reset mint seed counter

--- a/src/wallet/lelantusjoinsplitbuilder.cpp
+++ b/src/wallet/lelantusjoinsplitbuilder.cpp
@@ -219,6 +219,10 @@ CWalletTx LelantusJoinSplitBuilder::Build(
             }
         }
 
+        if ((sigmaSpendCoins.size() + spendCoins.size()) > consensusParams.nMaxLelantusInputPerTransaction)
+            throw std::invalid_argument(
+                    _("Number of inputs is bigger then limit."));
+
         for(const auto& demon : denomChanges) {
             int64_t intDenom;
             sigma::DenominationToInteger(demon, intDenom);
@@ -303,7 +307,7 @@ CWalletTx LelantusJoinSplitBuilder::Build(
         // If we made it here and we aren't even able to meet the relay fee on the next pass, give up
         // because we must be at the maximum allowed fee.
         if (feeNeeded < minRelayTxFee.GetFee(size)) {
-            throw std::runtime_error(_("Transaction too large for fee policy"));
+            throw std::invalid_argument(_("Transaction too large for fee policy"));
         }
 
         if (fee >= feeNeeded) {

--- a/src/wallet/test/sigma_tests.cpp
+++ b/src/wallet/test/sigma_tests.cpp
@@ -433,8 +433,8 @@ BOOST_AUTO_TEST_CASE(get_coin_by_limit_max_to_1)
     std::list<CSigmaEntry> availableCoins = pwalletMain->GetAvailableCoins();
 
     BOOST_CHECK_EXCEPTION(pwalletMain->GetCoinsToSpend(require, coins, coinsToMint, availableCoins, 1),
-        std::runtime_error,
-        [](const std::runtime_error& e) {
+        std::exception,
+        [](const std::exception& e) {
             return e.what() == std::string("Can not choose coins within limit.");
         });
     sigmaState->Reset();

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3112,21 +3112,12 @@ bool CWallet::GetCoinsToJoinSplit(
         const CAmount amountToSpendLimit,
         const CCoinControl *coinControl) const
 {
-    // Sanity check to make sure this function is never called with a too large
-    // amount to spend, resulting to a possible crash due to out of memory condition.
-    if (!MoneyRange(required)) {
-        throw WalletError(
-                _("The required amount exceeds 21 MLN FIRO"));
-    }
 
-    if (!MoneyRange(amountToSpendLimit)) {
-        throw WalletError(
-                _("The amount limit exceeds max money"));
-    }
+    EnsureMintWalletAvailable();
+    Consensus::Params consensusParams = Params().GetConsensus();
 
-    if (required > amountToSpendLimit) {
-        throw WalletError(
-                _("The required amount exceeds spend limit"));
+    if (required > consensusParams.nMaxValueLelantusSpendPerTransaction) {
+        throw WalletError(_("The required amount exceeds spend limit"));
     }
 
     CAmount availableBalance = CalculateLelantusCoinsBalance(coins.begin(), coins.end());
@@ -5295,18 +5286,21 @@ CWalletTx CWallet::CreateLelantusJoinSplitTransaction(
     return tx;
 }
 
-std::pair<CAmount, unsigned int> CWallet::EstimateJoinSplitFee(CAmount required, bool subtractFeeFromAmount, const CCoinControl *coinControl) {
+std::pair<CAmount, unsigned int> CWallet::EstimateJoinSplitFee(
+        CAmount required,
+        bool subtractFeeFromAmount,
+        std::list<CSigmaEntry> sigmaCoins,
+        std::list<CLelantusEntry> coins,
+        const CCoinControl *coinControl) {
     CAmount fee;
     unsigned size;
     std::vector<CLelantusEntry> spendCoins;
     std::vector<CSigmaEntry> sigmaSpendCoins;
-    std::list<CSigmaEntry> sigmaCoins = this->GetAvailableCoins(coinControl, false, true);
+
     CAmount availableSigmaBalance(0);
     for (auto coin : sigmaCoins) {
         availableSigmaBalance += coin.get_denomination_value();
     }
-
-    std::list<CLelantusEntry> coins = GetAvailableLelantusCoins(coinControl, false, true);
 
     for (fee = payTxFee.GetFeePerK();;) {
         CAmount currentRequired = required;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3087,16 +3087,16 @@ bool CWallet::GetCoinsToSpend(
         best_spend_val *= zeros;
 
         if (minimum == INT_MAX - 1)
-            throw std::runtime_error(
+            throw std::invalid_argument(
                 _("Can not choose coins within limit."));
     }
 
     if (SelectMintCoinsForAmount(best_spend_val - roundedRequired * zeros, denominations, coinsToMint_out) != best_spend_val - roundedRequired * zeros) {
-        throw std::runtime_error(
+        throw std::invalid_argument(
             _("Problem with coin selection for re-mint while spending."));
     }
     if (SelectSpendCoinsForAmount(best_spend_val, coins, coinsToSpend_out) != best_spend_val) {
-        throw std::runtime_error(
+        throw std::invalid_argument(
             _("Problem with coin selection for spend."));
     }
 
@@ -3117,7 +3117,7 @@ bool CWallet::GetCoinsToJoinSplit(
     Consensus::Params consensusParams = Params().GetConsensus();
 
     if (required > consensusParams.nMaxValueLelantusSpendPerTransaction) {
-        throw WalletError(_("The required amount exceeds spend limit"));
+        throw invalid_argument(_("The required amount exceeds spend limit"));
     }
 
     CAmount availableBalance = CalculateLelantusCoinsBalance(coins.begin(), coins.end());

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1028,7 +1028,7 @@ public:
 
     void JoinSplitLelantus(const std::vector<CRecipient>& recipients, const std::vector<CAmount>& newMints, CWalletTx& result);
 
-    std::pair<CAmount, unsigned int> EstimateJoinSplitFee(CAmount required, bool subtractFeeFromAmount, const CCoinControl *coinControl);
+    std::pair<CAmount, unsigned int> EstimateJoinSplitFee(CAmount required, bool subtractFeeFromAmount, std::list<CSigmaEntry> sigmaCoins, std::list<CLelantusEntry> coins, const CCoinControl *coinControl);
 
     bool GetMint(const uint256& hashSerial, CSigmaEntry& sigmaEntry, bool forEstimation = false) const;
 


### PR DESCRIPTION
This change reduces disk access during joinsplit creation, also fixed error messages when number of inputs exceeds the limit.
EstimateJoinSplitFee() was calling GetAvailableCoins() and GetAvailableLelantusCoins() functions, both are expensive as both are doing disk accesses.
The changes just passes already gotten vectors, as we have it in LelantusJoinSplitBuilder::Build() function.