### PR TITLE
Replace part of balance verification with multiscalar multiplication operation

### DIFF
--- a/src/liblelantus/lelantus_verifier.cpp
+++ b/src/liblelantus/lelantus_verifier.cpp
@@ -227,15 +227,24 @@ bool LelantusVerifier::verify_schnorrproof(
         const std::vector<PublicCoin>& Cout,
         const LelantusProof& proof,
         unique_ptr<ChallengeGenerator>& challengeGenerator) {
-    GroupElement A;
-    for (std::size_t i = 0; i < Cout.size(); ++i)
-        A += Cout[i].getValue();
-    if (Cout.size() > 0)
-        A *= x.exponent(params->get_sigma_m());
-    A += params->get_h1() * ((Vout + fee) * x.exponent(params->get_sigma_m()));
+    // x^m
+    Scalar x_m = x.exponent(params->get_sigma_m());
 
-    GroupElement B = (params->get_h1() * (Vin * x.exponent(params->get_sigma_m())))
-                     + LelantusPrimitives::double_commit(params->get_g(), uint64_t(0), params->get_h1(), zV, params->get_h0(), zR);
+    // A is computed directly, to take advantage of point addition
+    GroupElement A;
+    for (std::size_t j = 0; j < Cout.size(); ++j) {
+        A += Cout[j].getValue();
+    }
+    A += params->get_h1() * (Vout + fee);
+    A *= x_m;
+
+    // B is computed via multiscalar multiplication
+    std::vector<GroupElement> B_points;
+    std::vector<Scalar> B_scalars;
+    B_points.emplace_back(params->get_h1());
+    B_scalars.emplace_back(Vin*x_m + zV);
+    B_points.emplace_back(params->get_h0());
+    B_scalars.emplace_back(zR);
 
     NthPower x_k(x);
     std::vector<Scalar> x_ks;
@@ -246,18 +255,18 @@ bool LelantusVerifier::verify_schnorrproof(
         x_k.go_next();
     }
 
-    GroupElement Comm;
     for (std::size_t t = 0; t < proof.sigma_proofs.size(); ++t)
     {
-        GroupElement Comm_t;
         const std::vector<GroupElement>& Qk = proof.sigma_proofs[t].Qk;
         for (std::size_t k = 0; k < Qk.size(); ++k)
         {
-            Comm_t += (Qk[k]) * x_ks[k];
+            B_points.emplace_back(Qk[k]);
+            B_scalars.emplace_back(x_ks[k]);
         }
-        Comm += Comm_t;
     }
-    B += Comm;
+
+    GroupElement B = secp_primitives::MultiExponent(B_points, B_scalars).get_multiple();
+
     SchnorrVerifier schnorrVerifier(params->get_g(), params->get_h0(), version >= LELANTUS_TX_VERSION_4_5);
     const SchnorrProof& schnorrProof = proof.schnorrProof;
     GroupElement Y = A + B * (Scalar(uint64_t(1)).negate());


### PR DESCRIPTION
Updates balance proof verification to use multiscalar multiplication operations where applicable.

Review requested.