### PR TITLE
Improved batch verification for legacy one-of-many proofs

### DIFF
--- a/src/sigma/sigma_primitives.h
+++ b/src/sigma/sigma_primitives.h
@@ -35,9 +35,9 @@ public:
 
     static GroupElement commit(const GroupElement& g, const Exponent m, const GroupElement h, const Exponent r);
 
-    static void convert_to_sigma(uint64_t num, uint64_t n, uint64_t m, std::vector<Exponent>& out);
+    static void convert_to_sigma(std::size_t num, std::size_t n, std::size_t m, std::vector<Exponent>& out);
 
-    static std::vector<uint64_t> convert_to_nal(uint64_t num, uint64_t n, uint64_t m);
+    static std::vector<std::size_t> convert_to_nal(std::size_t num, std::size_t n, std::size_t m);
 
     static void generate_challenge(const std::vector<GroupElement>& group_elements,
                                    Exponent& result_out);

--- a/src/sigma/sigma_primitives.hpp
+++ b/src/sigma/sigma_primitives.hpp
@@ -23,18 +23,18 @@ GroupElement SigmaPrimitives<Exponent, GroupElement>::commit(
 
 template<class Exponent, class GroupElement>
 void SigmaPrimitives<Exponent, GroupElement>::convert_to_sigma(
-        uint64_t num,
-        uint64_t n,
-        uint64_t m,
+        std::size_t num,
+        std::size_t n,
+        std::size_t m,
         std::vector<Exponent>& out) {
-    uint64_t rem;
-    uint64_t j = 0;
+    std::size_t rem;
+    std::size_t j = 0;
 
     for (j = 0; j < m; ++j)
     {
         rem = num % n;
         num /= n;
-        for (uint64_t i = 0; i < n; ++i) {
+        for (std::size_t i = 0; i < n; ++i) {
             if(i == rem)
                 out.push_back(Exponent(uint64_t(1)));
             else
@@ -44,19 +44,16 @@ void SigmaPrimitives<Exponent, GroupElement>::convert_to_sigma(
 }
 
 template<class Exponent, class GroupElement>
-std::vector<uint64_t> SigmaPrimitives<Exponent, GroupElement>::convert_to_nal(
-        uint64_t num,
-        uint64_t n,
-        uint64_t m) {
-    std::vector<uint64_t> result;
-    uint64_t rem;
-    uint64_t j = 0;
+std::vector<std::size_t> SigmaPrimitives<Exponent, GroupElement>::convert_to_nal(
+        std::size_t num,
+        std::size_t n,
+        std::size_t m) {
+    std::vector<std::size_t> result;
+    result.reserve(m);
     while (num != 0)
     {
-        rem = num % n;
+        result.emplace_back(num % n);
         num /= n;
-        result.push_back(rem);
-        j++;
     }
     result.resize(m);
     return result;

--- a/src/sigma/sigmaplus_prover.h
+++ b/src/sigma/sigmaplus_prover.h
@@ -13,7 +13,7 @@ class SigmaPlusProver{
 
 public:
     SigmaPlusProver(const GroupElement& g,
-                    const std::vector<GroupElement>& h_gens, int n, int m);
+                    const std::vector<GroupElement>& h_gens, std::size_t n, std::size_t m);
     void proof(const std::vector<GroupElement>& commits,
                std::size_t l,
                const Exponent& r,
@@ -23,8 +23,8 @@ public:
 private:
     GroupElement g_;
     std::vector<GroupElement> h_;
-    int n_;
-    int m_;
+    std::size_t n_;
+    std::size_t m_;
 };
 
 } // namespace sigma

--- a/src/sigma/sigmaplus_prover.hpp
+++ b/src/sigma/sigmaplus_prover.hpp
@@ -84,9 +84,9 @@ void SigmaPlusProver<Exponent, GroupElement>::proof(
         std::vector<std::vector<Exponent>> partial_p_s;
 
         // Pre-calculate product parts and calculate p_s(x) at the same time, put the latter into p_i_sum
-        for (std::size_t j = m_; j > 0; j--) {
+        for (std::ptrdiff_t j = m_ - 1; j >= 0; j--) {
             partial_p_s.push_back(p_i_sum);
-            SigmaPrimitives<Exponent, GroupElement>::new_factor(sigma[(j - 1) * n_ + I[j - 1]], a[(j - 1) * n_ + I[j - 1]], p_i_sum);
+            SigmaPrimitives<Exponent, GroupElement>::new_factor(sigma[j*n_ + I[j]], a[j*n_ + I[j]], p_i_sum);
         }
 
         for (std::size_t j = 0; j < m_; j++) {

--- a/src/sigma/sigmaplus_verifier.h
+++ b/src/sigma/sigmaplus_verifier.h
@@ -30,7 +30,6 @@ public:
 
     bool membership_checks(const SigmaPlusProof<Exponent, GroupElement>& proof) const;
     bool compute_fs(const SigmaPlusProof<Exponent, GroupElement>& proof, const Exponent& x, std::vector<Exponent>& f_) const;
-    bool abcd_checks(const SigmaPlusProof<Exponent, GroupElement>& proof, const Exponent& x, const std::vector<Exponent>& f_) const;
 
     void compute_fis(int j, const std::vector<Exponent>& f, std::vector<Exponent>& f_i_) const;
     void compute_fis(const Exponent& f_i, int j, const std::vector<Exponent>& f, typename std::vector<Exponent>::iterator& ptr, typename std::vector<Exponent>::iterator end_ptr) const;

--- a/src/sigma/sigmaplus_verifier.h
+++ b/src/sigma/sigmaplus_verifier.h
@@ -11,11 +11,16 @@ class SigmaPlusVerifier{
 public:
     SigmaPlusVerifier(const GroupElement& g,
                       const std::vector<GroupElement>& h_gens,
-                      int n, int m_);
+                      std::size_t n, std::size_t m_);
 
     bool verify(const std::vector<GroupElement>& commits,
                 const SigmaPlusProof<Exponent, GroupElement>& proof,
                 bool fPadding) const;
+
+    bool verify(const std::vector<GroupElement>& commits,
+                const SigmaPlusProof<Exponent, GroupElement>& proof,
+                bool fPadding,
+                std::size_t setSize) const;
 
     bool batch_verify(const std::vector<GroupElement>& commits,
                       const std::vector<Exponent>& serials,
@@ -43,8 +48,8 @@ public:
 private:
     GroupElement g_;
     std::vector<GroupElement> h_;
-    int n;
-    int m;
+    std::size_t n;
+    std::size_t m;
 };
 
 } // namespace sigma

--- a/src/sigma/sigmaplus_verifier.hpp
+++ b/src/sigma/sigmaplus_verifier.hpp
@@ -99,12 +99,12 @@ bool SigmaPlusVerifier<Exponent, GroupElement>::batch_verify(
     std::vector<Scalar> commit_scalars; // associated to commitment list
     h_scalars.reserve(n * m);
     h_scalars.resize(n * m);
-    for (size_t i = 0; i < n * m; i++) {
+    for (std::size_t i = 0; i < n * m; i++) {
         h_scalars[i] = Scalar(uint64_t(0));
     }
     commit_scalars.reserve(commits.size());
     commit_scalars.resize(commits.size());
-    for (size_t i = 0; i < commits.size(); i++) {
+    for (std::size_t i = 0; i < commits.size(); i++) {
         commit_scalars[i] = Scalar(uint64_t(0));
     }
 
@@ -174,8 +174,8 @@ bool SigmaPlusVerifier<Exponent, GroupElement>::batch_verify(
 
         Scalar f_i(uint64_t(1));
         Scalar e;
-        size_t size = setSizes[t];
-        size_t start = commits.size() - size;
+        std::size_t size = setSizes[t];
+        std::size_t start = commits.size() - size;
 
         std::vector<Scalar>::iterator ptr = commit_scalars.begin() + start;
         compute_batch_fis(f_i, m, f_, w3, e, ptr, ptr, ptr + size - 1);
@@ -183,9 +183,9 @@ bool SigmaPlusVerifier<Exponent, GroupElement>::batch_verify(
         if(fPadding[t]) {
             Scalar pow(uint64_t(1));
             std::vector <Scalar> f_part_product;
-            for (std::size_t j = m; j > 0; j--) {
+            for (std::ptrdiff_t j = m - 1; j >= 0; j--) {
                 f_part_product.push_back(pow);
-                pow *= f_[(j - 1) * n + I_[size - 1][j - 1]];
+                pow *= f_[j*n + I_[size - 1][j]];
             }
 
             NthPower<Exponent> xj(x);

--- a/src/sigma/sigmaplus_verifier.hpp
+++ b/src/sigma/sigmaplus_verifier.hpp
@@ -177,12 +177,12 @@ bool SigmaPlusVerifier<Exponent, GroupElement>::batch_verify(
         size_t size = setSizes[t];
         size_t start = commits.size() - size;
 
-        vector<Scalar>::iterator ptr = commit_scalars.begin() + start;
+        std::vector<Scalar>::iterator ptr = commit_scalars.begin() + start;
         compute_batch_fis(f_i, m, f_, w3, e, ptr, ptr, ptr + size - 1);
 
         if(fPadding[t]) {
             Scalar pow(uint64_t(1));
-            vector <Scalar> f_part_product;
+            std::vector <Scalar> f_part_product;
             for (std::size_t j = m; j > 0; j--) {
                 f_part_product.push_back(pow);
                 pow *= f_[(j - 1) * n + I_[size - 1][j - 1]];

--- a/src/sigma/test/protocol_tests.cpp
+++ b/src/sigma/test/protocol_tests.cpp
@@ -11,16 +11,16 @@ BOOST_FIXTURE_TEST_SUITE(sigma_protocol_tests, ZerocoinTestingSetup200)
 BOOST_AUTO_TEST_CASE(one_out_of_n)
 {
     auto params = sigma::Params::get_default();
-    int N = 16384;
-    int n = params->get_n();
-    int m = params->get_m();
-    int index = 0;
+    std::size_t N = 16384;
+    std::size_t n = params->get_n();
+    std::size_t m = params->get_m();
+    std::size_t index = 0;
 
     secp_primitives::GroupElement g;
     g.randomize();
     std::vector<secp_primitives::GroupElement> h_gens;
     h_gens.resize(n * m);
-    for(int i = 0; i < n * m; ++i ){
+    for (std::size_t i = 0; i < n * m; ++i ){
         h_gens[i].randomize();
     }
     secp_primitives::Scalar r;
@@ -28,15 +28,15 @@ BOOST_AUTO_TEST_CASE(one_out_of_n)
     sigma::SigmaPlusProver<secp_primitives::Scalar,secp_primitives::GroupElement> prover(g,h_gens, n, m);
 
     std::vector<secp_primitives::GroupElement> commits;
-    for(int i = 0; i < N; ++i){
-        if(i == index){
+    for (std::size_t i = 0; i < N; ++i) {
+        if (i == index) {
             secp_primitives::GroupElement c;
             secp_primitives::Scalar zero(uint64_t(0));
             c = sigma::SigmaPrimitives<secp_primitives::Scalar,secp_primitives::GroupElement>::commit(g, zero, h_gens[0], r);
             commits.push_back(c);
 
         }
-        else{
+        else {
             commits.push_back(secp_primitives::GroupElement());
             commits[i].randomize();
         }
@@ -48,6 +48,71 @@ BOOST_AUTO_TEST_CASE(one_out_of_n)
     sigma::SigmaPlusVerifier<secp_primitives::Scalar,secp_primitives::GroupElement> verifier(g, h_gens, n, m);
 
     BOOST_CHECK(verifier.verify(commits, proof, true));
+}
+
+BOOST_AUTO_TEST_CASE(one_out_of_n_batch)
+{
+    auto params = sigma::Params::get_default();
+    const secp_primitives::Scalar zero(uint64_t(0));
+    const std::size_t N = 16000; // n^m == 16384
+    const std::size_t n = params->get_n();
+    const std::size_t m = params->get_m();
+    const std::vector<std::size_t> index = { 0, 1, 2, N - 1 };
+    const std::vector<std::size_t> set_sizes = { N, N - 1, N - 1, 16 };
+    const std::vector<secp_primitives::Scalar> serials = { zero, zero, zero, zero };
+    const std::vector<bool> fPadding = { true, true, true, true };
+
+    // Generators
+    secp_primitives::GroupElement g;
+    g.randomize();
+    std::vector<secp_primitives::GroupElement> h_gens;
+    h_gens.resize(n * m);
+    for (std::size_t i = 0; i < n * m; ++i ){
+        h_gens[i].randomize();
+    }
+    sigma::SigmaPlusProver<secp_primitives::Scalar,secp_primitives::GroupElement> prover(g, h_gens, n, m);
+
+    std::vector<secp_primitives::GroupElement> commits;
+
+    // All commitments
+    for (std::size_t i = 0; i < N; ++i) {
+        commits.push_back(secp_primitives::GroupElement());
+        commits[i].randomize();
+    }
+
+    // Known commitments
+    std::vector<Scalar> r;
+    r.resize(index.size());
+    for (std::size_t i = 0; i < index.size(); i++) {
+        r[i].randomize();
+        commits[index[i]] = h_gens[0] * r[i];
+    }
+
+    // Build the proofs
+    std::vector<sigma::SigmaPlusProof<secp_primitives::Scalar,secp_primitives::GroupElement>> proofs;
+    proofs.reserve(index.size());
+    sigma::SigmaPlusVerifier<secp_primitives::Scalar,secp_primitives::GroupElement> verifier(g, h_gens, n, m);
+    for (std::size_t i = 0; i < index.size(); i++) {
+        sigma::SigmaPlusProof<secp_primitives::Scalar,secp_primitives::GroupElement> proof(n, m);
+        std::vector<secp_primitives::GroupElement> commits_(commits.begin() + N - set_sizes[i], commits.end());
+
+        // Check commitment validity and prove
+        BOOST_CHECK(h_gens[0] * r[i] == commits[index[i]]);
+        BOOST_CHECK(h_gens[0] * r[i] == commits_[index[i] - (N - set_sizes[i])]);
+        prover.proof(commits_, index[i] - (N - set_sizes[i]), r[i], true, proof);
+        proofs.emplace_back(proof);
+
+        // Test individual verification
+        BOOST_CHECK(verifier.verify(commits_, proof, true));
+        BOOST_CHECK(verifier.verify(commits, proof, true, set_sizes[i]));
+    }
+
+    // Test batch verification
+    BOOST_CHECK(verifier.batch_verify(commits, serials, fPadding, set_sizes, proofs));
+
+    // Invalidate the batch
+    proofs[0] = proofs[1];
+    BOOST_CHECK(!verifier.batch_verify(commits, serials, fPadding, set_sizes, proofs));
 }
 
 BOOST_AUTO_TEST_CASE(one_out_of_n_padding)


### PR DESCRIPTION
Improves batch verification for legacy one-of-many proofs by reducing to a single multiscalar multiplication operation. Adds additional sanity checks for the verifier routine. Removes redundant code while retaining backwards compatibility.

Review requested.