### PR TITLE
Batching fail fix

### DIFF
--- a/src/batchproof_container.cpp
+++ b/src/batchproof_container.cpp
@@ -77,7 +77,6 @@ void BatchProofContainer::removeSigma(const sigma::spend_info_container& spendSe
                     if (dataItr->coinSerialNumber == spendSerial.first) {
                         vProofs.erase(dataItr);
                         foundAtSigma = true;
-                        break;
                     }
                 }
             }
@@ -99,7 +98,6 @@ void BatchProofContainer::removeSigma(const sigma::spend_info_container& spendSe
             for (auto dataItr = vProofs->begin(); dataItr != vProofs->end(); dataItr++) {
                 if (dataItr->serialNumber == spendSerial.first) {
                     vProofs->erase(dataItr);
-                    break;
                 }
             }
         }
@@ -121,7 +119,6 @@ void BatchProofContainer::removeLelantus(std::unordered_map<Scalar, int> spentSe
         for (auto dataItr = vProofs->begin(); dataItr != vProofs->end(); dataItr++) {
             if (dataItr->serialNumber == spendSerial.first) {
                 vProofs->erase(dataItr);
-                break;
             }
         }
     }

--- a/src/batchproof_container.cpp
+++ b/src/batchproof_container.cpp
@@ -75,6 +75,7 @@ void BatchProofContainer::removeSigma(const sigma::spend_info_container& spendSe
                 for (auto dataItr = vProofs.begin(); dataItr != vProofs.end(); dataItr++) {
                     if (dataItr->coinSerialNumber == spendSerial.first) {
                         vProofs.erase(dataItr);
+                        break;
                     }
                 }
             }
@@ -110,11 +111,11 @@ void BatchProofContainer::removeLelantus(std::unordered_map<Scalar, int> spentSe
 }
 
 void BatchProofContainer::erase(std::vector<LelantusSigmaProofData>* vProofs, const Scalar& serial) {
-    for (auto dataItr = vProofs->begin(); dataItr != vProofs->end(); dataItr++) {
-        if (dataItr->serialNumber == serial) {
-            vProofs->erase(dataItr);
-        }
-    }
+    vProofs->erase(std::remove_if(vProofs->begin(),
+                                  vProofs->end(),
+                                  [serial](LelantusSigmaProofData& proof){return proof.serialNumber == serial;}),
+                   vProofs->end());
+
 }
 
 void BatchProofContainer::batch_sigma() {

--- a/src/batchproof_container.h
+++ b/src/batchproof_container.h
@@ -12,27 +12,6 @@ class BatchProofContainer {
 public:
     static BatchProofContainer* get_instance();
 
-    void init();
-
-    void finalize();
-
-    void add(sigma::CoinSpend* spend,
-             bool fPadding,
-             int group_id,
-             size_t setSize,
-             bool fStartSigmaBlacklist);
-
-    void add(lelantus::JoinSplit* joinSplit,
-             const std::map<uint32_t, size_t>& setSizes,
-             const Scalar& challenge,
-             bool fStartLelantusBlacklist);
-
-    void removeSigma(const sigma::spend_info_container& spendSerials);
-    void removeLelantus(std::unordered_map<Scalar, int> spentSerials);
-
-    void batch_sigma();
-    void batch_lelantus();
-
     struct SigmaProofData {
         SigmaProofData() : sigmaProof(0, 0), coinSerialNumber(uint64_t(0)), fPadding(0), anonymitySetSize(0) {}
         SigmaProofData(const sigma::SigmaPlusProof<Scalar, GroupElement>& sigmaProof_,
@@ -65,6 +44,28 @@ public:
         Scalar challenge;
         size_t anonymitySetSize;
     };
+
+    void init();
+
+    void finalize();
+
+    void add(sigma::CoinSpend* spend,
+             bool fPadding,
+             int group_id,
+             size_t setSize,
+             bool fStartSigmaBlacklist);
+
+    void add(lelantus::JoinSplit* joinSplit,
+             const std::map<uint32_t, size_t>& setSizes,
+             const Scalar& challenge,
+             bool fStartLelantusBlacklist);
+
+    void removeSigma(const sigma::spend_info_container& spendSerials);
+    void removeLelantus(std::unordered_map<Scalar, int> spentSerials);
+    void erase(std::vector<LelantusSigmaProofData>* vProofs, const Scalar& serial);
+
+    void batch_sigma();
+    void batch_lelantus();
 
 public:
     bool fCollectProofs = 0;

--- a/src/lelantus.cpp
+++ b/src/lelantus.cpp
@@ -498,12 +498,14 @@ bool CheckLelantusJoinSplitTransaction(
     }
 
     BatchProofContainer* batchProofContainer = BatchProofContainer::get_instance();
+    bool useBatching = batchProofContainer->fCollectProofs && !isVerifyDB && !isCheckWallet && lelantusTxInfo && !lelantusTxInfo->fInfoIsComplete;
+
     Scalar challenge;
     // if we are collecting proofs, skip verification and collect proofs
-    passVerify = joinsplit->Verify(anonymity_sets, anonymity_set_hashes, Cout, Vout, txHashForMetadata, challenge, batchProofContainer->fCollectProofs);
+    passVerify = joinsplit->Verify(anonymity_sets, anonymity_set_hashes, Cout, Vout, txHashForMetadata, challenge, useBatching);
 
     // add proofs into container
-    if(batchProofContainer->fCollectProofs) {
+    if(useBatching) {
         std::map<uint32_t, size_t> idAndSizes;
 
         for(auto itr : anonymity_sets)

--- a/src/lelantus.cpp
+++ b/src/lelantus.cpp
@@ -505,7 +505,7 @@ bool CheckLelantusJoinSplitTransaction(
     passVerify = joinsplit->Verify(anonymity_sets, anonymity_set_hashes, Cout, Vout, txHashForMetadata, challenge, useBatching);
 
     // add proofs into container
-    if(useBatching) {
+    if(useBatching && passVerify) {
         std::map<uint32_t, size_t> idAndSizes;
 
         for(auto itr : anonymity_sets)

--- a/src/lelantus.cpp
+++ b/src/lelantus.cpp
@@ -505,7 +505,7 @@ bool CheckLelantusJoinSplitTransaction(
     passVerify = joinsplit->Verify(anonymity_sets, anonymity_set_hashes, Cout, Vout, txHashForMetadata, challenge, useBatching);
 
     // add proofs into container
-    if(useBatching && passVerify) {
+    if(useBatching) {
         std::map<uint32_t, size_t> idAndSizes;
 
         for(auto itr : anonymity_sets)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3189,6 +3189,7 @@ bool static DisconnectTip(CValidationState& state, const CChainParams& chainpara
 
     std::unordered_map<Scalar, int> lelantusSerialsToRemove;
     sigma::spend_info_container sigmaSerialsToRemove;
+    BatchProofContainer::get_instance()->fCollectProofs = false;
 
     for (CTransactionRef tx : block.vtx) {
         CheckTransaction(*tx, state, false, tx->GetHash(), false, pindexDelete->pprev->nHeight,

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3194,7 +3194,6 @@ bool static DisconnectTip(CValidationState& state, const CChainParams& chainpara
     for (CTransactionRef tx : block.vtx) {
         CheckTransaction(*tx, state, false, tx->GetHash(), false, pindexDelete->pprev->nHeight,
             false, false, block.sigmaTxInfo.get(), block.lelantusTxInfo.get());
-
         if(GetBoolArg("-batching", true)) {
             if (tx->IsLelantusJoinSplit()) {
                 const CTxIn &txin = tx->vin[0];
@@ -3214,22 +3213,8 @@ bool static DisconnectTip(CValidationState& state, const CChainParams& chainpara
                     continue;
                 }
 
-                if (joinsplit->isSigmaToLelantus()) {
-                    for (size_t i = 0; i < serials.size(); i++) {
-                        int coinGroupId = ids[i] % (CENT / 1000);
-                        int64_t intDenom = (ids[i] - coinGroupId);
-                        intDenom *= 1000;
-                        sigma::CoinDenomination denomination;
-                        if (!sigma::IntegerToDenomination(intDenom, denomination))
-                            lelantusSerialsToRemove.insert(std::make_pair(serials[i], ids[i]));
-                        else
-                            sigmaSerialsToRemove.insert(std::make_pair(
-                                    serials[i], sigma::CSpendCoinInfo::make(denomination, coinGroupId)));
-                    }
-                } else {
-                    for (size_t i = 0; i < serials.size(); i++) {
-                        lelantusSerialsToRemove.insert(std::make_pair(serials[i], ids[i]));
-                    }
+                for (size_t i = 0; i < serials.size(); i++) {
+                    lelantusSerialsToRemove.insert(std::make_pair(serials[i], ids[i]));
                 }
             } else if (tx->IsSigmaSpend()) {
                 for (const CTxIn &txin : tx->vin) {
@@ -3267,6 +3252,16 @@ bool static DisconnectTip(CValidationState& state, const CChainParams& chainpara
 
 	sigma::DisconnectTipSigma(block, pindexDelete);
     lelantus::DisconnectTipLelantus(block, pindexDelete);
+
+    BatchProofContainer* batchProofContainer = BatchProofContainer::get_instance();
+    if (sigmaSerialsToRemove.size() > 0) {
+        batchProofContainer->removeSigma(sigmaSerialsToRemove);
+    }
+
+    if (lelantusSerialsToRemove.size() > 0) {
+        batchProofContainer->removeLelantus(lelantusSerialsToRemove);
+    }
+
     // Roll back MTP state
     MTPState::GetMTPState()->SetLastBlock(pindexDelete->pprev, chainparams.GetConsensus());
 
@@ -3312,15 +3307,6 @@ bool static DisconnectTip(CValidationState& state, const CChainParams& chainpara
     }
     // Update chainActive and related variables.
     UpdateTip(pindexDelete->pprev, chainparams);
-
-    BatchProofContainer* batchProofContainer = BatchProofContainer::get_instance();
-    if (sigmaSerialsToRemove.size() > 0) {
-        batchProofContainer->removeSigma(sigmaSerialsToRemove);
-    }
-
-    if (lelantusSerialsToRemove.size() > 0) {
-        batchProofContainer->removeLelantus(lelantusSerialsToRemove);
-    }
 
 #ifdef ENABLE_WALLET
     // update mint/spend wallet

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3189,7 +3189,6 @@ bool static DisconnectTip(CValidationState& state, const CChainParams& chainpara
 
     std::unordered_map<Scalar, int> lelantusSerialsToRemove;
     sigma::spend_info_container sigmaSerialsToRemove;
-    BatchProofContainer::get_instance()->fCollectProofs = false;
 
     for (CTransactionRef tx : block.vtx) {
         CheckTransaction(*tx, state, false, tx->GetHash(), false, pindexDelete->pprev->nHeight,


### PR DESCRIPTION
The PR fixes batch verification failing issue in case of reindex/sync, The fail was happening when you had reorgs in chain, During DisconnectBlock it should remove proofs from container, but it was not removed and verification failed as proof from wrong chain is not valid after reorg. 
Removing was not being done correctly as third element in key, was being set as true, https://github.com/firoorg/firo/pull/1048/commits/7c9550af534691ee8c1e695400bb562bd87b02bc#diff-755c76a1b8be7607bc371ca3a5b4ea39a91bf46946913fd5fd67b4d06b808d7dR97 , 
but actually it should be false, but now in removeLelantus() function is being removed also sigmaToLelantus proofs.