### PR TITLE
Switch to C++17 compilation standard

### DIFF
--- a/build-aux/m4/ax_cxx_compile_stdcxx.m4
+++ b/build-aux/m4/ax_cxx_compile_stdcxx.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-#   http://www.gnu.org/software/autoconf-archive/ax_cxx_compile_stdcxx.html
+#  https://www.gnu.org/software/autoconf-archive/ax_cxx_compile_stdcxx.html
 # ===========================================================================
 #
 # SYNOPSIS
@@ -33,21 +33,23 @@
 #   Copyright (c) 2014, 2015 Google Inc.; contributed by Alexey Sokolov <sokolov@google.com>
 #   Copyright (c) 2015 Paul Norman <penorman@mac.com>
 #   Copyright (c) 2015 Moritz Klammler <moritz@klammler.eu>
+#   Copyright (c) 2016, 2018 Krzesimir Nowak <qdlacz@gmail.com>
+#   Copyright (c) 2019 Enji Cooper <yaneurabeya@gmail.com>
 #
 #   Copying and distribution of this file, with or without modification, are
 #   permitted in any medium without royalty provided the copyright notice
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 4
+#serial 11
 
 dnl  This macro is based on the code from the AX_CXX_COMPILE_STDCXX_11 macro
 dnl  (serial version number 13).
 
 AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
-  m4_if([$1], [11], [],
-        [$1], [14], [],
-        [$1], [17], [m4_fatal([support for C++17 not yet implemented in AX_CXX_COMPILE_STDCXX])],
+  m4_if([$1], [11], [ax_cxx_compile_alternatives="11 0x"],
+        [$1], [14], [ax_cxx_compile_alternatives="14 1y"],
+        [$1], [17], [ax_cxx_compile_alternatives="17 1z"],
         [m4_fatal([invalid first argument `$1' to AX_CXX_COMPILE_STDCXX])])dnl
   m4_if([$2], [], [],
         [$2], [ext], [],
@@ -57,26 +59,13 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
         [$3], [mandatory], [ax_cxx_compile_cxx$1_required=true],
         [$3], [optional], [ax_cxx_compile_cxx$1_required=false],
         [m4_fatal([invalid third argument `$3' to AX_CXX_COMPILE_STDCXX])])
-  m4_if([$4], [], [ax_cxx_compile_cxx$1_try_default=true],
-        [$4], [default], [ax_cxx_compile_cxx$1_try_default=true],
-        [$4], [nodefault], [ax_cxx_compile_cxx$1_try_default=false],
-        [m4_fatal([invalid fourth argument `$4' to AX_CXX_COMPILE_STDCXX])])
   AC_LANG_PUSH([C++])dnl
   ac_success=no
 
-  m4_if([$4], [nodefault], [], [dnl
-  AC_CACHE_CHECK(whether $CXX supports C++$1 features by default,
-  ax_cv_cxx_compile_cxx$1,
-  [AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
-    [ax_cv_cxx_compile_cxx$1=yes],
-    [ax_cv_cxx_compile_cxx$1=no])])
-  if test x$ax_cv_cxx_compile_cxx$1 = xyes; then
-    ac_success=yes
-  fi])
-
   m4_if([$2], [noext], [], [dnl
   if test x$ac_success = xno; then
-    for switch in -std=gnu++$1 -std=gnu++0x; do
+    for alternative in ${ax_cxx_compile_alternatives}; do
+      switch="-std=gnu++${alternative}"
       cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_$switch])
       AC_CACHE_CHECK(whether $CXX supports C++$1 features with $switch,
                      $cachevar,
@@ -102,22 +91,27 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
     dnl HP's aCC needs +std=c++11 according to:
     dnl http://h21007.www2.hp.com/portal/download/files/unprot/aCxx/PDF_Release_Notes/769149-001.pdf
     dnl Cray's crayCC needs "-h std=c++11"
-    for switch in -std=c++$1 -std=c++0x +std=c++$1 "-h std=c++$1"; do
-      cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_$switch])
-      AC_CACHE_CHECK(whether $CXX supports C++$1 features with $switch,
-                     $cachevar,
-        [ac_save_CXX="$CXX"
-         CXX="$CXX $switch"
-         AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
-          [eval $cachevar=yes],
-          [eval $cachevar=no])
-         CXX="$ac_save_CXX"])
-      if eval test x\$$cachevar = xyes; then
-        CXX="$CXX $switch"
-        if test -n "$CXXCPP" ; then
-          CXXCPP="$CXXCPP $switch"
+    for alternative in ${ax_cxx_compile_alternatives}; do
+      for switch in -std=c++${alternative} +std=c++${alternative} "-h std=c++${alternative}"; do
+        cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_$switch])
+        AC_CACHE_CHECK(whether $CXX supports C++$1 features with $switch,
+                       $cachevar,
+          [ac_save_CXX="$CXX"
+           CXX="$CXX $switch"
+           AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
+            [eval $cachevar=yes],
+            [eval $cachevar=no])
+           CXX="$ac_save_CXX"])
+        if eval test x\$$cachevar = xyes; then
+          CXX="$CXX $switch"
+          if test -n "$CXXCPP" ; then
+            CXXCPP="$CXXCPP $switch"
+          fi
+          ac_success=yes
+          break
         fi
-        ac_success=yes
+      done
+      if test x$ac_success = xyes; then
         break
       fi
     done
@@ -154,6 +148,11 @@ m4_define([_AX_CXX_COMPILE_STDCXX_testbody_14],
   _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
 )
 
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_17],
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_17
+)
 
 dnl  Tests for new features in C++11
 
@@ -191,11 +190,13 @@ namespace cxx11
 
     struct Base
     {
+      virtual ~Base() {}
       virtual void f() {}
     };
 
     struct Derived : public Base
     {
+      virtual ~Derived() override {}
       virtual void f() override {}
     };
 
@@ -524,7 +525,7 @@ namespace cxx14
 
   }
 
-  namespace test_digit_seperators
+  namespace test_digit_separators
   {
 
     constexpr auto ten_million = 100'000'000;
@@ -564,5 +565,387 @@ namespace cxx14
 }  // namespace cxx14
 
 #endif  // __cplusplus >= 201402L
+
+]])
+
+
+dnl  Tests for new features in C++17
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_17], [[
+
+// If the compiler admits that it is not ready for C++17, why torture it?
+// Hopefully, this will speed up the test.
+
+#ifndef __cplusplus
+
+#error "This is not a C++ compiler"
+
+#elif __cplusplus < 201703L
+
+#error "This is not a C++17 compiler"
+
+#else
+
+#include <initializer_list>
+#include <utility>
+#include <type_traits>
+
+namespace cxx17
+{
+
+  namespace test_constexpr_lambdas
+  {
+
+    constexpr int foo = [](){return 42;}();
+
+  }
+
+  namespace test::nested_namespace::definitions
+  {
+
+  }
+
+  namespace test_fold_expression
+  {
+
+    template<typename... Args>
+    int multiply(Args... args)
+    {
+      return (args * ... * 1);
+    }
+
+    template<typename... Args>
+    bool all(Args... args)
+    {
+      return (args && ...);
+    }
+
+  }
+
+  namespace test_extended_static_assert
+  {
+
+    static_assert (true);
+
+  }
+
+  namespace test_auto_brace_init_list
+  {
+
+    auto foo = {5};
+    auto bar {5};
+
+    static_assert(std::is_same<std::initializer_list<int>, decltype(foo)>::value);
+    static_assert(std::is_same<int, decltype(bar)>::value);
+  }
+
+  namespace test_typename_in_template_template_parameter
+  {
+
+    template<template<typename> typename X> struct D;
+
+  }
+
+  namespace test_fallthrough_nodiscard_maybe_unused_attributes
+  {
+
+    int f1()
+    {
+      return 42;
+    }
+
+    [[nodiscard]] int f2()
+    {
+      [[maybe_unused]] auto unused = f1();
+
+      switch (f1())
+      {
+      case 17:
+        f1();
+        [[fallthrough]];
+      case 42:
+        f1();
+      }
+      return f1();
+    }
+
+  }
+
+  namespace test_extended_aggregate_initialization
+  {
+
+    struct base1
+    {
+      int b1, b2 = 42;
+    };
+
+    struct base2
+    {
+      base2() {
+        b3 = 42;
+      }
+      int b3;
+    };
+
+    struct derived : base1, base2
+    {
+        int d;
+    };
+
+    derived d1 {{1, 2}, {}, 4};  // full initialization
+    derived d2 {{}, {}, 4};      // value-initialized bases
+
+  }
+
+  namespace test_general_range_based_for_loop
+  {
+
+    struct iter
+    {
+      int i;
+
+      int& operator* ()
+      {
+        return i;
+      }
+
+      const int& operator* () const
+      {
+        return i;
+      }
+
+      iter& operator++()
+      {
+        ++i;
+        return *this;
+      }
+    };
+
+    struct sentinel
+    {
+      int i;
+    };
+
+    bool operator== (const iter& i, const sentinel& s)
+    {
+      return i.i == s.i;
+    }
+
+    bool operator!= (const iter& i, const sentinel& s)
+    {
+      return !(i == s);
+    }
+
+    struct range
+    {
+      iter begin() const
+      {
+        return {0};
+      }
+
+      sentinel end() const
+      {
+        return {5};
+      }
+    };
+
+    void f()
+    {
+      range r {};
+
+      for (auto i : r)
+      {
+        [[maybe_unused]] auto v = i;
+      }
+    }
+
+  }
+
+  namespace test_lambda_capture_asterisk_this_by_value
+  {
+
+    struct t
+    {
+      int i;
+      int foo()
+      {
+        return [*this]()
+        {
+          return i;
+        }();
+      }
+    };
+
+  }
+
+  namespace test_enum_class_construction
+  {
+
+    enum class byte : unsigned char
+    {};
+
+    byte foo {42};
+
+  }
+
+  namespace test_constexpr_if
+  {
+
+    template <bool cond>
+    int f ()
+    {
+      if constexpr(cond)
+      {
+        return 13;
+      }
+      else
+      {
+        return 42;
+      }
+    }
+
+  }
+
+  namespace test_selection_statement_with_initializer
+  {
+
+    int f()
+    {
+      return 13;
+    }
+
+    int f2()
+    {
+      if (auto i = f(); i > 0)
+      {
+        return 3;
+      }
+
+      switch (auto i = f(); i + 4)
+      {
+      case 17:
+        return 2;
+
+      default:
+        return 1;
+      }
+    }
+
+  }
+
+  namespace test_template_argument_deduction_for_class_templates
+  {
+
+    template <typename T1, typename T2>
+    struct pair
+    {
+      pair (T1 p1, T2 p2)
+        : m1 {p1},
+          m2 {p2}
+      {}
+
+      T1 m1;
+      T2 m2;
+    };
+
+    void f()
+    {
+      [[maybe_unused]] auto p = pair{13, 42u};
+    }
+
+  }
+
+  namespace test_non_type_auto_template_parameters
+  {
+
+    template <auto n>
+    struct B
+    {};
+
+    B<5> b1;
+    B<'a'> b2;
+
+  }
+
+  namespace test_structured_bindings
+  {
+
+    int arr[2] = { 1, 2 };
+    std::pair<int, int> pr = { 1, 2 };
+
+    auto f1() -> int(&)[2]
+    {
+      return arr;
+    }
+
+    auto f2() -> std::pair<int, int>&
+    {
+      return pr;
+    }
+
+    struct S
+    {
+      int x1 : 2;
+      volatile double y1;
+    };
+
+    S f3()
+    {
+      return {};
+    }
+
+    auto [ x1, y1 ] = f1();
+    auto& [ xr1, yr1 ] = f1();
+    auto [ x2, y2 ] = f2();
+    auto& [ xr2, yr2 ] = f2();
+    const auto [ x3, y3 ] = f3();
+
+  }
+
+  namespace test_exception_spec_type_system
+  {
+
+    struct Good {};
+    struct Bad {};
+
+    void g1() noexcept;
+    void g2();
+
+    template<typename T>
+    Bad
+    f(T*, T*);
+
+    template<typename T1, typename T2>
+    Good
+    f(T1*, T2*);
+
+    static_assert (std::is_same_v<Good, decltype(f(g1, g2))>);
+
+  }
+
+  namespace test_inline_variables
+  {
+
+    template<class T> void f(T)
+    {}
+
+    template<class T> inline T g(T)
+    {
+      return T{};
+    }
+
+    template<> inline void f<>(int)
+    {}
+
+    template<> int g<>(int)
+    {
+      return 5;
+    }
+
+  }
+
+}  // namespace cxx17
+
+#endif  // __cplusplus < 201703L
 
 ]])

--- a/configure.ac
+++ b/configure.ac
@@ -54,8 +54,8 @@ case $host in
      lt_cv_deplibs_check_method="pass_all"
   ;;
 esac
-dnl Require C++14 compiler (no GNU extensions)
-AX_CXX_COMPILE_STDCXX([14], [noext], [mandatory], [nodefault])
+dnl Require C++17 compiler (no GNU extensions)
+AX_CXX_COMPILE_STDCXX([17], [noext], [mandatory], [nodefault])
 dnl Check if -latomic is required for <std::atomic>
 CHECK_ATOMIC
 

--- a/src/batchproof_container.cpp
+++ b/src/batchproof_container.cpp
@@ -140,11 +140,11 @@ void BatchProofContainer::batch_sigma() {
         size_t m = itr.second.size();
         std::vector<Scalar> serials;
         serials.reserve(m);
-        vector<bool> fPadding;
+        std::vector<bool> fPadding;
         fPadding.reserve(m);
         std::vector<size_t> setSizes;
         setSizes.reserve(m);
-        vector<sigma::SigmaPlusProof<Scalar, GroupElement>> proofs;
+        std::vector<sigma::SigmaPlusProof<Scalar, GroupElement>> proofs;
         proofs.reserve(m);
 
         for (auto& proofData : itr.second) {

--- a/src/bip47/bip47utils.cpp
+++ b/src/bip47/bip47utils.cpp
@@ -11,8 +11,6 @@
 #include "wallet/wallet.h"
 #include "wallet/walletexcept.h"
 
-using namespace std;
-
 namespace bip47 {
 namespace utils {
 
@@ -101,8 +99,8 @@ Bytes GetMaskedPcode(CTransactionRef const & tx)
 bool GetScriptSigPubkey(CTxIn const & txin, CPubKey& pubkey)
 {
     CScript::const_iterator pc = txin.scriptSig.begin();
-    vector<unsigned char> chunk0data;
-    vector<unsigned char> chunk1data;
+    std::vector<unsigned char> chunk0data;
+    std::vector<unsigned char> chunk1data;
 
     opcodetype opcode0, opcode1;
     if (!txin.scriptSig.GetOp(pc, opcode0, chunk0data))
@@ -176,7 +174,7 @@ GroupElement GeFromPubkey(CPubKey const & pubKey)
 
 CPubKey PubkeyFromGe(GroupElement const & ge)
 {
-    vector<unsigned char> pubkey_vch = ge.getvch();
+    std::vector<unsigned char> pubkey_vch = ge.getvch();
     pubkey_vch.pop_back();
     unsigned char header_char = pubkey_vch[pubkey_vch.size()-1] == 0 ? 0x02 : 0x03;
     pubkey_vch.pop_back();

--- a/src/bip47/bip47utils.h
+++ b/src/bip47/bip47utils.h
@@ -15,6 +15,8 @@ class CTransaction;
 typedef class std::shared_ptr<const CTransaction> CTransactionRef;
 class CWallet;
 
+using secp_primitives::GroupElement;
+
 namespace bip47 {
 
 class CPaymentCode;

--- a/src/bip47/paymentchannel.cpp
+++ b/src/bip47/paymentchannel.cpp
@@ -28,7 +28,7 @@ CBitcoinAddress generate(CKey const & privkey, CPubKey const & sharedSecretPubke
     if (privkeyOut) {
         Scalar a = Scalar(privkey.begin()) + Scalar(spHash.data());
 
-        vector<unsigned char> ppkeybytes = ParseHex(a.GetHex());
+        std::vector<unsigned char> ppkeybytes = ParseHex(a.GetHex());
         privkeyOut->Set(ppkeybytes.begin(), ppkeybytes.end(), true);
         assert(privkeyOut->IsValid());
     }

--- a/src/bitcoin_bignum/bignum.h
+++ b/src/bitcoin_bignum/bignum.h
@@ -707,8 +707,8 @@ public:
         return ret;
     }
 
-    vector<unsigned char> ToBytes() const {
-        vector<unsigned char> result(BN_num_bytes(bn));
+    std::vector<unsigned char> ToBytes() const {
+        std::vector<unsigned char> result(BN_num_bytes(bn));
         BN_bn2bin(bn, result.data());
         return result;
     }

--- a/src/bitcoin_bignum/serialize.h
+++ b/src/bitcoin_bignum/serialize.h
@@ -26,7 +26,6 @@
 #include "prevector.h"
 #include <memory>
 #include "definition.h"
-using namespace std;
 
 
 static const unsigned int MAX_SIZE = 0x02000000;

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -238,7 +238,6 @@ protected:
 class CBLSSecretKey : public CBLSWrapper<bls::PrivateKey, BLS_CURVE_SECKEY_SIZE, CBLSSecretKey>
 {
 public:
-    using CBLSWrapper::operator=;
     using CBLSWrapper::operator==;
     using CBLSWrapper::operator!=;
 

--- a/src/chain.h
+++ b/src/chain.h
@@ -226,31 +226,31 @@ public:
 
     //! Public coin values of mints in this block, ordered by serialized value of public coin
     //! Maps <denomination,id> to vector of public coins
-    map<pair<int,int>, vector<CBigNum>> mintedPubCoins;
+    std::map<std::pair<int,int>, std::vector<CBigNum>> mintedPubCoins;
 
     //! Accumulator updates. Contains only changes made by mints in this block
     //! Maps <denomination, id> to <accumulator value (CBigNum), number of such mints in this block>
-    map<pair<int,int>, pair<CBigNum,int>> accumulatorChanges;
+    std::map<std::pair<int,int>, std::pair<CBigNum,int>> accumulatorChanges;
 
     //! Values of coin serials spent in this block
-	set<CBigNum> spentSerials;
+	std::set<CBigNum> spentSerials;
 
 /////////////////////// Sigma index entries. ////////////////////////////////////////////
 
     //! Public coin values of mints in this block, ordered by serialized value of public coin
     //! Maps <denomination,id> to vector of public coins
-    std::map<pair<sigma::CoinDenomination, int>, vector<sigma::PublicCoin>> sigmaMintedPubCoins;
+    std::map<std::pair<sigma::CoinDenomination, int>, std::vector<sigma::PublicCoin>> sigmaMintedPubCoins;
     //! Map id to <public coin, tag>
-    std::map<int, vector<std::pair<lelantus::PublicCoin, uint256>>>  lelantusMintedPubCoins;
+    std::map<int, std::vector<std::pair<lelantus::PublicCoin, uint256>>>  lelantusMintedPubCoins;
     //! Map id to <hash of the set>
-    std::map<int, vector<unsigned char>> anonymitySetHash;
+    std::map<int, std::vector<unsigned char>> anonymitySetHash;
 
     //! Values of coin serials spent in this block
     sigma::spend_info_container sigmaSpentSerials;
     std::unordered_map<Scalar, int> lelantusSpentSerials;
 
     //! list of disabling sporks active at this block height
-    //! map {feature name} -> {block number when feature is re-enabled again, parameter}
+    //! std::map {feature name} -> {block number when feature is re-enabled again, parameter}
     ActiveSporkMap activeDisablingSporks;
 
     void SetNull()
@@ -496,7 +496,7 @@ public:
                 && nHeight >= params.nLelantusStartBlock
                 && nVersion >= LELANTUS_PROTOCOL_ENABLEMENT_VERSION) {
             if(nVersion == LELANTUS_PROTOCOL_ENABLEMENT_VERSION) {
-                std::map<int, vector<lelantus::PublicCoin>>  lelantusPubCoins;
+                std::map<int, std::vector<lelantus::PublicCoin>>  lelantusPubCoins;
                 READWRITE(lelantusPubCoins);
                 for(auto& itr : lelantusPubCoins) {
                     if(!itr.second.empty()) {

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -21,6 +21,7 @@
 #include "chainparamsseeds.h"
 #include "arith_uint256.h"
 
+using namespace secp_primitives;
 
 static CBlock CreateGenesisBlock(const char *pszTimestamp, const CScript &genesisOutputScript, uint32_t nTime, uint32_t nNonce,
         uint32_t nBits, int32_t nVersion, const CAmount &genesisReward,

--- a/src/coin_containers.cpp
+++ b/src/coin_containers.cpp
@@ -6,7 +6,7 @@
 namespace sigma {
 
 std::size_t CScalarHash::operator ()(const Scalar& bn) const noexcept {
-    vector<unsigned char> bnData(bn.memoryRequired());
+    std::vector<unsigned char> bnData(bn.memoryRequired());
     bn.serialize(&bnData[0]);
 
     unsigned char hash[CSHA256::OUTPUT_SIZE];

--- a/src/elysium/createpayload.h
+++ b/src/elysium/createpayload.h
@@ -12,6 +12,9 @@
 
 #include <stdint.h>
 
+using elysium::ECDSASignature;
+using elysium::SigmaStatus;
+
 std::vector<unsigned char> CreatePayload_SimpleSend(uint32_t propertyId, uint64_t amount);
 std::vector<unsigned char> CreatePayload_SimpleMint(uint32_t propertyId, const std::vector<std::pair<uint8_t, elysium::SigmaPublicKey>>& mints);
 std::vector<unsigned char> CreatePayload_SimpleSpend(uint32_t propertyId, uint8_t denomination, uint32_t group,

--- a/src/elysium/rpcrequirements.cpp
+++ b/src/elysium/rpcrequirements.cpp
@@ -162,7 +162,7 @@ void RequireHeightInChain(int blockHeight)
     }
 }
 
-void RequireSigmaStatus(SigmaStatus status)
+void RequireSigmaStatus(elysium::SigmaStatus status)
 {
     if (!elysium::IsSigmaStatusValid(status)) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Sigma status is not valid");

--- a/src/elysium/rpcrequirements.h
+++ b/src/elysium/rpcrequirements.h
@@ -23,7 +23,7 @@ void RequireSaneReferenceAmount(int64_t amount);
 void RequireSaneDExPaymentWindow(const std::string& address, uint32_t propertyId);
 void RequireSaneDExFee(const std::string& address, uint32_t propertyId);
 void RequireHeightInChain(int blockHeight);
-void RequireSigmaStatus(SigmaStatus status);
+void RequireSigmaStatus(elysium::SigmaStatus status);
 
 namespace elysium {
 

--- a/src/elysium/test/build_tx_tests.cpp
+++ b/src/elysium/test/build_tx_tests.cpp
@@ -30,6 +30,8 @@
 
 #include <inttypes.h>
 
+using namespace std;
+
 namespace elysium {
 
 BOOST_FIXTURE_TEST_SUITE(elysium_build_tx_tests, ZerocoinTestingSetup200)

--- a/src/elysium/test/elysium_handler_tx.cpp
+++ b/src/elysium/test/elysium_handler_tx.cpp
@@ -135,7 +135,7 @@ BOOST_AUTO_TEST_CASE(elysium_parse_sigma_tx_with_non_spend)
     std::vector<sigma::PrivateCoin> privCoins(10, sigma::PrivateCoin(sigmaParams, denomination));
 
     CWalletTx wtx;
-    vector<CHDMint> vDMints;
+    std::vector<CHDMint> vDMints;
     auto vecSend = CWallet::CreateSigmaMintRecipients(privCoins, vDMints);
     stringError = pwalletMain->MintAndStoreSigma(vecSend, privCoins, vDMints, wtx);
 
@@ -182,7 +182,7 @@ BOOST_AUTO_TEST_CASE(elysium_parse_sigma_tx_with_spend)
     std::vector<sigma::PrivateCoin> privCoins(10, sigma::PrivateCoin(sigmaParams, denomination));
 
     CWalletTx wtx;
-    vector<CHDMint> vDMints;
+    std::vector<CHDMint> vDMints;
     auto vecSend = CWallet::CreateSigmaMintRecipients(privCoins, vDMints);
     stringError = pwalletMain->MintAndStoreSigma(vecSend, privCoins, vDMints, wtx);
 

--- a/src/elysium/test/encoding_b_tests.cpp
+++ b/src/elysium/test/encoding_b_tests.cpp
@@ -18,6 +18,8 @@
 
 #include <inttypes.h>
 
+using namespace elysium;
+
 BOOST_FIXTURE_TEST_SUITE(elysium_encoding_b_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(class_b_empty)

--- a/src/elysium/test/encoding_c_tests.cpp
+++ b/src/elysium/test/encoding_c_tests.cpp
@@ -15,6 +15,8 @@
 
 #include <inttypes.h>
 
+using namespace elysium;
+
 // Is resetted to a norm value in each test
 extern unsigned nMaxDatacarrierBytes;
 

--- a/src/elysium/test/parsing_b_tests.cpp
+++ b/src/elysium/test/parsing_b_tests.cpp
@@ -120,7 +120,7 @@ BOOST_AUTO_TEST_CASE(valid_arbitrary_output_number_class_b)
         txOutputs.push_back(PayToPubKeyHash_Elysium());
     }
 
-    std::random_shuffle(txOutputs.begin(), txOutputs.end());
+    Shuffle(txOutputs.begin(), txOutputs.end(), FastRandomContext());
 
     CTransaction dummyTx = TxClassB(txInputs, txOutputs);
     BOOST_CHECK_EQUAL(dummyTx.vout.size(), nOutputs);

--- a/src/elysium/test/sender_bycontribution_tests.cpp
+++ b/src/elysium/test/sender_bycontribution_tests.cpp
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(p2pkh_contribution_by_sum_test)
     std::string strExpected("aAVHyFLdKNH8qHZQYv4eN742hNiVJ9qzHk");
 
     for (int i = 0; i < 10; ++i) {
-        std::random_shuffle(vouts.begin(), vouts.end(), GetRandInt);
+        Shuffle(vouts.begin(), vouts.end(), FastRandomContext());
 
         std::string strSender;
         BOOST_CHECK(GetSenderByContribution(vouts, strSender));
@@ -111,7 +111,7 @@ BOOST_AUTO_TEST_CASE(p2pkh_contribution_by_total_sum_test)
     std::string strExpected("aJThrdhEzf4yZmRwhzSMGxxmeC7BQEwAKC");
 
     for (int i = 0; i < 10; ++i) {
-        std::random_shuffle(vouts.begin(), vouts.end(), GetRandInt);
+        Shuffle(vouts.begin(), vouts.end(), FastRandomContext());
 
         std::string strSender;
         BOOST_CHECK(GetSenderByContribution(vouts, strSender));
@@ -142,7 +142,7 @@ BOOST_AUTO_TEST_CASE(p2pkh_contribution_by_sum_order_test)
     std::string strExpected("a1CJjinipg4PUDquNiUsP9cTfcyKLvyb3K");
 
     for (int i = 0; i < 10; ++i) {
-        std::random_shuffle(vouts.begin(), vouts.end(), GetRandInt);
+        Shuffle(vouts.begin(), vouts.end(), FastRandomContext());
 
         std::string strSender;
         BOOST_CHECK(GetSenderByContribution(vouts, strSender));
@@ -169,7 +169,7 @@ BOOST_AUTO_TEST_CASE(p2sh_contribution_by_sum_test)
     std::string strExpected("aA3ijhTqu7ywrft9fJGxnEHMUpVjW5ZnrL");
 
     for (int i = 0; i < 10; ++i) {
-        std::random_shuffle(vouts.begin(), vouts.end(), GetRandInt);
+        Shuffle(vouts.begin(), vouts.end(), FastRandomContext());
 
         std::string strSender;
         BOOST_CHECK(GetSenderByContribution(vouts, strSender));
@@ -197,7 +197,7 @@ BOOST_AUTO_TEST_CASE(p2sh_contribution_by_total_sum_test)
     std::string strExpected("a2oXxnaSLGfYskMzMh3YHyTre5mCbLL5Mn");
 
     for (int i = 0; i < 10; ++i) {
-        std::random_shuffle(vouts.begin(), vouts.end(), GetRandInt);
+        Shuffle(vouts.begin(), vouts.end(), FastRandomContext());
 
         std::string strSender;
         BOOST_CHECK(GetSenderByContribution(vouts, strSender));
@@ -228,7 +228,7 @@ BOOST_AUTO_TEST_CASE(p2sh_contribution_by_sum_order_test)
     std::string strExpected("a1CJjinipg4PUDquNiUsP9cTfcyKLvyb3K");
 
     for (int i = 0; i < 10; ++i) {
-        std::random_shuffle(vouts.begin(), vouts.end(), GetRandInt);
+        Shuffle(vouts.begin(), vouts.end(), FastRandomContext());
 
         std::string strSender;
         BOOST_CHECK(GetSenderByContribution(vouts, strSender));
@@ -257,7 +257,7 @@ BOOST_AUTO_TEST_CASE(sender_selection_string_based_test)
     std::string strExpected("a11WeUi6HFkHNdG5puD9LHCXTySddeNcu8");
 
     for (int i = 0; i < 24; ++i) {
-        std::random_shuffle(vouts.begin(), vouts.end(), GetRandInt);
+        Shuffle(vouts.begin(), vouts.end(), FastRandomContext());
 
         std::string strSender;
         BOOST_CHECK(GetSenderByContribution(vouts, strSender));
@@ -414,7 +414,7 @@ void shuffleAndCheck(std::vector<CTxOut>& vouts, unsigned nRounds)
     BOOST_CHECK(GetSenderByContribution(vouts, strSenderFirst));
 
     for (unsigned j = 0; j < nRounds; ++j) {
-        std::random_shuffle(vouts.begin(), vouts.end(), GetRandInt);
+        Shuffle(vouts.begin(), vouts.end(), FastRandomContext());
 
         std::string strSender;
         BOOST_CHECK(GetSenderByContribution(vouts, strSender));

--- a/src/elysium/test/walletmodels_tests.cpp
+++ b/src/elysium/test/walletmodels_tests.cpp
@@ -8,6 +8,8 @@
 
 #include <ostream>
 
+using namespace elysium;
+
 namespace {
 
 SigmaMintId GenerateSigmaMintId(PropertyId property, SigmaDenomination denom)

--- a/src/elysium/tx.h
+++ b/src/elysium/tx.h
@@ -136,7 +136,7 @@ private:
     uint32_t min_client_version;
 
     // Sigma
-    SigmaStatus sigmaStatus;
+    elysium::SigmaStatus sigmaStatus;
     std::vector<std::pair<uint8_t, elysium::SigmaPublicKey>> mints;
     uint8_t denomination;
     uint32_t group;
@@ -145,7 +145,7 @@ private:
     std::unique_ptr<elysium::SigmaProof> spend;
 
     CPubKey ecdsaPubkey;
-    ECDSASignature ecdsaSignature;
+    elysium::ECDSASignature ecdsaSignature;
 
     // Indicates whether the transaction can be used to execute logic
     bool rpcOnly;
@@ -278,7 +278,7 @@ public:
     const secp_primitives::Scalar *getSerial() const { return serial.get(); }
     const elysium::SigmaProof *getSpend() const { return spend.get(); }
     const CPubKey &getECDSAPublicKey() const { return ecdsaPubkey; }
-    const ECDSASignature &getECDSASignature() const { return ecdsaSignature; }
+    const elysium::ECDSASignature &getECDSASignature() const { return ecdsaSignature; }
     CAmount getMintAmount() const {
         auto itr = boost::make_transform_iterator(mints.begin(), [] (std::pair<uint8_t, elysium::SigmaPublicKey> const &m) -> uint8_t {
             return m.first;
@@ -289,7 +289,7 @@ public:
 
     CAmount getSpendAmount() const {
         std::array<uint8_t, 1> denoms = {getDenomination()};
-        return SumDenominationsValue(getProperty(), denoms.begin(), denoms.end());
+        return elysium::SumDenominationsValue(getProperty(), denoms.begin(), denoms.end());
     }
 
 
@@ -343,7 +343,7 @@ public:
         activation_block = 0;
         min_client_version = 0;
         distribution_property = 0;
-        sigmaStatus = SigmaStatus::SoftDisabled;
+        sigmaStatus = elysium::SigmaStatus::SoftDisabled;
     }
 
     /** Sets the given values. */

--- a/src/hdmint/mintpool.cpp
+++ b/src/hdmint/mintpool.cpp
@@ -5,8 +5,6 @@
 #include "hdmint/mintpool.h"
 #include "sigma.h"
 
-using namespace std;
-
 CMintPool::CMintPool(){}
 
 /**
@@ -14,12 +12,12 @@ CMintPool::CMintPool(){}
  *
  * @return void
  */
-void CMintPool::Add(pair<uint256, MintPoolEntry> pMint, bool fVerbose)
+void CMintPool::Add(std::pair<uint256, MintPoolEntry> pMint, bool fVerbose)
 {
     insert(pMint);
 
     if (fVerbose)
-        LogPrintf("%s : add %s count %d to mint pool\n", __func__, pMint.first.GetHex().substr(0, 6), get<2>(pMint.second));
+        LogPrintf("%s : add %s count %d to mint pool\n", __func__, pMint.first.GetHex().substr(0, 6), std::get<2>(pMint.second));
 }
 
 /**
@@ -27,9 +25,9 @@ void CMintPool::Add(pair<uint256, MintPoolEntry> pMint, bool fVerbose)
  *
  * @return success
  */
-bool SortSmallest(const pair<uint256, MintPoolEntry>& a, const pair<uint256, MintPoolEntry>& b)
+bool SortSmallest(const std::pair<uint256, MintPoolEntry>& a, const std::pair<uint256, MintPoolEntry>& b)
 {
-    return get<2>(a.second) < get<2>(b.second);
+    return std::get<2>(a.second) < std::get<2>(b.second);
 }
 
 /**
@@ -38,7 +36,7 @@ bool SortSmallest(const pair<uint256, MintPoolEntry>& a, const pair<uint256, Min
  * @param listMints
  * @return void
  */
-void CMintPool::List(list<pair<uint256, MintPoolEntry>>& listMints)
+void CMintPool::List(std::list<std::pair<uint256, MintPoolEntry>>& listMints)
 {
     for (auto pMint : *(this)) {
         listMints.emplace_back(pMint);
@@ -57,9 +55,9 @@ void CMintPool::Reset()
     clear();
 }
 
-bool CMintPool::Get(int32_t nCount, uint160 hashSeedMaster, pair<uint256, MintPoolEntry>& result){
+bool CMintPool::Get(int32_t nCount, uint160 hashSeedMaster, std::pair<uint256, MintPoolEntry>& result){
     for (auto pMint : *(this)) {
-        if(get<0>(pMint.second)==hashSeedMaster && get<2>(pMint.second)==nCount){
+        if(std::get<0>(pMint.second)==hashSeedMaster && std::get<2>(pMint.second)==nCount){
            result = pMint;
            return true;
         }

--- a/src/hdmint/mintpool.h
+++ b/src/hdmint/mintpool.h
@@ -26,10 +26,10 @@ class CMintPool : public std::map<uint256, MintPoolEntry> //hashPubcoin mapped t
 
 public:
     CMintPool();
-    void Add(pair<uint256, MintPoolEntry> pMint, bool fVerbose = false);
-    void List(list<pair<uint256, MintPoolEntry>>& listMints);
+    void Add(std::pair<uint256, MintPoolEntry> pMint, bool fVerbose = false);
+    void List(std::list<std::pair<uint256, MintPoolEntry>>& listMints);
     void Reset();
-    bool Get(int32_t nCount, uint160 hashSeedMaster, pair<uint256, MintPoolEntry>& result);
+    bool Get(int32_t nCount, uint160 hashSeedMaster, std::pair<uint256, MintPoolEntry>& result);
 };
 
 #endif // FIRO_MINTPOOL_H

--- a/src/hdmint/test/hdmint_tests.cpp
+++ b/src/hdmint/test/hdmint_tests.cpp
@@ -38,6 +38,7 @@
 #include <boost/thread.hpp>
 
 using namespace sigma;
+using namespace std;
 
 BOOST_FIXTURE_TEST_SUITE(hdmint_tests, ZerocoinTestingSetup200)
 

--- a/src/hdmint/tracker.cpp
+++ b/src/hdmint/tracker.cpp
@@ -14,7 +14,6 @@
 #include "lelantus.h"
 #include "txmempool.h"
 
-using namespace std;
 using namespace sigma;
 
 /**
@@ -198,7 +197,7 @@ bool CHDMintTracker::GetLelantusMetaFromPubcoin(const uint256& hashPubcoin, CLel
  */
 std::vector<uint256> CHDMintTracker::GetSerialHashes()
 {
-    vector<uint256> vHashes;
+    std::vector<uint256> vHashes;
     for (auto it : mapSerialHashes) {
         if (it.second.isArchived)
             continue;
@@ -478,7 +477,7 @@ void CHDMintTracker::SetPubcoinUsed(const uint256& hashPubcoin, const uint256& t
     if(!GetMetaFromPubcoin(hashPubcoin, meta))
         return;
     meta.isUsed = true;
-    mapPendingSpends.insert(make_pair(meta.hashSerial, txid));
+    mapPendingSpends.insert(std::make_pair(meta.hashSerial, txid));
     UpdateState(meta);
 }
 
@@ -488,7 +487,7 @@ void CHDMintTracker::SetLelantusPubcoinUsed(const uint256& hashPubcoin, const ui
     if(!GetLelantusMetaFromPubcoin(hashPubcoin, meta))
         return;
     meta.isUsed = true;
-    mapPendingSpends.insert(make_pair(meta.hashSerial, txid));
+    mapPendingSpends.insert(std::make_pair(meta.hashSerial, txid));
     UpdateState(meta);
 }
 
@@ -995,7 +994,7 @@ void CHDMintTracker::UpdateMintStateFromMempool(const std::vector<GroupElement>&
     UpdateFromBlock(mintPoolEntries, updatedMeta);
 }
 
-void CHDMintTracker::UpdateLelantusMintStateFromMempool(const std::vector<GroupElement>& pubCoins, const vector<uint64_t>& amounts) {
+void CHDMintTracker::UpdateLelantusMintStateFromMempool(const std::vector<GroupElement>& pubCoins, const std::vector<uint64_t>& amounts) {
     CWalletDB walletdb(strWalletFile);
     std::vector<CLelantusMintMeta> updatedLelantusMeta;
     std::list<std::pair<uint256, MintPoolEntry>> mintPoolEntries;
@@ -1046,7 +1045,7 @@ void CHDMintTracker::UpdateLelantusMintStateFromMempool(const std::vector<GroupE
  * @param spentSerials the set of spent serial objects to check for.
  * @return void
  */
-void CHDMintTracker::UpdateSpendStateFromMempool(const vector<Scalar>& spentSerials) {
+void CHDMintTracker::UpdateSpendStateFromMempool(const std::vector<Scalar>& spentSerials) {
     CWalletDB walletdb(strWalletFile);
     std::vector<CMintMeta> updatedMeta;
     std::list<std::pair<uint256, MintPoolEntry>> mintPoolEntries;
@@ -1079,7 +1078,7 @@ void CHDMintTracker::UpdateSpendStateFromMempool(const vector<Scalar>& spentSeri
     UpdateFromBlock(mintPoolEntries, updatedMeta);
 }
 
-void CHDMintTracker::UpdateJoinSplitStateFromMempool(const vector<Scalar>& spentSerials) {
+void CHDMintTracker::UpdateJoinSplitStateFromMempool(const std::vector<Scalar>& spentSerials) {
     CWalletDB walletdb(strWalletFile);
     std::vector<CLelantusMintMeta> updatedMeta;
     std::list<std::pair<uint256, MintPoolEntry>> mintPoolEntries;
@@ -1119,11 +1118,11 @@ void CHDMintTracker::UpdateJoinSplitStateFromMempool(const vector<Scalar>& spent
  * @param fMatureOnly convert mature (ie. spendable due to sufficient confirmations) mints only
  * @return list of CSigmaEntry objects
  */
-list<CSigmaEntry> CHDMintTracker::MintsAsSigmaEntries(bool fUnusedOnly, bool fMatureOnly){
-    list <CSigmaEntry> listPubcoin;
+std::list<CSigmaEntry> CHDMintTracker::MintsAsSigmaEntries(bool fUnusedOnly, bool fMatureOnly){
+    std::list <CSigmaEntry> listPubcoin;
     CWalletDB walletdb(strWalletFile);
     std::vector<CMintMeta> vecMists = ListMints(fUnusedOnly, fMatureOnly, false);
-    list<CMintMeta> listMints(vecMists.begin(), vecMists.end());
+    std::list<CMintMeta> listMints(vecMists.begin(), vecMists.end());
     for (const CMintMeta& mint : listMints) {
         CSigmaEntry entry;
         pwalletMain->GetMint(mint.hashSerial, entry);
@@ -1132,11 +1131,11 @@ list<CSigmaEntry> CHDMintTracker::MintsAsSigmaEntries(bool fUnusedOnly, bool fMa
     return listPubcoin;
 }
 
-list<CLelantusEntry> CHDMintTracker::MintsAsLelantusEntries(bool fUnusedOnly, bool fMatureOnly){
-    list <CLelantusEntry> listCoin;
+std::list<CLelantusEntry> CHDMintTracker::MintsAsLelantusEntries(bool fUnusedOnly, bool fMatureOnly){
+    std::list <CLelantusEntry> listCoin;
     CWalletDB walletdb(strWalletFile);
     std::vector<CLelantusMintMeta> vecMists = ListLelantusMints(fUnusedOnly, fMatureOnly, false);
-    list<CLelantusMintMeta> listMints(vecMists.begin(), vecMists.end());
+    std::list<CLelantusMintMeta> listMints(vecMists.begin(), vecMists.end());
     for (const CLelantusMintMeta& mint : listMints) {
         CLelantusEntry entry;
         pwalletMain->GetMint(mint.hashSerial, entry);

--- a/src/hdmint/tracker.h
+++ b/src/hdmint/tracker.h
@@ -52,11 +52,11 @@ public:
     void UpdateSpendStateFromBlock(const sigma::spend_info_container& spentSerials);
     void UpdateSpendStateFromBlock(const std::unordered_map<Scalar, int>& spentSerials);
     void UpdateMintStateFromMempool(const std::vector<GroupElement>& pubCoins);
-    void UpdateLelantusMintStateFromMempool(const std::vector<GroupElement>& pubCoins, const vector<uint64_t>& amounts);
-    void UpdateSpendStateFromMempool(const vector<Scalar>& spentSerials);
-    void UpdateJoinSplitStateFromMempool(const vector<Scalar>& spentSerials);
-    list<CSigmaEntry> MintsAsSigmaEntries(bool fUnusedOnly = true, bool fMatureOnly = true);
-    list<CLelantusEntry> MintsAsLelantusEntries(bool fUnusedOnly = true, bool fMatureOnly = true);
+    void UpdateLelantusMintStateFromMempool(const std::vector<GroupElement>& pubCoins, const std::vector<uint64_t>& amounts);
+    void UpdateSpendStateFromMempool(const std::vector<Scalar>& spentSerials);
+    void UpdateJoinSplitStateFromMempool(const std::vector<Scalar>& spentSerials);
+    std::list<CSigmaEntry> MintsAsSigmaEntries(bool fUnusedOnly = true, bool fMatureOnly = true);
+    std::list<CLelantusEntry> MintsAsLelantusEntries(bool fUnusedOnly = true, bool fMatureOnly = true);
     std::vector<CMintMeta> ListMints(bool fUnusedOnly = true, bool fMatureOnly = true, bool fUpdateStatus = true, bool fLoad = false, bool fWrongSeed = false);
     std::vector<CLelantusMintMeta> ListLelantusMints(bool fUnusedOnly = true, bool fMatureOnly = true, bool fUpdateStatus = true, bool fLoad = false, bool fWrongSeed = false);
     void SetPubcoinUsed(const uint256& hashPubcoin, const uint256& txid);

--- a/src/hdmint/wallet.cpp
+++ b/src/hdmint/wallet.cpp
@@ -114,7 +114,7 @@ std::pair<uint256,uint256> CHDMintWallet::RegenerateMintPoolEntry(CWalletDB& wal
     uint256 hashSerial = primitives::GetSerialHash(coin.getSerialNumber());
 
     MintPoolEntry mintPoolEntry(mintHashSeedMaster, seedId, nCount);
-    mintPool.Add(make_pair(hashPubcoin, mintPoolEntry));
+    mintPool.Add(std::make_pair(hashPubcoin, mintPoolEntry));
     walletdb.WritePubcoin(hashSerial, commitmentValue);
     walletdb.WriteMintPoolPair(hashPubcoin, mintPoolEntry);
 
@@ -170,7 +170,7 @@ void CHDMintWallet::GenerateMintPool(CWalletDB& walletdb, int32_t nIndex)
         uint256 hashPubcoin = primitives::GetPubCoinValueHash(commitmentValue);
 
         MintPoolEntry mintPoolEntry(hashSeedMaster, seedId, nLastCount);
-        mintPool.Add(make_pair(hashPubcoin, mintPoolEntry));
+        mintPool.Add(std::make_pair(hashPubcoin, mintPoolEntry));
         walletdb.WritePubcoin(primitives::GetSerialHash(coin.getSerialNumber()), commitmentValue);
         walletdb.WriteMintPoolPair(hashPubcoin, mintPoolEntry);
     }
@@ -192,7 +192,7 @@ void CHDMintWallet::GenerateMintPool(CWalletDB& walletdb, int32_t nIndex)
 bool CHDMintWallet::LoadMintPoolFromDB()
 {
     CWalletDB walletdb(strWalletFile);
-    vector<std::pair<uint256, MintPoolEntry>> listMintPool = walletdb.ListMintPool();
+    std::vector<std::pair<uint256, MintPoolEntry>> listMintPool = walletdb.ListMintPool();
 
     for (auto& mintPoolPair : listMintPool){
         mintPool.Add(mintPoolPair);
@@ -250,7 +250,7 @@ void CHDMintWallet::SyncWithChain(bool fGenerateMintPool, boost::optional<std::l
     CWalletDB walletdb(strWalletFile);
     bool found = true;
 
-    set<uint256> setAddedTx;
+    std::set<uint256> setAddedTx;
     std::set<uint256> setChecked;
     while (found) {
         found = false;
@@ -259,10 +259,10 @@ void CHDMintWallet::SyncWithChain(bool fGenerateMintPool, boost::optional<std::l
         LogPrintf("%s: Mintpool size=%d\n", __func__, mintPool.size());
 
         if(listMints==boost::none){
-            listMints = list<pair<uint256, MintPoolEntry>>();
+            listMints = std::list<std::pair<uint256, MintPoolEntry>>();
             mintPool.List(listMints.get());
         }
-        for (pair<uint256, MintPoolEntry>& pMint : listMints.get()) {
+        for (std::pair<uint256, MintPoolEntry>& pMint : listMints.get()) {
             if (setChecked.count(pMint.first))
                 continue;
             setChecked.insert(pMint.first);
@@ -270,14 +270,14 @@ void CHDMintWallet::SyncWithChain(bool fGenerateMintPool, boost::optional<std::l
             if (ShutdownRequested())
                 return;
 
-            uint160& mintHashSeedMaster = get<0>(pMint.second);
-            int32_t& mintCount = get<2>(pMint.second);
+            uint160& mintHashSeedMaster = std::get<0>(pMint.second);
+            int32_t& mintCount = std::get<2>(pMint.second);
 
             // halt processing if mint already in tracker
             if (tracker.HasPubcoinHash(pMint.first, walletdb))
                 continue;
 
-            uint160 seedId = get<1>(pMint.second);
+            uint160 seedId = std::get<1>(pMint.second);
             CDataStream ss(SER_GETHASH, 0);
             ss << pMint.first;
             ss << seedId;
@@ -452,8 +452,8 @@ bool CHDMintWallet::SetMintSeedSeen(CWalletDB& walletdb, std::pair<uint256,MintP
 {
     // Regenerate the mint
     uint256 hashPubcoin = mintPoolEntryPair.first;
-    CKeyID seedId = get<1>(mintPoolEntryPair.second);
-    int32_t mintCount = get<2>(mintPoolEntryPair.second);
+    CKeyID seedId = std::get<1>(mintPoolEntryPair.second);
+    int32_t mintCount = std::get<2>(mintPoolEntryPair.second);
 
     GroupElement bnValue;
     uint256 hashSerial;
@@ -530,8 +530,8 @@ bool CHDMintWallet::SetLelantusMintSeedSeen(CWalletDB& walletdb, std::pair<uint2
 {
     // Regenerate the mint
     uint256 hashPubcoin = mintPoolEntryPair.first;
-    CKeyID seedId = get<1>(mintPoolEntryPair.second);
-    int32_t mintCount = get<2>(mintPoolEntryPair.second);
+    CKeyID seedId = std::get<1>(mintPoolEntryPair.second);
+    int32_t mintCount = std::get<2>(mintPoolEntryPair.second);
 
     auto params = lelantus::Params::get_default();
 
@@ -736,7 +736,7 @@ CKeyID CHDMintWallet::GetMintSeedID(CWalletDB& walletdb, int32_t nCount){
         }
     }
 
-    return get<1>(mintPoolEntryPair.second);
+    return std::get<1>(mintPoolEntryPair.second);
 }
 
 /**
@@ -785,7 +785,7 @@ bool CHDMintWallet::CreateMintSeed(CWalletDB& walletdb, uint512& mintSeed, const
     unsigned char countHash[CSHA256().OUTPUT_SIZE];
     std::vector<unsigned char> result(CSHA512().OUTPUT_SIZE);
 
-    std::string nCountStr = to_string(nCount);
+    std::string nCountStr = std::to_string(nCount);
     CSHA256().Write(reinterpret_cast<const unsigned char*>(nCountStr.c_str()), nCountStr.size()).Finalize(countHash);
 
     CHMAC_SHA512(countHash, CSHA256().OUTPUT_SIZE).Write(key.begin(), key.size()).Finalize(&result[0]);
@@ -862,7 +862,7 @@ void CHDMintWallet::UpdateCountDB(CWalletDB& walletdb)
  */
 bool CHDMintWallet::GetHDMintFromMintPoolEntry(CWalletDB& walletdb, const sigma::CoinDenomination denom, sigma::PrivateCoin& coin, CHDMint& dMint, MintPoolEntry& mintPoolEntry){
     uint512 mintSeed;
-    CreateMintSeed(walletdb, mintSeed, get<2>(mintPoolEntry), get<1>(mintPoolEntry));
+    CreateMintSeed(walletdb, mintSeed, std::get<2>(mintPoolEntry), std::get<1>(mintPoolEntry));
 
     GroupElement commitmentValue;
     if(!SeedToMint(mintSeed, commitmentValue, coin)){
@@ -872,7 +872,7 @@ bool CHDMintWallet::GetHDMintFromMintPoolEntry(CWalletDB& walletdb, const sigma:
     coin.setPublicCoin(sigma::PublicCoin(commitmentValue, denom));
 
     uint256 hashSerial = primitives::GetSerialHash(coin.getSerialNumber());
-    dMint = CHDMint(get<2>(mintPoolEntry), get<1>(mintPoolEntry), hashSerial, coin.getPublicCoin().getValue());
+    dMint = CHDMint(std::get<2>(mintPoolEntry), std::get<1>(mintPoolEntry), hashSerial, coin.getPublicCoin().getValue());
     return true;
 }
 
@@ -886,14 +886,14 @@ bool CHDMintWallet::GetHDMintFromMintPoolEntry(CWalletDB& walletdb, const sigma:
  */
 bool CHDMintWallet::GetLelantusHDMintFromMintPoolEntry(CWalletDB& walletdb, lelantus::PrivateCoin& coin, CHDMint& dMint, MintPoolEntry& mintPoolEntry){
     uint512 mintSeed;
-    CreateMintSeed(walletdb, mintSeed, get<2>(mintPoolEntry), get<1>(mintPoolEntry));
+    CreateMintSeed(walletdb, mintSeed, std::get<2>(mintPoolEntry), std::get<1>(mintPoolEntry));
 
     if(!SeedToLelantusMint(mintSeed, coin)){
         return false;
     }
 
     uint256 hashSerial = primitives::GetSerialHash(coin.getSerialNumber());
-    dMint = CHDMint(get<2>(mintPoolEntry), get<1>(mintPoolEntry), hashSerial, coin.getPublicCoin().getValue());
+    dMint = CHDMint(std::get<2>(mintPoolEntry), std::get<1>(mintPoolEntry), hashSerial, coin.getPublicCoin().getValue());
     return true;
 }
 
@@ -937,9 +937,9 @@ bool CHDMintWallet::GenerateMint(CWalletDB& walletdb, const sigma::CoinDenominat
         // New HDMint exists, try new count
         if(walletdb.HasHDMint(dMint.GetPubcoinValue()) ||
            sigmaState->HasCoin(coin.getPublicCoin())) {
-            LogPrintf("%s: Coin detected used, trying next. count: %d\n", __func__, get<2>(mintPoolEntry.get()));
+            LogPrintf("%s: Coin detected used, trying next. count: %d\n", __func__, std::get<2>(mintPoolEntry.get()));
         }else{
-            LogPrintf("%s: Found unused coin, count: %d\n", __func__, get<2>(mintPoolEntry.get()));
+            LogPrintf("%s: Found unused coin, count: %d\n", __func__, std::get<2>(mintPoolEntry.get()));
             break;
         }
     }
@@ -991,9 +991,9 @@ bool CHDMintWallet::GenerateLelantusMint(CWalletDB& walletdb, lelantus::PrivateC
         // New HDMint exists, try new count
         if(walletdb.HasHDMint(dMint.GetPubcoinValue())
         || lelantusState->HasCoin(coin.getPublicCoin())) {
-            LogPrintf("%s: Coin detected used, trying next. count: %d\n", __func__, get<2>(mintPoolEntry.get()));
+            LogPrintf("%s: Coin detected used, trying next. count: %d\n", __func__, std::get<2>(mintPoolEntry.get()));
         }else{
-            LogPrintf("%s: Found unused coin, count: %d\n", __func__, get<2>(mintPoolEntry.get()));
+            LogPrintf("%s: Found unused coin, count: %d\n", __func__, std::get<2>(mintPoolEntry.get()));
             break;
         }
     }
@@ -1140,7 +1140,7 @@ bool CHDMintWallet::TxOutToPublicCoin(const CTxOut& txout, sigma::PublicCoin& pu
 {
     // If you wonder why +1, go to file wallet.cpp and read the comments in function
     // CWallet::CreateSigmaMintModel around "scriptSerializedCoin << OP_SIGMAMINT";
-    vector<unsigned char> coin_serialised(txout.scriptPubKey.begin() + 1,
+    std::vector<unsigned char> coin_serialised(txout.scriptPubKey.begin() + 1,
                                           txout.scriptPubKey.end());
     secp_primitives::GroupElement publicSigma;
     publicSigma.deserialize(&coin_serialised[0]);

--- a/src/lelantus.cpp
+++ b/src/lelantus.cpp
@@ -105,7 +105,7 @@ void GenerateMintSchnorrProof(const lelantus::PrivateCoin& coin, CDataStream&  s
     secp_primitives::GroupElement commit = coin.getPublicCoin().getValue();
     secp_primitives::GroupElement comm = commit + (params->get_h1() * v.negate());
 
-    unique_ptr<ChallengeGenerator> challengeGenerator;
+    std::unique_ptr<ChallengeGenerator> challengeGenerator;
     if (afterFixes) {
         // start to use CHash256 which is more secure
         challengeGenerator = std::make_unique<ChallengeGeneratorImpl<CHash256>>(1);
@@ -128,7 +128,7 @@ bool VerifyMintSchnorrProof(const uint64_t& v, const secp_primitives::GroupEleme
     bool afterFixes = chainActive.Height() >= ::Params().GetConsensus().nLelantusFixesStartBlock;
     secp_primitives::GroupElement comm = commit + (params->get_h1() * Scalar(v).negate());
     SchnorrVerifier verifier(params->get_g(), params->get_h0(), afterFixes);
-    unique_ptr<ChallengeGenerator> challengeGenerator;
+    std::unique_ptr<ChallengeGenerator> challengeGenerator;
     if (afterFixes) {
         // start to use CHash256 which is more secure
         challengeGenerator = std::make_unique<ChallengeGeneratorImpl<CHash256>>(1);
@@ -432,7 +432,7 @@ bool CheckLelantusJoinSplitTransaction(
             while (index != coinGroup.firstBlock && index->GetBlockHash() != idAndHash.second)
                 index = index->pprev;
 
-            pair<sigma::CoinDenomination, int> denominationAndId = std::make_pair(denomination, coinGroupId);
+            std::pair<sigma::CoinDenomination, int> denominationAndId = std::make_pair(denomination, coinGroupId);
 
             auto lelantusParams = lelantus::Params::get_default();
             while (true) {
@@ -1472,7 +1472,7 @@ std::pair<int, int> CLelantusState::GetMintedCoinHeightAndId(
     return std::make_pair(-1, -1);
 }
 
-bool CLelantusState::AddSpendToMempool(const vector<Scalar> &coinSerials, uint256 txHash) {
+bool CLelantusState::AddSpendToMempool(const std::vector<Scalar> &coinSerials, uint256 txHash) {
     LOCK(mempool.cs);
     BOOST_FOREACH(const Scalar& coinSerial, coinSerials){
         if (IsUsedCoinSerial(coinSerial) || mempool.lelantusState.HasCoinSerial(coinSerial))
@@ -1484,14 +1484,14 @@ bool CLelantusState::AddSpendToMempool(const vector<Scalar> &coinSerials, uint25
     return true;
 }
 
-void CLelantusState::RemoveSpendFromMempool(const vector<Scalar> &coinSerials) {
+void CLelantusState::RemoveSpendFromMempool(const std::vector<Scalar> &coinSerials) {
     LOCK(mempool.cs);
     BOOST_FOREACH(const Scalar& coinSerial, coinSerials) {
         mempool.lelantusState.RemoveSpendFromMempool(coinSerial);
     }
 }
 
-void CLelantusState::AddMintsToMempool(const vector<GroupElement>& pubCoins) {
+void CLelantusState::AddMintsToMempool(const std::vector<GroupElement>& pubCoins) {
     LOCK(mempool.cs);
     BOOST_FOREACH(const GroupElement& pubCoin, pubCoins) {
         mempool.lelantusState.AddMintToMempool(pubCoin);

--- a/src/lelantus.h
+++ b/src/lelantus.h
@@ -133,7 +133,7 @@ public:
  * State of minted/spent coins as extracted from the index
  */
 class CLelantusState {
-friend bool BuildLelantusStateFromIndex(CChain *, set<CBlockIndex *> &);
+friend bool BuildLelantusStateFromIndex(CChain *, std::set<CBlockIndex *> &);
 public:
     // First and last block where mint with given id was seen
     struct LelantusCoinGroupInfo {
@@ -208,16 +208,16 @@ public:
 
     // Add spend into the mempool.
     // Check if there is a coin with such serial in either blockchain or mempool
-    bool AddSpendToMempool(const vector<Scalar>& coinSerials, uint256 txHash);
+    bool AddSpendToMempool(const std::vector<Scalar>& coinSerials, uint256 txHash);
 
-    void AddMintsToMempool(const vector<GroupElement>& pubCoins);
+    void AddMintsToMempool(const std::vector<GroupElement>& pubCoins);
     void RemoveMintFromMempool(const GroupElement& pubCoin);
 
     // Get conflicting tx hash by coin serial number
     uint256 GetMempoolConflictingTxHash(const Scalar& coinSerial);
 
     // Remove spend from the mempool (usually as the result of adding tx to the block)
-    void RemoveSpendFromMempool(const vector<Scalar>& coinSerials);
+    void RemoveSpendFromMempool(const std::vector<Scalar>& coinSerials);
 
     static CLelantusState* GetState();
 

--- a/src/liblelantus/innerproduct_proof_generator.cpp
+++ b/src/liblelantus/innerproduct_proof_generator.cpp
@@ -32,7 +32,7 @@ void InnerProductProofGenerator::generate_proof(
         const std::vector<Scalar>& a,
         const std::vector<Scalar>& b,
         const Scalar& x,
-        unique_ptr<ChallengeGenerator>& challengeGenerator,
+        std::unique_ptr<ChallengeGenerator>& challengeGenerator,
         InnerProductProof& proof_out) {
     const Scalar c = LelantusPrimitives::scalar_dot_product(a.begin(), a.end(), b.begin(), b.end());
     compute_P(a, b, P_initial);
@@ -45,7 +45,7 @@ void InnerProductProofGenerator::generate_proof(
 void InnerProductProofGenerator::generate_proof_util(
         const std::vector<Scalar>& a,
         const std::vector<Scalar>& b,
-        unique_ptr<ChallengeGenerator>& challengeGenerator,
+        std::unique_ptr<ChallengeGenerator>& challengeGenerator,
         InnerProductProof& proof_out) {
 
     if(a.size() != b.size())

--- a/src/liblelantus/innerproduct_proof_generator.h
+++ b/src/liblelantus/innerproduct_proof_generator.h
@@ -20,7 +20,7 @@ public:
             const std::vector<Scalar>& a,
             const std::vector<Scalar>& b,
             const Scalar& x,
-            unique_ptr<ChallengeGenerator>& challengeGenerator,
+            std::unique_ptr<ChallengeGenerator>& challengeGenerator,
             InnerProductProof& proof_out);
 
     const GroupElement& get_P();
@@ -37,7 +37,7 @@ private:
     void generate_proof_util(
             const std::vector<Scalar>& a,
             const std::vector<Scalar>& b,
-            unique_ptr<ChallengeGenerator>& challengeGenerator,
+            std::unique_ptr<ChallengeGenerator>& challengeGenerator,
             InnerProductProof& proof_out);
 
     void l(typename std::vector<Scalar>::const_iterator a_start,

--- a/src/liblelantus/innerproduct_proof_verifier.cpp
+++ b/src/liblelantus/innerproduct_proof_verifier.cpp
@@ -19,7 +19,7 @@ InnerProductProofVerifier::InnerProductProofVerifier(
 bool InnerProductProofVerifier::verify(
         const Scalar& x,
         const InnerProductProof& proof,
-        unique_ptr<ChallengeGenerator>& challengeGenerator) {
+        std::unique_ptr<ChallengeGenerator>& challengeGenerator) {
     auto itr_l = proof.L_.begin();
     auto itr_r = proof.R_.begin();
     u_  *= x;
@@ -31,7 +31,7 @@ bool InnerProductProofVerifier::verify_util(
         const InnerProductProof& proof,
         typename std::vector<GroupElement>::const_iterator itr_l,
         typename std::vector<GroupElement>::const_iterator itr_r,
-        unique_ptr<ChallengeGenerator>& challengeGenerator) {
+        std::unique_ptr<ChallengeGenerator>& challengeGenerator) {
     if(itr_l == proof.L_.end()){
         Scalar c = proof.a_ * proof.b_;
         GroupElement uc = u_ * c;
@@ -62,7 +62,7 @@ bool InnerProductProofVerifier::verify_util(
     return InnerProductProofVerifier(g_p, h_p, u_, p_p, version_).verify_util(proof, itr_l + 1, itr_r + 1, challengeGenerator);
 }
 
-bool InnerProductProofVerifier::verify_fast(uint64_t n, const Scalar& x, const InnerProductProof& proof, unique_ptr<ChallengeGenerator>& challengeGenerator) {
+bool InnerProductProofVerifier::verify_fast(uint64_t n, const Scalar& x, const InnerProductProof& proof, std::unique_ptr<ChallengeGenerator>& challengeGenerator) {
     u_  *= x;
     P_ += u_ * proof.c_;
     return verify_fast_util(n, proof, challengeGenerator);
@@ -71,7 +71,7 @@ bool InnerProductProofVerifier::verify_fast(uint64_t n, const Scalar& x, const I
 bool InnerProductProofVerifier::verify_fast_util(
         uint64_t n,
         const InnerProductProof& proof,
-        unique_ptr<ChallengeGenerator>& challengeGenerator){
+        std::unique_ptr<ChallengeGenerator>& challengeGenerator){
     std::size_t log_n = proof.L_.size();
     std::vector<Scalar> x_j;
     x_j.resize(log_n);

--- a/src/liblelantus/innerproduct_proof_verifier.h
+++ b/src/liblelantus/innerproduct_proof_verifier.h
@@ -17,17 +17,17 @@ public:
             const GroupElement& P,
             int version); // if(version >= 2) we should pass CHash256 in verify
 
-    bool verify(const Scalar& x, const InnerProductProof& proof, unique_ptr<ChallengeGenerator>& challengeGenerator);
-    bool verify_fast(uint64_t n, const Scalar& x, const InnerProductProof& proof, unique_ptr<ChallengeGenerator>& challengeGenerator);
+    bool verify(const Scalar& x, const InnerProductProof& proof, std::unique_ptr<ChallengeGenerator>& challengeGenerator);
+    bool verify_fast(uint64_t n, const Scalar& x, const InnerProductProof& proof, std::unique_ptr<ChallengeGenerator>& challengeGenerator);
 
 private:
     bool verify_util(
             const InnerProductProof& proof,
             typename std::vector<GroupElement>::const_iterator ltr_l,
             typename std::vector<GroupElement>::const_iterator itr_r,
-            unique_ptr<ChallengeGenerator>& challengeGenerator);
+            std::unique_ptr<ChallengeGenerator>& challengeGenerator);
 
-    bool verify_fast_util(uint64_t n, const InnerProductProof& proof, unique_ptr<ChallengeGenerator>& challengeGenerator);
+    bool verify_fast_util(uint64_t n, const InnerProductProof& proof, std::unique_ptr<ChallengeGenerator>& challengeGenerator);
 
 private:
     const std::vector<GroupElement>& g_;

--- a/src/liblelantus/lelantus_primitives.cpp
+++ b/src/liblelantus/lelantus_primitives.cpp
@@ -96,7 +96,7 @@ void  LelantusPrimitives::generate_Lelantus_challenge(
         const std::vector<std::vector<unsigned char>>& ecdsaPubkeys,
         const std::vector<GroupElement>& Cout,
         unsigned int version,
-        unique_ptr<ChallengeGenerator>& challengeGenerator,
+        std::unique_ptr<ChallengeGenerator>& challengeGenerator,
         Scalar& result_out) {
 
     result_out = uint64_t(1);

--- a/src/liblelantus/lelantus_primitives.h
+++ b/src/liblelantus/lelantus_primitives.h
@@ -75,7 +75,7 @@ public:
             const std::vector<std::vector<unsigned char>>& ecdsaPubkeys,
             const std::vector<GroupElement>& Cout,
             unsigned int version,
-            unique_ptr<ChallengeGenerator>& challengeGenerator,
+            std::unique_ptr<ChallengeGenerator>& challengeGenerator,
             Scalar& result_out);
 
     static void new_factor(const Scalar& x, const Scalar& a, std::vector<Scalar>& coefficients);

--- a/src/liblelantus/lelantus_prover.cpp
+++ b/src/liblelantus/lelantus_prover.cpp
@@ -33,7 +33,7 @@ void LelantusProver::proof(
     std::vector<Scalar> Yk_sum;
     Yk_sum.resize(Cin.size());
     // we are passing challengeGenerator ptr here, as after LELANTUS_TX_VERSION_4_5 we need  it back, with filled data, to use in schnorr proof,
-    unique_ptr<ChallengeGenerator> challengeGenerator;
+    std::unique_ptr<ChallengeGenerator> challengeGenerator;
     generate_sigma_proofs(anonymity_sets, anonymity_set_hashes, Cin, Cout, indexes, ecdsaPubkeys, x, challengeGenerator, Yk_sum, proof_out.sigma_proofs, qkSchnorrProof);
 
     generate_bulletproofs(Cout, proof_out.bulletproofs);
@@ -79,7 +79,7 @@ void LelantusProver::generate_sigma_proofs(
         const std::vector<size_t>& indexes,
         const std::vector<std::vector<unsigned char>>& ecdsaPubkeys,
         Scalar& x,
-        unique_ptr<ChallengeGenerator>& challengeGenerator,
+        std::unique_ptr<ChallengeGenerator>& challengeGenerator,
         std::vector<Scalar>& Yk_sum,
         std::vector<SigmaExtendedProof>& sigma_proofs,
         SchnorrProof& qkSchnorrProof) {

--- a/src/liblelantus/lelantus_prover.h
+++ b/src/liblelantus/lelantus_prover.h
@@ -33,7 +33,7 @@ private:
             const std::vector<size_t>& indexes,
             const std::vector<std::vector<unsigned char>>& ecdsaPubkeys,
             Scalar& x,
-            unique_ptr<ChallengeGenerator>& challengeGenerator,
+            std::unique_ptr<ChallengeGenerator>& challengeGenerator,
             std::vector<Scalar>& Yk_sum,
             std::vector<SigmaExtendedProof>& sigma_proofs,
             SchnorrProof& qkSchnorrProof);

--- a/src/liblelantus/lelantus_verifier.cpp
+++ b/src/liblelantus/lelantus_verifier.cpp
@@ -74,7 +74,7 @@ bool LelantusVerifier::verify(
     }
 
     Scalar zV, zR;
-    unique_ptr<ChallengeGenerator> challengeGenerator;
+    std::unique_ptr<ChallengeGenerator> challengeGenerator;
     try {
         // we are passing challengeGenerator ptr here, as after LELANTUS_TX_VERSION_4_5 we need  it back, with filled data, to use in schnorr proof,
         if (!(verify_sigma(vAnonymity_sets, anonymity_set_hashes, vSin, serialNumbers, ecdsaPubkeys, Cout, proof.sigma_proofs, qkSchnorrProof, x, challengeGenerator, zV, zR, fSkipVerification) &&
@@ -98,7 +98,7 @@ bool LelantusVerifier::verify_sigma(
         const std::vector<SigmaExtendedProof> &sigma_proofs,
         const SchnorrProof& qkSchnorrProof,
         Scalar& x,
-        unique_ptr<ChallengeGenerator>& challengeGenerator,
+        std::unique_ptr<ChallengeGenerator>& challengeGenerator,
         Scalar& zV,
         Scalar& zR,
         bool fSkipVerification) {
@@ -226,7 +226,7 @@ bool LelantusVerifier::verify_schnorrproof(
         const Scalar fee,
         const std::vector<PublicCoin>& Cout,
         const LelantusProof& proof,
-        unique_ptr<ChallengeGenerator>& challengeGenerator) {
+        std::unique_ptr<ChallengeGenerator>& challengeGenerator) {
     // x^m
     Scalar x_m = x.exponent(params->get_sigma_m());
 

--- a/src/liblelantus/lelantus_verifier.h
+++ b/src/liblelantus/lelantus_verifier.h
@@ -51,7 +51,7 @@ private:
             const std::vector<SigmaExtendedProof> &sigma_proofs,
             const SchnorrProof& qkSchnorrProof,
             Scalar& x,
-            unique_ptr<ChallengeGenerator>& challengeGenerator,
+            std::unique_ptr<ChallengeGenerator>& challengeGenerator,
             Scalar& zV,
             Scalar& zR,
             bool fSkipVerification = false);
@@ -67,7 +67,7 @@ private:
             const Scalar fee,
             const std::vector<PublicCoin>& Cout,
             const LelantusProof& proof,
-            unique_ptr<ChallengeGenerator>& challengeGenerator);
+            std::unique_ptr<ChallengeGenerator>& challengeGenerator);
 
 private:
     const Params* params;

--- a/src/liblelantus/range_prover.cpp
+++ b/src/liblelantus/range_prover.cpp
@@ -62,7 +62,7 @@ void RangeProver::batch_proof(
     LelantusPrimitives::commit(h1, ro, g_, sL, h_, sR, proof_out.S);
 
     Scalar y, z;
-    unique_ptr<ChallengeGenerator> challengeGenerator;
+    std::unique_ptr<ChallengeGenerator> challengeGenerator;
     if (version >= LELANTUS_TX_VERSION_4_5) {
         challengeGenerator = std::make_unique<ChallengeGeneratorImpl<CHash256>>(1);
         // add domain separator and transaction version into transcript

--- a/src/liblelantus/range_verifier.cpp
+++ b/src/liblelantus/range_verifier.cpp
@@ -27,7 +27,7 @@ bool RangeVerifier::verify_batch(const std::vector<GroupElement>& V, const std::
 
     //computing challenges
     Scalar x, x_u, y, z;
-    unique_ptr<ChallengeGenerator> challengeGenerator;
+    std::unique_ptr<ChallengeGenerator> challengeGenerator;
     if (version >= LELANTUS_TX_VERSION_4_5) {
         challengeGenerator = std::make_unique<ChallengeGeneratorImpl<CHash256>>(1);
         // add domain separator and transaction version into transcript

--- a/src/liblelantus/schnorr_prover.cpp
+++ b/src/liblelantus/schnorr_prover.cpp
@@ -14,7 +14,7 @@ void SchnorrProver::proof(
         const GroupElement& y,
         const GroupElement& a,
         const GroupElement& b,
-        unique_ptr<ChallengeGenerator>& challengeGenerator,
+        std::unique_ptr<ChallengeGenerator>& challengeGenerator,
         SchnorrProof& proof_out){
     Scalar P0;
     Scalar T0;

--- a/src/liblelantus/schnorr_prover.h
+++ b/src/liblelantus/schnorr_prover.h
@@ -11,7 +11,7 @@ public:
     SchnorrProver(const GroupElement& g, const GroupElement& h, bool withFixes_);
 
     // values a, b and y are included into transcript if(withFixes_), also better to use CHash256 in that case
-    void proof(const Scalar& P, const Scalar& T, const GroupElement& y, const GroupElement& a, const GroupElement& b, unique_ptr<ChallengeGenerator>& challengeGenerator, SchnorrProof& proof_out);
+    void proof(const Scalar& P, const Scalar& T, const GroupElement& y, const GroupElement& a, const GroupElement& b, std::unique_ptr<ChallengeGenerator>& challengeGenerator, SchnorrProof& proof_out);
     void proof(const Scalar& P, const Scalar& T, const std::vector<GroupElement>& groupElements, SchnorrProof& proof_out);
 
 private:

--- a/src/liblelantus/schnorr_verifier.cpp
+++ b/src/liblelantus/schnorr_verifier.cpp
@@ -12,7 +12,7 @@ bool SchnorrVerifier::verify(
         const GroupElement& a,
         const GroupElement& b,
         const SchnorrProof& proof,
-        unique_ptr<ChallengeGenerator>& challengeGenerator){
+        std::unique_ptr<ChallengeGenerator>& challengeGenerator){
 
     const GroupElement& u = proof.u;
     Scalar c;

--- a/src/liblelantus/schnorr_verifier.h
+++ b/src/liblelantus/schnorr_verifier.h
@@ -11,7 +11,7 @@ public:
     SchnorrVerifier(const GroupElement& g, const GroupElement& h, bool withFixes_);
 
     // values a, b and y are included into transcript if(withFixes_), also better to use CHash256 in that case
-    bool verify(const GroupElement& y, const GroupElement& a, const GroupElement& b,const SchnorrProof& proof, unique_ptr<ChallengeGenerator>& challengeGenerator);
+    bool verify(const GroupElement& y, const GroupElement& a, const GroupElement& b,const SchnorrProof& proof, std::unique_ptr<ChallengeGenerator>& challengeGenerator);
     bool verify(const GroupElement& y, const std::vector<GroupElement>& groupElements,const SchnorrProof& proof);
 
 private:

--- a/src/liblelantus/sigmaextended_verifier.cpp
+++ b/src/liblelantus/sigmaextended_verifier.cpp
@@ -18,7 +18,7 @@ bool SigmaExtendedVerifier::batchverify(
         const std::vector<GroupElement>& commits,
         const Scalar& x,
         const std::vector<Scalar>& serials,
-        const vector<SigmaExtendedProof>& proofs) const {
+        const std::vector<SigmaExtendedProof>& proofs) const {
     int M = proofs.size();
     int N = commits.size();
 
@@ -65,7 +65,7 @@ bool SigmaExtendedVerifier::batchverify(
         Scalar e;
 
         Scalar f_i(uint64_t(1));
-        vector<Scalar>::iterator ptr = f_i_t.begin();
+        std::vector<Scalar>::iterator ptr = f_i_t.begin();
         compute_batch_fis(f_i, m, f_[t], y[t], e, ptr, ptr, ptr + N - 1);
         /*
         * Optimization for getting power for last 'commits' array element is done similarly to the one used in creating
@@ -83,7 +83,7 @@ bool SigmaExtendedVerifier::batchverify(
         */
 
         Scalar pow(uint64_t(1));
-        vector<Scalar> f_part_product;    // partial product of f array elements for lastIndex
+        std::vector<Scalar> f_part_product;    // partial product of f array elements for lastIndex
         for (int j = m - 1; j >= 0; j--) {
             f_part_product.push_back(pow);
             pow *= f_[t][j * n + I_[N - 1][j]];
@@ -144,7 +144,7 @@ bool SigmaExtendedVerifier::batchverify(
         const std::vector<Scalar>& challenges,
         const std::vector<Scalar>& serials,
         const std::vector<size_t>& setSizes,
-        const vector<SigmaExtendedProof>& proofs) const {
+        const std::vector<SigmaExtendedProof>& proofs) const {
     int M = proofs.size();
     int N = commits.size();
 
@@ -185,7 +185,7 @@ bool SigmaExtendedVerifier::batchverify(
         size_t start = N - size;
 
         Scalar f_i(uint64_t(1));
-        vector<Scalar>::iterator ptr = f_i_t.begin() + start;
+        std::vector<Scalar>::iterator ptr = f_i_t.begin() + start;
         compute_batch_fis(f_i, m, f_[t], y[t], e, ptr, ptr, ptr + size - 1);
 
         /*
@@ -204,7 +204,7 @@ bool SigmaExtendedVerifier::batchverify(
         */
 
         Scalar pow(uint64_t(1));
-        vector<Scalar> f_part_product;    // partial product of f array elements for lastIndex
+        std::vector<Scalar> f_part_product;    // partial product of f array elements for lastIndex
         for (int j = m - 1; j >= 0; j--) {
             f_part_product.push_back(pow);
             pow *= f_[t][j * n + I_[size - 1][j]];
@@ -342,7 +342,7 @@ bool SigmaExtendedVerifier::abcd_checks(
 
 void SigmaExtendedVerifier::compute_fis(int j, const std::vector<Scalar>& f, std::vector<Scalar>& f_i_) const {
     Scalar f_i(uint64_t(1));
-    vector<Scalar>::iterator ptr = f_i_.begin();
+    std::vector<Scalar>::iterator ptr = f_i_.begin();
     compute_fis(f_i, m, f, ptr, f_i_.end());
 }
 
@@ -350,8 +350,8 @@ void SigmaExtendedVerifier::compute_fis(
         const Scalar& f_i,
         int j,
         const std::vector<Scalar>& f,
-        vector<Scalar>::iterator& ptr,
-        vector<Scalar>::iterator end_ptr) const {
+        std::vector<Scalar>::iterator& ptr,
+        std::vector<Scalar>::iterator end_ptr) const {
     j--;
     if (j == -1)
     {
@@ -377,9 +377,9 @@ void SigmaExtendedVerifier::compute_batch_fis(
         const std::vector<Scalar>& f,
         const Scalar& y,
         Scalar& e,
-        vector<Scalar>::iterator& ptr,
-        vector<Scalar>::iterator start_ptr,
-        vector<Scalar>::iterator end_ptr) const {
+        std::vector<Scalar>::iterator& ptr,
+        std::vector<Scalar>::iterator start_ptr,
+        std::vector<Scalar>::iterator end_ptr) const {
     j--;
     if (j == -1)
     {

--- a/src/liblelantus/sigmaextended_verifier.h
+++ b/src/liblelantus/sigmaextended_verifier.h
@@ -17,14 +17,14 @@ public:
     bool batchverify(const std::vector<GroupElement>& commits,
                      const Scalar& x,
                      const std::vector<Scalar>& serials,
-                     const vector<SigmaExtendedProof>& proofs) const;
+                     const std::vector<SigmaExtendedProof>& proofs) const;
     //gets initial double-blinded Pedersen commitments
     //verifies proofs from different transactions, where set sizes and challenges are different
     bool batchverify(const std::vector<GroupElement>& commits,
                      const std::vector<Scalar>& challenges,
                      const std::vector<Scalar>& serials,
                      const std::vector<size_t>& setSizes,
-                     const vector<SigmaExtendedProof>& proofs) const;
+                     const std::vector<SigmaExtendedProof>& proofs) const;
 
 private:
     //auxiliary functions
@@ -43,17 +43,17 @@ private:
             const Scalar& f_i,
             int j,
             const std::vector<Scalar>& f,
-            vector<Scalar>::iterator& ptr,
-            vector<Scalar>::iterator end_ptr) const;
+            std::vector<Scalar>::iterator& ptr,
+            std::vector<Scalar>::iterator end_ptr) const;
     void compute_batch_fis(
             const Scalar& f_i,
             int j,
             const std::vector<Scalar>& f,
             const Scalar& y,
             Scalar& e,
-            vector<Scalar>::iterator& ptr,
-            vector<Scalar>::iterator start_ptr,
-            vector<Scalar>::iterator end_ptr) const;
+            std::vector<Scalar>::iterator& ptr,
+            std::vector<Scalar>::iterator start_ptr,
+            std::vector<Scalar>::iterator end_ptr) const;
 
 private:
     GroupElement g_;

--- a/src/liblelantus/test/inner_product_test.cpp
+++ b/src/liblelantus/test/inner_product_test.cpp
@@ -57,7 +57,7 @@ BOOST_AUTO_TEST_CASE(prove_verify_one)
 
     Scalar x;
     x.randomize();
-    unique_ptr<ChallengeGenerator> challengeGenerator = std::make_unique<ChallengeGeneratorImpl<CHash256>>(1);
+    std::unique_ptr<ChallengeGenerator> challengeGenerator = std::make_unique<ChallengeGeneratorImpl<CHash256>>(1);
 
     // generating proofs
     Proof proof;
@@ -89,7 +89,7 @@ BOOST_AUTO_TEST_CASE(prove_verify)
 
     Scalar x;
     x.randomize();
-    unique_ptr<ChallengeGenerator> challengeGenerator = std::make_unique<ChallengeGeneratorImpl<CHash256>>(1);
+    std::unique_ptr<ChallengeGenerator> challengeGenerator = std::make_unique<ChallengeGeneratorImpl<CHash256>>(1);
 
     // generating proofs
     Proof proof;
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_CASE(fake_proof_not_verify)
 
     Scalar x;
     x.randomize();
-    unique_ptr<ChallengeGenerator> challengeGenerator = std::make_unique<ChallengeGeneratorImpl<CHash256>>(1);
+    std::unique_ptr<ChallengeGenerator> challengeGenerator = std::make_unique<ChallengeGeneratorImpl<CHash256>>(1);
 
     // generating genertor
     Proof proof;

--- a/src/liblelantus/test/lelantus_primitives_tests.cpp
+++ b/src/liblelantus/test/lelantus_primitives_tests.cpp
@@ -149,7 +149,7 @@ BOOST_AUTO_TEST_CASE(generate_lelantus_challenge)
     }
 
     Scalar out;
-    unique_ptr<ChallengeGenerator> challengeGenerator = std::make_unique<ChallengeGeneratorImpl<CSHA256>>();
+    std::unique_ptr<ChallengeGenerator> challengeGenerator = std::make_unique<ChallengeGeneratorImpl<CSHA256>>();
     Primitives::generate_Lelantus_challenge(proofs, {}, {}, {}, {}, 0, challengeGenerator, out);
 
     BOOST_CHECK_EQUAL(

--- a/src/liblelantus/test/schnorr_test.cpp
+++ b/src/liblelantus/test/schnorr_test.cpp
@@ -31,7 +31,7 @@ BOOST_FIXTURE_TEST_SUITE(lelantus_schnorr_proof_tests, SchnorrProofTests)
 
 BOOST_AUTO_TEST_CASE(serialization)
 {
-    unique_ptr<ChallengeGenerator> challengeGenerator = std::make_unique<ChallengeGeneratorImpl<CHash256>>(1);
+    std::unique_ptr<ChallengeGenerator> challengeGenerator = std::make_unique<ChallengeGeneratorImpl<CHash256>>(1);
     SchnorrProver prover(g, h, true);
     GroupElement y;
     y.randomize();
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(serialization)
 BOOST_AUTO_TEST_CASE(prove_verify)
 {
     auto y = LelantusPrimitives::commit(g, P, h, T);
-    unique_ptr<ChallengeGenerator> challengeGenerator = std::make_unique<ChallengeGeneratorImpl<CHash256>>(1);
+    std::unique_ptr<ChallengeGenerator> challengeGenerator = std::make_unique<ChallengeGeneratorImpl<CHash256>>(1);
 
     SchnorrProver prover(g, h, true);
     SchnorrProof proof;
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE(prove_verify)
 BOOST_AUTO_TEST_CASE(fake_prove_not_verify)
 {
     auto y = LelantusPrimitives::commit(g, P, h, T);
-    unique_ptr<ChallengeGenerator> challengeGenerator = std::make_unique<ChallengeGeneratorImpl<CHash256>>(1);
+    std::unique_ptr<ChallengeGenerator> challengeGenerator = std::make_unique<ChallengeGeneratorImpl<CHash256>>(1);
 
     SchnorrProver prover(g, h, true);
     SchnorrProof proof;

--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -797,7 +797,7 @@ void CSigSharesManager::CollectSigSharesToRequest(std::unordered_map<NodeId, std
         }
         shuffledNodeIds.emplace_back(p.first);
     }
-    std::random_shuffle(shuffledNodeIds.begin(), shuffledNodeIds.end(), rnd);
+    Shuffle(shuffledNodeIds.begin(), shuffledNodeIds.end(), rnd);
 
     for (auto& nodeId : shuffledNodeIds) {
         auto& nodeState = nodeStates[nodeId];

--- a/src/llmq/quorums_utils.h
+++ b/src/llmq/quorums_utils.h
@@ -47,7 +47,7 @@ public:
         if (rndNodes.empty()) {
             return;
         }
-        std::random_shuffle(rndNodes.begin(), rndNodes.end(), rnd);
+        Shuffle(rndNodes.begin(), rndNodes.end(), rnd);
 
         size_t idx = 0;
         while (!rndNodes.empty() && cont()) {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -50,7 +50,6 @@
 
 #include "llmq/quorums_blockprocessor.h"
 
-using namespace std;
 #include <utility>
 
 //////////////////////////////////////////////////////////////////////////////
@@ -298,7 +297,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
 
     // Firo - MTP
     if (fMTP)
-        pblock->mtpHashData = make_shared<CMTPHashData>();
+        pblock->mtpHashData = std::make_shared<CMTPHashData>();
 
     CValidationState state;
     if (!TestBlockValidity(state, chainparams, *pblock, pindexPrev, false, false)) {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2989,7 +2989,7 @@ void CNode::CheckDandelionEmbargoes()
             // Embargo time is over, we did not "see" the transaction back in fluff phase,
             // so start fluffing/relaying it.
             CValidationState state;
-            shared_ptr<const CTransaction> ptx = txpools.getStemTxPool().get(iter->first);
+            std::shared_ptr<const CTransaction> ptx = txpools.getStemTxPool().get(iter->first);
             // If txn was not found in Stempool, then something went wrong,
             // Keep it embargoed for now.
             if (!ptx) {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2247,7 +2247,7 @@ void CConnman::ThreadOpenMasternodeConnections()
                 continue;
             }
 
-            std::random_shuffle(pending.begin(), pending.end());
+            Shuffle(pending.begin(), pending.end(), FastRandomContext());
             addr = pending.front();
         }
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -56,7 +56,7 @@ std::atomic<int64_t> nTimeBestReceived(0); // Used only to inform the wallet of 
 struct IteratorComparator
 {
     template<typename I>
-    bool operator()(const I& a, const I& b)
+    bool operator()(const I& a, const I& b) const
     {
         return &(*a) < &(*b);
     }

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -85,7 +85,7 @@ public:
             uint8_t numberOfProofBlocks;
             READWRITE(numberOfProofBlocks);
             for (uint8_t j=0; j<numberOfProofBlocks; j++) {
-                vector<uint8_t> mtpData(16, 0);
+                std::vector<uint8_t> mtpData(16, 0);
                 s.read((char *)mtpData.data(), 16);
                 nProofMTP[i].emplace_back(std::move(mtpData));
             }
@@ -145,7 +145,7 @@ public:
             READWRITE(reserved[0]);
             READWRITE(reserved[1]);
             if (ser_action.ForRead()) {
-                mtpHashData = make_shared<CMTPHashData>();
+                mtpHashData = std::make_shared<CMTPHashData>();
                 READWRITE(*mtpHashData);
             }
             else {

--- a/src/qt/lelantusmodel.cpp
+++ b/src/qt/lelantusmodel.cpp
@@ -58,65 +58,12 @@ AutoMintModel* LelantusModel::getAutoMintModel()
 std::pair<CAmount, CAmount> LelantusModel::getPrivateBalance()
 {
     size_t confirmed, unconfirmed;
-    return getPrivateBalance(confirmed, unconfirmed);
+    return pwalletMain->GetPrivateBalance(confirmed, unconfirmed);
 }
 
 std::pair<CAmount, CAmount> LelantusModel::getPrivateBalance(size_t &confirmed, size_t &unconfirmed)
 {
-    std::pair<CAmount, CAmount> balance = {0, 0};
-
-    confirmed = 0;
-    unconfirmed = 0;
-
-    auto zwallet = pwalletMain->zwallet.get();
-
-    if(!zwallet)
-        return balance;
-
-    auto coins = zwallet->GetTracker().ListLelantusMints(true, false, false);
-    for (auto const &c : coins) {
-
-        if (c.isUsed || c.isArchived || !c.isSeedCorrect) {
-            continue;
-        }
-
-        auto conf = c.nHeight > 0
-            ? chainActive.Height() - c.nHeight + 1 : 0;
-
-        if (conf >= ZC_MINT_CONFIRMATIONS) {
-            confirmed++;
-            balance.first += c.amount;
-        } else {
-            unconfirmed++;
-            balance.second += c.amount;
-        }
-    }
-
-    auto sigmaCoins = zwallet->GetTracker().ListMints(true, false, false);
-    for (auto const &c : sigmaCoins) {
-
-        if (c.isUsed || c.isArchived || !c.isSeedCorrect) {
-            continue;
-        }
-
-        CAmount amount;
-        if (!sigma::DenominationToInteger(c.denom, amount)) {
-            throw std::runtime_error("Fail to get denomination value");
-        }
-
-        auto conf = c.nHeight > 0
-            ? chainActive.Height() - c.nHeight + 1 : 0;
-
-        if (conf >= ZC_MINT_CONFIRMATIONS) {
-            confirmed++;
-            balance.first += amount;
-        } else {
-            unconfirmed++;
-            balance.second += amount;
-        }
-    }
-
-    return balance;
+    return pwalletMain->GetPrivateBalance(confirmed, unconfirmed);
 }
 
 bool LelantusModel::unlockWallet(SecureString const &passphase, size_t msecs)

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -1415,7 +1415,7 @@ void WalletModel::sigmaMint(const CAmount& n, const CCoinControl *coinControl)
             return sigma::PrivateCoin(sigmaParams, denom);
         });
 
-    vector<CHDMint> vDMints;
+    std::vector<CHDMint> vDMints;
     auto recipients = CWallet::CreateSigmaMintRecipients(privCoins, vDMints);
 
     CWalletTx wtx;

--- a/src/random.h
+++ b/src/random.h
@@ -111,9 +111,11 @@ public:
     /** Generate a random boolean. */
     bool randbool() { return randbits(1); }
 
-    uint32_t operator()(uint32_t nMax) {
-        return (uint32_t)randrange(nMax);
-    }
+    // Compatibility with the C++11 UniformRandomBitGenerator concept
+    typedef uint64_t result_type;
+    static constexpr uint64_t min() { return 0; }
+    static constexpr uint64_t max() { return std::numeric_limits<uint64_t>::max(); }
+    inline uint64_t operator()() noexcept { return rand64(); }
 };
 
 /** More efficient than using std::shuffle on a FastRandomContext.

--- a/src/random.h
+++ b/src/random.h
@@ -116,6 +116,29 @@ public:
     }
 };
 
+/** More efficient than using std::shuffle on a FastRandomContext.
+ *
+ * This is more efficient as std::shuffle will consume entropy in groups of
+ * 64 bits at the time and throw away most.
+ *
+ * This also works around a bug in libstdc++ std::shuffle that may cause
+ * type::operator=(type&&) to be invoked on itself, which the library's
+ * debug mode detects and panics on. This is a known issue, see
+ * https://stackoverflow.com/questions/22915325/avoiding-self-assignment-in-stdshuffle
+ */
+template<typename I, typename R>
+void Shuffle(I first, I last, R&& rng)
+{
+    while (first != last) {
+        size_t j = rng.randrange(last - first);
+        if (j) {
+            using std::swap;
+            swap(*first, *(first + j));
+        }
+        ++first;
+    }
+}
+
 /* Number of random bytes returned by GetOSRand.
  * When changing this constant make sure to change all call sites, and make
  * sure that the underlying OS APIs for all platforms support the number.

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -37,7 +37,6 @@
 
 #include <mutex>
 #include <condition_variable>
-using namespace std;
 
 struct CUpdatedBlock
 {
@@ -163,7 +162,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
 UniValue getblockcount(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 0)
-        throw runtime_error(
+        throw std::runtime_error(
             "getblockcount\n"
             "\nReturns the number of blocks in the longest blockchain.\n"
             "\nResult:\n"
@@ -180,7 +179,7 @@ UniValue getblockcount(const JSONRPCRequest& request)
 UniValue getbestblockhash(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 0)
-        throw runtime_error(
+        throw std::runtime_error(
             "getbestblockhash\n"
             "\nReturns the hash of the best (tip) block in the longest blockchain.\n"
             "\nResult:\n"
@@ -207,7 +206,7 @@ void RPCNotifyBlockChange(bool ibd, const CBlockIndex * pindex)
 UniValue waitfornewblock(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() > 1)
-        throw runtime_error(
+        throw std::runtime_error(
             "waitfornewblock (timeout)\n"
             "\nWaits for a specific new block and returns useful info about it.\n"
             "\nReturns the current block on timeout or exit.\n"
@@ -245,7 +244,7 @@ UniValue waitfornewblock(const JSONRPCRequest& request)
 UniValue waitforblock(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
-        throw runtime_error(
+        throw std::runtime_error(
             "waitforblock <blockhash> (timeout)\n"
             "\nWaits for a specific new block and returns useful info about it.\n"
             "\nReturns the current block on timeout or exit.\n"
@@ -287,7 +286,7 @@ UniValue waitforblock(const JSONRPCRequest& request)
 UniValue waitforblockheight(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
-        throw runtime_error(
+        throw std::runtime_error(
             "waitforblockheight <height> (timeout)\n"
             "\nWaits for (at least) block height and returns the height and hash\n"
             "of the current tip.\n"
@@ -329,7 +328,7 @@ UniValue waitforblockheight(const JSONRPCRequest& request)
 UniValue getdifficulty(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 0)
-        throw runtime_error(
+        throw std::runtime_error(
             "getdifficulty\n"
             "\nReturns the proof-of-work difficulty as a multiple of the minimum difficulty.\n"
             "\nResult:\n"
@@ -381,7 +380,7 @@ void entryToJSON(UniValue &info, const CTxMemPoolEntry &e)
     info.push_back(Pair("ancestorsize", e.GetSizeWithAncestors()));
     info.push_back(Pair("ancestorfees", e.GetModFeesWithAncestors()));
     const CTransaction& tx = e.GetTx();
-    set<string> setDepends;
+    std::set<std::string> setDepends;
     BOOST_FOREACH(const CTxIn& txin, tx.vin)
     {
         if (mempool.exists(txin.prevout.hash))
@@ -389,7 +388,7 @@ void entryToJSON(UniValue &info, const CTxMemPoolEntry &e)
     }
 
     UniValue depends(UniValue::VARR);
-    BOOST_FOREACH(const string& dep, setDepends)
+    BOOST_FOREACH(const std::string& dep, setDepends)
     {
         depends.push_back(dep);
     }
@@ -414,7 +413,7 @@ UniValue mempoolToJSON(bool fVerbose = false)
     }
     else
     {
-        vector<uint256> vtxid;
+        std::vector<uint256> vtxid;
         mempool.queryHashes(vtxid);
 
         UniValue a(UniValue::VARR);
@@ -428,7 +427,7 @@ UniValue mempoolToJSON(bool fVerbose = false)
 UniValue getrawmempool(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() > 1)
-        throw runtime_error(
+        throw std::runtime_error(
             "getrawmempool ( verbose )\n"
             "\nReturns all transaction ids in memory pool as a json array of string transaction ids.\n"
             "\nHint: use getmempoolentry to fetch a specific transaction from the mempool.\n"
@@ -460,7 +459,7 @@ UniValue getrawmempool(const JSONRPCRequest& request)
 UniValue clearmempool(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() > 0)
-        throw runtime_error(
+        throw std::runtime_error(
             "clearmempool\n"
             "\nClears the memory pool and returns a list of the removed transactions.\n"
             "\nResult:\n"
@@ -489,7 +488,7 @@ UniValue clearmempool(const JSONRPCRequest& request)
 UniValue getmempoolancestors(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2) {
-        throw runtime_error(
+        throw std::runtime_error(
             "getmempoolancestors txid (verbose)\n"
             "\nIf txid is in the mempool, returns all in-mempool ancestors.\n"
             "\nArguments:\n"
@@ -553,7 +552,7 @@ UniValue getmempoolancestors(const JSONRPCRequest& request)
 UniValue getmempooldescendants(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2) {
-        throw runtime_error(
+        throw std::runtime_error(
             "getmempooldescendants txid (verbose)\n"
             "\nIf txid is in the mempool, returns all in-mempool descendants.\n"
             "\nArguments:\n"
@@ -617,7 +616,7 @@ UniValue getmempooldescendants(const JSONRPCRequest& request)
 UniValue getmempoolentry(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 1) {
-        throw runtime_error(
+        throw std::runtime_error(
             "getmempoolentry txid\n"
             "\nReturns mempool data for given transaction\n"
             "\nArguments:\n"
@@ -650,7 +649,7 @@ UniValue getmempoolentry(const JSONRPCRequest& request)
 UniValue getblockhashes(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() < 3)
-        throw runtime_error(
+        throw std::runtime_error(
                 "getblockhashes timestamp\n"
                         "\nReturns array of hashes of blocks within the timestamp range provided.\n"
                         "\nArguments:\n"
@@ -684,7 +683,7 @@ UniValue getblockhashes(const JSONRPCRequest& request)
 UniValue getblockhash(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 1)
-        throw runtime_error(
+        throw std::runtime_error(
             "getblockhash height\n"
             "\nReturns hash of block in best-block-chain at height provided.\n"
             "\nArguments:\n"
@@ -709,7 +708,7 @@ UniValue getblockhash(const JSONRPCRequest& request)
 UniValue getblockheader(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
-        throw runtime_error(
+        throw std::runtime_error(
             "getblockheader \"hash\" ( verbose )\n"
             "\nIf verbose is false, returns a string that is serialized, hex-encoded data for blockheader 'hash'.\n"
             "If verbose is true, returns an Object with information about blockheader <hash>.\n"
@@ -768,7 +767,7 @@ UniValue getblockheader(const JSONRPCRequest& request)
 UniValue getblock(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
-        throw runtime_error(
+        throw std::runtime_error(
             "getblock \"blockhash\" ( verbose )\n"
             "\nIf verbose is false, returns a string that is serialized, hex-encoded data for block 'hash'.\n"
             "If verbose is true, returns an Object with information about block <hash>.\n"
@@ -918,7 +917,7 @@ static bool GetUTXOStats(CCoinsView *view, CCoinsStats &stats)
 UniValue pruneblockchain(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 1)
-        throw runtime_error(
+        throw std::runtime_error(
             "pruneblockchain\n"
             "\nArguments:\n"
             "1. \"height\"       (numeric, required) The block height to prune up to. May be set to a discrete height, or a unix timestamp\n"
@@ -967,7 +966,7 @@ UniValue pruneblockchain(const JSONRPCRequest& request)
 UniValue gettxoutsetinfo(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 0)
-        throw runtime_error(
+        throw std::runtime_error(
             "gettxoutsetinfo\n"
             "\nReturns statistics about the unspent transaction output set.\n"
             "Note this call may take some time.\n"
@@ -1007,7 +1006,7 @@ UniValue gettxoutsetinfo(const JSONRPCRequest& request)
 UniValue gettxout(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() < 2 || request.params.size() > 3)
-        throw runtime_error(
+        throw std::runtime_error(
             "gettxout \"txid\" n ( include_mempool )\n"
             "\nReturns details about an unspent transaction output.\n"
             "\nArguments:\n"
@@ -1089,7 +1088,7 @@ UniValue verifychain(const JSONRPCRequest& request)
     int nCheckLevel = GetArg("-checklevel", DEFAULT_CHECKLEVEL);
     int nCheckDepth = GetArg("-checkblocks", DEFAULT_CHECKBLOCKS);
     if (request.fHelp || request.params.size() > 2)
-        throw runtime_error(
+        throw std::runtime_error(
             "verifychain ( checklevel nblocks )\n"
             "\nVerifies blockchain database.\n"
             "\nArguments:\n"
@@ -1175,7 +1174,7 @@ void BIP9SoftForkDescPushBack(UniValue& bip9_softforks, const std::string &name,
 UniValue getblockchaininfo(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 0)
-        throw runtime_error(
+        throw std::runtime_error(
             "getblockchaininfo\n"
             "Returns an object containing various state info regarding blockchain processing.\n"
             "\nResult:\n"
@@ -1268,7 +1267,7 @@ struct CompareBlocksByHeight
 UniValue getchaintips(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 0)
-        throw runtime_error(
+        throw std::runtime_error(
             "getchaintips\n"
             "Return information about all known tips in the block tree,"
             " including the main chain as well as orphaned branches.\n"
@@ -1340,7 +1339,7 @@ UniValue getchaintips(const JSONRPCRequest& request)
         const int branchLen = block->nHeight - chainActive.FindFork(block)->nHeight;
         obj.push_back(Pair("branchlen", branchLen));
 
-        string status;
+        std::string status;
         if (chainActive.Contains(block)) {
             // This block is part of the currently active chain.
             status = "active";
@@ -1384,7 +1383,7 @@ UniValue mempoolInfoToJSON()
 UniValue getmempoolinfo(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 0)
-        throw runtime_error(
+        throw std::runtime_error(
             "getmempoolinfo\n"
             "\nReturns details on the active state of the TX memory pool.\n"
             "\nResult:\n"
@@ -1406,7 +1405,7 @@ UniValue getmempoolinfo(const JSONRPCRequest& request)
 UniValue preciousblock(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 1)
-        throw runtime_error(
+        throw std::runtime_error(
             "preciousblock \"blockhash\"\n"
             "\nTreats a block as if it were received before others with the same work.\n"
             "\nA later preciousblock call can override the effect of an earlier one.\n"
@@ -1444,7 +1443,7 @@ UniValue preciousblock(const JSONRPCRequest& request)
 UniValue invalidateblock(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 1)
-        throw runtime_error(
+        throw std::runtime_error(
             "invalidateblock \"blockhash\"\n"
             "\nPermanently marks a block as invalid, as if it violated a consensus rule.\n"
             "\nArguments:\n"
@@ -1482,7 +1481,7 @@ UniValue invalidateblock(const JSONRPCRequest& request)
 UniValue reconsiderblock(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 1)
-        throw runtime_error(
+        throw std::runtime_error(
             "reconsiderblock \"blockhash\"\n"
             "\nRemoves invalidity status of a block and its descendants, reconsider them for activation.\n"
             "This can be used to undo the effects of invalidateblock.\n"

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -13,8 +13,6 @@
 #include <boost/algorithm/string/case_conv.hpp> // for to_lower()
 #include <univalue.h>
 
-using namespace std;
-
 class CRPCConvertParam
 {
 public:
@@ -382,7 +380,7 @@ UniValue ParseNonRFCJSONValue(const std::string& strVal)
     UniValue jVal;
     if (!jVal.read(std::string("[")+strVal+std::string("]")) ||
         !jVal.isArray() || jVal.size()!=1)
-        throw runtime_error(string("Error parsing JSON:")+strVal);
+        throw std::runtime_error(std::string("Error parsing JSON:")+strVal);
     return jVal[0];
 }
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -33,8 +33,6 @@
 
 #include <univalue.h>
 
-using namespace std;
-
 extern CTxPoolAggregate txpools;
 
 /**
@@ -82,7 +80,7 @@ UniValue GetNetworkHashPS(int lookup, int height) {
 UniValue getnetworkhashps(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() > 2)
-        throw runtime_error(
+        throw std::runtime_error(
             "getnetworkhashps ( nblocks height )\n"
             "\nReturns the estimated network hashes per second based on the last n blocks.\n"
             "Pass in [blocks] to override # of blocks, -1 specifies since last difficulty change.\n"
@@ -166,7 +164,7 @@ UniValue generateBlocks(boost::shared_ptr<CReserveScript> coinbaseScript, int nG
 UniValue generate(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
-        throw runtime_error(
+        throw std::runtime_error(
             "generate nblocks ( maxtries )\n"
             "\nMine up to nblocks blocks immediately (before the RPC call returns)\n"
             "\nArguments:\n"
@@ -202,7 +200,7 @@ UniValue generate(const JSONRPCRequest& request)
 UniValue generatetoaddress(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() < 2 || request.params.size() > 3)
-        throw runtime_error(
+        throw std::runtime_error(
             "generatetoaddress nblocks address (maxtries)\n"
             "\nMine blocks immediately to a specified address (before the RPC call returns)\n"
             "\nArguments:\n"
@@ -236,7 +234,7 @@ UniValue generatetoaddress(const JSONRPCRequest& request)
 UniValue setgenerate(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
-        throw runtime_error(
+        throw std::runtime_error(
                 "setgenerate generate ( genproclimit )\n"
                         "\nSet 'generate' true or false to turn generation on or off.\n"
                         "Generation is limited to 'genproclimit' processors, 1 is unlimited.\n"
@@ -273,7 +271,7 @@ UniValue setgenerate(const JSONRPCRequest& request)
 UniValue getmininginfo(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 0)
-        throw runtime_error(
+        throw std::runtime_error(
             "getmininginfo\n"
             "\nReturns a json object containing mining-related information."
             "\nResult:\n"
@@ -317,7 +315,7 @@ UniValue getmininginfo(const JSONRPCRequest& request)
 UniValue prioritisetransaction(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 3)
-        throw runtime_error(
+        throw std::runtime_error(
             "prioritisetransaction <txid> <priority delta> <fee delta>\n"
             "Accepts the transaction into mined blocks at a higher (or lower) priority\n"
             "\nArguments:\n"
@@ -377,7 +375,7 @@ std::string gbt_vb_name(const Consensus::DeploymentPos pos) {
 UniValue getblocktemplate(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() > 1)
-        throw runtime_error(
+        throw std::runtime_error(
             "getblocktemplate ( TemplateRequest )\n"
             "\nIf the request parameters include a 'mode' key, that is used to explicitly select between the default 'template' request or a 'proposal'.\n"
             "It returns data needed to construct a block to work on.\n"
@@ -640,7 +638,7 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
     UniValue aCaps(UniValue::VARR); aCaps.push_back("proposal");
 
     UniValue transactions(UniValue::VARR);
-    map<uint256, int64_t> setTxIndex;
+    std::map<uint256, int64_t> setTxIndex;
     int i = 0;
     for (const auto& it : pblock->vtx) {
         const CTransaction& tx = *it;
@@ -828,7 +826,7 @@ protected:
 UniValue submitblock(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
-        throw runtime_error(
+        throw std::runtime_error(
             "submitblock \"hexdata\" ( \"jsonparametersobject\" )\n"
             "\nAttempts to submit new block to network.\n"
             "The 'jsonparametersobject' parameter is currently ignored.\n"
@@ -897,7 +895,7 @@ UniValue submitblock(const JSONRPCRequest& request)
 UniValue estimatefee(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 1)
-        throw runtime_error(
+        throw std::runtime_error(
             "estimatefee nblocks\n"
             "\nEstimates the approximate fee per kilobyte needed for a transaction to begin\n"
             "confirmation within nblocks blocks. Uses virtual transaction size of transaction\n"
@@ -931,7 +929,7 @@ UniValue estimatefee(const JSONRPCRequest& request)
 UniValue estimatepriority(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 1)
-        throw runtime_error(
+        throw std::runtime_error(
             "estimatepriority nblocks\n"
             "\nDEPRECATED. Estimates the approximate priority a zero-fee transaction needs to begin\n"
             "confirmation within nblocks blocks.\n"
@@ -958,7 +956,7 @@ UniValue estimatepriority(const JSONRPCRequest& request)
 UniValue estimatesmartfee(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 1)
-        throw runtime_error(
+        throw std::runtime_error(
             "estimatesmartfee nblocks\n"
             "\nWARNING: This interface is unstable and may disappear or change!\n"
             "\nEstimates the approximate fee per kilobyte needed for a transaction to begin\n"
@@ -995,7 +993,7 @@ UniValue estimatesmartfee(const JSONRPCRequest& request)
 UniValue estimatesmartpriority(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 1)
-        throw runtime_error(
+        throw std::runtime_error(
             "estimatesmartpriority nblocks\n"
             "\nDEPRECATED. WARNING: This interface is unstable and may disappear or change!\n"
             "\nEstimates the approximate priority a zero-fee transaction needs to begin\n"

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -29,8 +29,6 @@
 
 #include <univalue.h>
 
-using namespace std;
-
 /**
  * @note Do not add or change anything in the information returned by this
  * method. `getinfo` exists for backwards-compatibility only. It combines
@@ -47,7 +45,7 @@ using namespace std;
 UniValue getinfo(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 0)
-        throw runtime_error(
+        throw std::runtime_error(
             "getinfo\n"
             "\nDEPRECATED. Returns an object containing various state info.\n"
             "\nResult:\n"
@@ -98,7 +96,7 @@ UniValue getinfo(const JSONRPCRequest& request)
     obj.push_back(Pair("timeoffset",    GetTimeOffset()));
     if(g_connman)
         obj.push_back(Pair("connections",   (int)g_connman->GetNodeCount(CConnman::CONNECTIONS_ALL)));
-    obj.push_back(Pair("proxy",         (proxy.IsValid() ? proxy.proxy.ToStringIPPort() : string())));
+    obj.push_back(Pair("proxy",         (proxy.IsValid() ? proxy.proxy.ToStringIPPort() : std::string())));
     obj.push_back(Pair("difficulty",    (double)GetDifficulty()));
     obj.push_back(Pair("testnet",       Params().NetworkIDString() == CBaseChainParams::TESTNET));
 #ifdef ENABLE_WALLET
@@ -164,7 +162,7 @@ public:
 UniValue validateaddress(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 1)
-        throw runtime_error(
+        throw std::runtime_error(
             "validateaddress \"address\"\n"
             "\nReturn information about the given Firo address.\n"
             "\nArguments:\n"
@@ -205,7 +203,7 @@ UniValue validateaddress(const JSONRPCRequest& request)
     if (isValid)
     {
         CTxDestination dest = address.Get();
-        string currentAddress = address.ToString();
+        std::string currentAddress = address.ToString();
         ret.push_back(Pair("address", currentAddress));
 
         CScript scriptPubKey = GetScriptForDestination(dest);
@@ -253,13 +251,13 @@ CScript _createmultisig_redeemScript(CWallet * const pwallet, const UniValue& pa
 
     // Gather public keys
     if (nRequired < 1)
-        throw runtime_error("a multisignature address must require at least one key to redeem");
+        throw std::runtime_error("a multisignature address must require at least one key to redeem");
     if ((int)keys.size() < nRequired)
-        throw runtime_error(
+        throw std::runtime_error(
             strprintf("not enough keys supplied "
                       "(got %u keys, but need at least %d to redeem)", keys.size(), nRequired));
     if (keys.size() > 16)
-        throw runtime_error("Number of addresses involved in the multisignature address creation > 16\nReduce the number");
+        throw std::runtime_error("Number of addresses involved in the multisignature address creation > 16\nReduce the number");
     std::vector<CPubKey> pubkeys;
     pubkeys.resize(keys.size());
     for (unsigned int i = 0; i < keys.size(); i++)
@@ -271,15 +269,15 @@ CScript _createmultisig_redeemScript(CWallet * const pwallet, const UniValue& pa
         if (pwallet && address.IsValid()) {
             CKeyID keyID;
             if (!address.GetKeyID(keyID))
-                throw runtime_error(
+                throw std::runtime_error(
                     strprintf("%s does not refer to a key",ks));
             CPubKey vchPubKey;
             if (!pwallet->GetPubKey(keyID, vchPubKey)) {
-                throw runtime_error(
+                throw std::runtime_error(
                     strprintf("no full public key for address %s",ks));
             }
             if (!vchPubKey.IsFullyValid())
-                throw runtime_error(" Invalid public key: "+ks);
+                throw std::runtime_error(" Invalid public key: "+ks);
             pubkeys[i] = vchPubKey;
         }
 
@@ -290,18 +288,18 @@ CScript _createmultisig_redeemScript(CWallet * const pwallet, const UniValue& pa
         {
             CPubKey vchPubKey(ParseHex(ks));
             if (!vchPubKey.IsFullyValid())
-                throw runtime_error(" Invalid public key: "+ks);
+                throw std::runtime_error(" Invalid public key: "+ks);
             pubkeys[i] = vchPubKey;
         }
         else
         {
-            throw runtime_error(" Invalid public key: "+ks);
+            throw std::runtime_error(" Invalid public key: "+ks);
         }
     }
     CScript result = GetScriptForMultisig(nRequired, pubkeys);
 
     if (result.size() > MAX_SCRIPT_ELEMENT_SIZE)
-        throw runtime_error(
+        throw std::runtime_error(
                 strprintf("redeemScript exceeds size limit: %d > %d", result.size(), MAX_SCRIPT_ELEMENT_SIZE));
 
     return result;
@@ -354,7 +352,7 @@ UniValue createmultisig(const JSONRPCRequest& request)
 
     if (request.fHelp || request.params.size() < 2 || request.params.size() > 2)
     {
-        string msg = "createmultisig nrequired [\"key\",...]\n"
+        std::string msg = "createmultisig nrequired [\"key\",...]\n"
             "\nCreates a multi-signature address with n signature of m keys required.\n"
             "It returns a json object with the address and redeemScript.\n"
 
@@ -378,7 +376,7 @@ UniValue createmultisig(const JSONRPCRequest& request)
             "\nAs a json rpc call\n"
             + HelpExampleRpc("createmultisig", "2, \"[\\\"16sSauSf5pF2UkUwvKGq4qjNRzBZYqgEL5\\\",\\\"171sgjn4YtPu27adkKGrdDwzRTxnRkBfKV\\\"]\"")
         ;
-        throw runtime_error(msg);
+        throw std::runtime_error(msg);
     }
 
     // Construct using pay-to-script-hash:
@@ -396,7 +394,7 @@ UniValue createmultisig(const JSONRPCRequest& request)
 UniValue verifymessage(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 3)
-        throw runtime_error(
+        throw std::runtime_error(
             "verifymessage \"address\" \"signature\" \"message\"\n"
             "\nVerify a signed message\n"
             "\nArguments:\n"
@@ -418,9 +416,9 @@ UniValue verifymessage(const JSONRPCRequest& request)
 
     LOCK(cs_main);
 
-    string strAddress  = request.params[0].get_str();
-    string strSign     = request.params[1].get_str();
-    string strMessage  = request.params[2].get_str();
+    std::string strAddress  = request.params[0].get_str();
+    std::string strSign     = request.params[1].get_str();
+    std::string strMessage  = request.params[2].get_str();
 
     CBitcoinAddress addr(strAddress);
     if (!addr.IsValid())
@@ -431,7 +429,7 @@ UniValue verifymessage(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_TYPE_ERROR, "Address does not refer to key");
 
     bool fInvalid = false;
-    vector<unsigned char> vchSig = DecodeBase64(strSign.c_str(), &fInvalid);
+    std::vector<unsigned char> vchSig = DecodeBase64(strSign.c_str(), &fInvalid);
 
     if (fInvalid)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Malformed base64 encoding");
@@ -450,7 +448,7 @@ UniValue verifymessage(const JSONRPCRequest& request)
 UniValue signmessagewithprivkey(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 2)
-        throw runtime_error(
+        throw std::runtime_error(
             "signmessagewithprivkey \"privkey\" \"message\"\n"
             "\nSign a message with the private key of an address\n"
             "\nArguments:\n"
@@ -467,8 +465,8 @@ UniValue signmessagewithprivkey(const JSONRPCRequest& request)
             + HelpExampleRpc("signmessagewithprivkey", "\"privkey\", \"my message\"")
         );
 
-    string strPrivkey = request.params[0].get_str();
-    string strMessage = request.params[1].get_str();
+    std::string strPrivkey = request.params[0].get_str();
+    std::string strMessage = request.params[1].get_str();
 
     CBitcoinSecret vchSecret;
     bool fGood = vchSecret.SetString(strPrivkey);
@@ -482,7 +480,7 @@ UniValue signmessagewithprivkey(const JSONRPCRequest& request)
     ss << strMessageMagic;
     ss << strMessage;
 
-    vector<unsigned char> vchSig;
+    std::vector<unsigned char> vchSig;
     if (!key.SignCompact(ss.GetHash(), vchSig))
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Sign failed");
 
@@ -492,7 +490,7 @@ UniValue signmessagewithprivkey(const JSONRPCRequest& request)
 UniValue setmocktime(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 1)
-        throw runtime_error(
+        throw std::runtime_error(
             "setmocktime timestamp\n"
             "\nSet the local time to given timestamp (-regtest only)\n"
             "\nArguments:\n"
@@ -501,7 +499,7 @@ UniValue setmocktime(const JSONRPCRequest& request)
         );
 
     if (!Params().MineBlocksOnDemand())
-        throw runtime_error("setmocktime for regression testing (-regtest mode) only");
+        throw std::runtime_error("setmocktime for regression testing (-regtest mode) only");
 
     // For now, don't change mocktime if we're in the middle of validation, as
     // this could have an effect on mempool time-based eviction, as well as
@@ -645,7 +643,7 @@ bool timestampSort(std::pair<CMempoolAddressDeltaKey, CMempoolAddressDelta> a,
 UniValue getaddressmempool(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 1)
-        throw runtime_error(
+        throw std::runtime_error(
                 "getaddressmempool\n"
                         "\nReturns all mempool deltas for an address (requires addressindex to be enabled).\n"
                         "\nArguments:\n"
@@ -715,7 +713,7 @@ UniValue getaddressmempool(const JSONRPCRequest& request)
 UniValue getaddressutxos(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 1)
-        throw runtime_error(
+        throw std::runtime_error(
                 "getaddressutxos\n"
                         "\nReturns all unspent outputs for an address (requires addressindex to be enabled).\n"
                         "\nArguments:\n"
@@ -782,7 +780,7 @@ UniValue getaddressutxos(const JSONRPCRequest& request)
 UniValue getaddressdeltas(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 1 || !request.params[0].isObject())
-        throw runtime_error(
+        throw std::runtime_error(
                 "getaddressdeltas\n"
                         "\nReturns all changes for an address (requires addressindex to be enabled).\n"
                         "\nArguments:\n"
@@ -870,7 +868,7 @@ UniValue getaddressdeltas(const JSONRPCRequest& request)
 UniValue getaddressbalance(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 1)
-        throw runtime_error(
+        throw std::runtime_error(
                 "getaddressbalance\n"
                         "\nReturns the balance for an address(es) (requires addressindex to be enabled).\n"
                         "\nArguments:\n"
@@ -926,7 +924,7 @@ UniValue getaddressbalance(const JSONRPCRequest& request)
 UniValue getanonymityset(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 2)
-        throw runtime_error(
+        throw std::runtime_error(
                 "getanonymityset\n"
                         "\nReturns the anonymity set and latest block hash.\n"
                         "\nArguments:\n"
@@ -950,7 +948,7 @@ UniValue getanonymityset(const JSONRPCRequest& request)
         intDenom = std::stol(request.params[0].get_str());
         coinGroupId = std::stol(request.params[1].get_str());
     } catch (std::logic_error const & e) {
-        throw runtime_error(std::string("An exception occurred while parsing parameters: ") + e.what());
+        throw std::runtime_error(std::string("An exception occurred while parsing parameters: ") + e.what());
     }
 
     sigma::CoinDenomination denomination;
@@ -987,7 +985,7 @@ UniValue getanonymityset(const JSONRPCRequest& request)
 UniValue getmintmetadata(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 1)
-        throw runtime_error(
+        throw std::runtime_error(
                 "getmintmetadata\n"
                         "\nReturns the anonymity set id and nHeight of mint.\n"
                         "\nArguments:\n"
@@ -1014,7 +1012,7 @@ UniValue getmintmetadata(const JSONRPCRequest& request)
     sigma::CSigmaState* sigmaState = sigma::CSigmaState::GetState();
     UniValue ret(UniValue::VARR);
     for(UniValue const & mintData : mintValues.getValues()){
-        vector<unsigned char> serializedCoin = ParseHex(find_value(mintData, "pubcoin").get_str().c_str());
+        std::vector<unsigned char> serializedCoin = ParseHex(find_value(mintData, "pubcoin").get_str().c_str());
 
         secp_primitives::GroupElement pubCoin;
         pubCoin.deserialize(serializedCoin.data());
@@ -1029,7 +1027,7 @@ UniValue getmintmetadata(const JSONRPCRequest& request)
             coinHeightAndId = sigmaState->GetMintedCoinHeightAndId(sigma::PublicCoin(pubCoin, denomination));
         }
         UniValue metaData(UniValue::VOBJ);
-        metaData.pushKV(to_string(coinHeightAndId.first), coinHeightAndId.second);
+        metaData.pushKV(std::to_string(coinHeightAndId.first), coinHeightAndId.second);
         ret.push_back(metaData);
     }
     return ret;
@@ -1038,7 +1036,7 @@ UniValue getmintmetadata(const JSONRPCRequest& request)
 UniValue getusedcoinserials(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 0)
-        throw runtime_error(
+        throw std::runtime_error(
                 "getusedcoinserials\n"
                 "\nReturns the set of used coin serial.\n"
                 "\nResult:\n"
@@ -1067,7 +1065,7 @@ UniValue getusedcoinserials(const JSONRPCRequest& request)
 UniValue getlatestcoinids(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 0)
-        throw runtime_error(
+        throw std::runtime_error(
                 "getlatestcoinids\n"
                 "\nReturns the set of used coin serial.\n"
                 "\nResult:\n"
@@ -1107,7 +1105,7 @@ UniValue getlatestcoinids(const JSONRPCRequest& request)
 UniValue getaddresstxids(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 1)
-        throw runtime_error(
+        throw std::runtime_error(
                 "getaddresstxids\n"
                         "\nReturns the txids for an address(es) (requires addressindex to be enabled).\n"
                         "\nArguments:\n"
@@ -1191,7 +1189,7 @@ UniValue getspentinfo(const JSONRPCRequest& request)
 {
 
     if (request.fHelp || request.params.size() != 1 || !request.params[0].isObject())
-        throw runtime_error(
+        throw std::runtime_error(
                 "getspentinfo\n"
                         "\nReturns the txid and index where an output is spent.\n"
                         "\nArguments:\n"
@@ -1238,7 +1236,7 @@ UniValue getspentinfo(const JSONRPCRequest& request)
 UniValue gettotalsupply(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 0)
-        throw runtime_error(
+        throw std::runtime_error(
                 "gettotalsupply\n"
                         "\nReturns the total coin amount produced in the coinbase transactions up until the latest block.\n"
                         "\nArguments: none\n"
@@ -1265,7 +1263,7 @@ UniValue gettotalsupply(const JSONRPCRequest& request)
 UniValue getinfoex(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 0)
-        throw runtime_error(
+        throw std::runtime_error(
             "getinfoex\n"
             "An engineering version of getinfo. Takes significant time to finish.\n"
             "Returns an object containing various state info.\n"
@@ -1325,7 +1323,7 @@ UniValue getmemoryinfo(const JSONRPCRequest& request)
      * as users will undoubtedly confuse it with the other "memory pool"
      */
     if (request.fHelp || request.params.size() != 0)
-        throw runtime_error(
+        throw std::runtime_error(
             "getmemoryinfo\n"
             "Returns an object containing information about memory usage.\n"
             "\nResult:\n"
@@ -1351,7 +1349,7 @@ UniValue getmemoryinfo(const JSONRPCRequest& request)
 UniValue echo(const JSONRPCRequest& request)
 {
     if (request.fHelp)
-        throw runtime_error(
+        throw std::runtime_error(
             "echo|echojson \"message\" ...\n"
             "\nSimply echo back the input arguments. This command is for testing.\n"
             "\nThe difference between echo and echojson is that echojson has argument conversion enabled in the client-side table in"

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -23,12 +23,10 @@
 
 #include <univalue.h>
 
-using namespace std;
-
 UniValue getconnectioncount(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 0)
-        throw runtime_error(
+        throw std::runtime_error(
             "getconnectioncount\n"
             "\nReturns the number of connections to other nodes.\n"
             "\nResult:\n"
@@ -47,7 +45,7 @@ UniValue getconnectioncount(const JSONRPCRequest& request)
 UniValue ping(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 0)
-        throw runtime_error(
+        throw std::runtime_error(
             "ping\n"
             "\nRequests that a ping be sent to all other nodes, to measure ping time.\n"
             "Results provided in getpeerinfo, pingtime and pingwait fields are decimal seconds.\n"
@@ -70,7 +68,7 @@ UniValue ping(const JSONRPCRequest& request)
 UniValue getpeerinfo(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 0)
-        throw runtime_error(
+        throw std::runtime_error(
             "getpeerinfo\n"
             "\nReturns data about each connected network node as a json array of objects.\n"
             "\nResult:\n"
@@ -125,7 +123,7 @@ UniValue getpeerinfo(const JSONRPCRequest& request)
     if(!g_connman)
         throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
 
-    vector<CNodeStats> vstats;
+    std::vector<CNodeStats> vstats;
     g_connman->GetNodeStats(vstats);
 
     UniValue ret(UniValue::VARR);
@@ -197,12 +195,12 @@ UniValue getpeerinfo(const JSONRPCRequest& request)
 
 UniValue addnode(const JSONRPCRequest& request)
 {
-    string strCommand;
+    std::string strCommand;
     if (request.params.size() == 2)
         strCommand = request.params[1].get_str();
     if (request.fHelp || request.params.size() != 2 ||
         (strCommand != "onetry" && strCommand != "add" && strCommand != "remove"))
-        throw runtime_error(
+        throw std::runtime_error(
             "addnode \"node\" \"add|remove|onetry\"\n"
             "\nAttempts add or remove a node from the addnode list.\n"
             "Or try a connection to a node once.\n"
@@ -217,7 +215,7 @@ UniValue addnode(const JSONRPCRequest& request)
     if(!g_connman)
         throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
 
-    string strNode = request.params[0].get_str();
+    std::string strNode = request.params[0].get_str();
 
     if (strCommand == "onetry")
     {
@@ -266,7 +264,7 @@ UniValue disconnectnode(const JSONRPCRequest& request)
 UniValue getaddednodeinfo(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() > 1)
-        throw runtime_error(
+        throw std::runtime_error(
             "getaddednodeinfo ( \"node\" )\n"
             "\nReturns information about the given added node, or all added nodes\n"
             "(note that onetry addnodes are not listed here)\n"
@@ -334,7 +332,7 @@ UniValue getaddednodeinfo(const JSONRPCRequest& request)
 UniValue getnettotals(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() > 0)
-        throw runtime_error(
+        throw std::runtime_error(
             "getnettotals\n"
             "\nReturns information about network traffic, including bytes in, bytes out,\n"
             "and current time.\n"
@@ -390,7 +388,7 @@ static UniValue GetNetworksInfo()
         obj.push_back(Pair("name", GetNetworkName(network)));
         obj.push_back(Pair("limited", IsLimited(network)));
         obj.push_back(Pair("reachable", IsReachable(network)));
-        obj.push_back(Pair("proxy", proxy.IsValid() ? proxy.proxy.ToStringIPPort() : string()));
+        obj.push_back(Pair("proxy", proxy.IsValid() ? proxy.proxy.ToStringIPPort() : std::string()));
         obj.push_back(Pair("proxy_randomize_credentials", proxy.randomize_credentials));
         networks.push_back(obj);
     }
@@ -400,7 +398,7 @@ static UniValue GetNetworksInfo()
 UniValue getnetworkinfo(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 0)
-        throw runtime_error(
+        throw std::runtime_error(
             "getnetworkinfo\n"
             "Returns an object containing various state info regarding P2P networking.\n"
             "\nResult:\n"
@@ -475,12 +473,12 @@ UniValue getnetworkinfo(const JSONRPCRequest& request)
 
 UniValue setban(const JSONRPCRequest& request)
 {
-    string strCommand;
+    std::string strCommand;
     if (request.params.size() >= 2)
         strCommand = request.params[1].get_str();
     if (request.fHelp || request.params.size() < 2 ||
         (strCommand != "add" && strCommand != "remove"))
-        throw runtime_error(
+        throw std::runtime_error(
                             "setban \"subnet\" \"add|remove\" (bantime) (absolute)\n"
                             "\nAttempts add or remove a IP/Subnet from the banned list.\n"
                             "\nArguments:\n"
@@ -500,7 +498,7 @@ UniValue setban(const JSONRPCRequest& request)
     CNetAddr netAddr;
     bool isSubnet = false;
 
-    if (request.params[0].get_str().find("/") != string::npos)
+    if (request.params[0].get_str().find("/") != std::string::npos)
         isSubnet = true;
 
     if (!isSubnet) {
@@ -540,7 +538,7 @@ UniValue setban(const JSONRPCRequest& request)
 UniValue listbanned(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 0)
-        throw runtime_error(
+        throw std::runtime_error(
                             "listbanned\n"
                             "\nList all banned IPs/Subnets.\n"
                             "\nExamples:\n"
@@ -573,7 +571,7 @@ UniValue listbanned(const JSONRPCRequest& request)
 UniValue clearbanned(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 0)
-        throw runtime_error(
+        throw std::runtime_error(
                             "clearbanned\n"
                             "\nClear all banned IPs.\n"
                             "\nExamples:\n"
@@ -591,7 +589,7 @@ UniValue clearbanned(const JSONRPCRequest& request)
 UniValue setnetworkactive(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 1) {
-        throw runtime_error(
+        throw std::runtime_error(
             "setnetworkactive true|false\n"
             "\nDisable/enable all p2p network activity.\n"
             "\nArguments:\n"

--- a/src/rpc/protocol.cpp
+++ b/src/rpc/protocol.cpp
@@ -15,8 +15,6 @@
 #include <stdint.h>
 #include <fstream>
 
-using namespace std;
-
 /**
  * JSON-RPC protocol.  Bitcoin speaks version 1.0 for maximum compatibility,
  * but uses JSON-RPC 1.1/2.0 standards for parts of the 1.0 standard that were
@@ -26,7 +24,7 @@ using namespace std;
  * 1.2 spec: http://jsonrpc.org/historical/json-rpc-over-http.html
  */
 
-UniValue JSONRPCRequestObj(const string& strMethod, const UniValue& params, const UniValue& id)
+UniValue JSONRPCRequestObj(const std::string& strMethod, const UniValue& params, const UniValue& id)
 {
     UniValue request(UniValue::VOBJ);
     request.push_back(Pair("method", strMethod));
@@ -47,13 +45,13 @@ UniValue JSONRPCReplyObj(const UniValue& result, const UniValue& error, const Un
     return reply;
 }
 
-string JSONRPCReply(const UniValue& result, const UniValue& error, const UniValue& id)
+std::string JSONRPCReply(const UniValue& result, const UniValue& error, const UniValue& id)
 {
     UniValue reply = JSONRPCReplyObj(result, error, id);
     return reply.write() + "\n";
 }
 
-UniValue JSONRPCError(int code, const string& message)
+UniValue JSONRPCError(int code, const std::string& message)
 {
     UniValue error(UniValue::VOBJ);
     error.push_back(Pair("code", code));

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -40,8 +40,6 @@
 #include "evo/providertx.h"
 #include "lelantus.h"
 
-using namespace std;
-
 namespace {
     template<class Tx>
     void ExtraPayloadToJson(const CTransaction& tx, const char * jsonId, UniValue & entry) {
@@ -57,7 +55,7 @@ namespace {
 void ScriptPubKeyToJSON(const CScript& scriptPubKey, UniValue& out, bool fIncludeHex)
 {
     txnouttype type;
-    vector<CTxDestination> addresses;
+    std::vector<CTxDestination> addresses;
     int nRequired;
 
     out.push_back(Pair("asm", ScriptToAsmStr(scriptPubKey)));
@@ -234,7 +232,7 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
 UniValue getrawtransaction(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
-        throw runtime_error(
+        throw std::runtime_error(
             "getrawtransaction \"txid\" ( verbose )\n"
 
             "\nNOTE: By default this function only works for mempool transactions. If the -txindex option is\n"
@@ -332,7 +330,7 @@ UniValue getrawtransaction(const JSONRPCRequest& request)
             : "No such mempool transaction. Use -txindex to enable blockchain transaction queries") +
             ". Use gettransaction for wallet transactions.");
 
-    string strHex = EncodeHexTx(*tx, RPCSerializationFlags());
+    std::string strHex = EncodeHexTx(*tx, RPCSerializationFlags());
 
     if (!fVerbose)
         return strHex;
@@ -346,7 +344,7 @@ UniValue getrawtransaction(const JSONRPCRequest& request)
 UniValue gettxoutproof(const JSONRPCRequest& request)
 {
     if (request.fHelp || (request.params.size() != 1 && request.params.size() != 2))
-        throw runtime_error(
+        throw std::runtime_error(
             "gettxoutproof [\"txid\",...] ( blockhash )\n"
             "\nReturns a hex-encoded proof that \"txid\" was included in a block.\n"
             "\nNOTE: By default this function only works sometimes. This is when there is an\n"
@@ -364,16 +362,16 @@ UniValue gettxoutproof(const JSONRPCRequest& request)
             "\"data\"           (string) A string that is a serialized, hex-encoded data for the proof.\n"
         );
 
-    set<uint256> setTxids;
+    std::set<uint256> setTxids;
     uint256 oneTxid;
     UniValue txids = request.params[0].get_array();
     for (unsigned int idx = 0; idx < txids.size(); idx++) {
         const UniValue& txid = txids[idx];
         if (txid.get_str().length() != 64 || !IsHex(txid.get_str()))
-            throw JSONRPCError(RPC_INVALID_PARAMETER, string("Invalid txid ")+txid.get_str());
+            throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("Invalid txid ")+txid.get_str());
         uint256 hash(uint256S(txid.get_str()));
         if (setTxids.count(hash))
-            throw JSONRPCError(RPC_INVALID_PARAMETER, string("Invalid parameter, duplicated txid: ")+txid.get_str());
+            throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("Invalid parameter, duplicated txid: ")+txid.get_str());
        setTxids.insert(hash);
        oneTxid = hash;
     }
@@ -427,7 +425,7 @@ UniValue gettxoutproof(const JSONRPCRequest& request)
 UniValue verifytxoutproof(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 1)
-        throw runtime_error(
+        throw std::runtime_error(
             "verifytxoutproof \"proof\"\n"
             "\nVerifies that a proof points to a transaction in a block, returning the transaction it commits to\n"
             "and throwing an RPC error if the block is not in our best chain\n"
@@ -443,8 +441,8 @@ UniValue verifytxoutproof(const JSONRPCRequest& request)
 
     UniValue res(UniValue::VARR);
 
-    vector<uint256> vMatch;
-    vector<unsigned int> vIndex;
+    std::vector<uint256> vMatch;
+    std::vector<unsigned int> vIndex;
     if (merkleBlock.txn.ExtractMatches(vMatch, vIndex) != merkleBlock.header.hashMerkleRoot)
         return res;
 
@@ -461,7 +459,7 @@ UniValue verifytxoutproof(const JSONRPCRequest& request)
 UniValue createrawtransaction(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() < 2 || request.params.size() > 3)
-        throw runtime_error(
+        throw std::runtime_error(
             "createrawtransaction [{\"txid\":\"id\",\"vout\":n},...] {\"address\":amount,\"data\":\"hex\",...} ( locktime )\n"
             "\nCreate a transaction spending the given inputs and creating new outputs.\n"
             "Outputs can be addresses or data.\n"
@@ -542,9 +540,9 @@ UniValue createrawtransaction(const JSONRPCRequest& request)
         rawTx.vin.push_back(in);
     }
 
-    set<CBitcoinAddress> setAddress;
-    vector<string> addrList = sendTo.getKeys();
-    BOOST_FOREACH(const string& name_, addrList) {
+    std::set<CBitcoinAddress> setAddress;
+    std::vector<std::string> addrList = sendTo.getKeys();
+    BOOST_FOREACH(const std::string& name_, addrList) {
 
         if (name_ == "data") {
             std::vector<unsigned char> data = ParseHexV(sendTo[name_].getValStr(),"Data");
@@ -554,10 +552,10 @@ UniValue createrawtransaction(const JSONRPCRequest& request)
         } else {
             CBitcoinAddress address(name_);
             if (!address.IsValid())
-                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, string("Invalid Firo address: ")+name_);
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid Firo address: ")+name_);
 
             if (setAddress.count(address))
-                throw JSONRPCError(RPC_INVALID_PARAMETER, string("Invalid parameter, duplicated address: ")+name_);
+                throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("Invalid parameter, duplicated address: ")+name_);
             setAddress.insert(address);
 
             CScript scriptPubKey = GetScriptForDestination(address.Get());
@@ -574,7 +572,7 @@ UniValue createrawtransaction(const JSONRPCRequest& request)
 UniValue decoderawtransaction(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 1)
-        throw runtime_error(
+        throw std::runtime_error(
             "decoderawtransaction \"hexstring\"\n"
             "\nReturn a JSON object representing the serialized, hex-encoded transaction.\n"
 
@@ -643,7 +641,7 @@ UniValue decoderawtransaction(const JSONRPCRequest& request)
 UniValue decodescript(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 1)
-        throw runtime_error(
+        throw std::runtime_error(
             "decodescript \"hexstring\"\n"
             "\nDecode a hex-encoded script.\n"
             "\nArguments:\n"
@@ -670,7 +668,7 @@ UniValue decodescript(const JSONRPCRequest& request)
     UniValue r(UniValue::VOBJ);
     CScript script;
     if (request.params[0].get_str().size() > 0){
-        vector<unsigned char> scriptData(ParseHexV(request.params[0], "argument"));
+        std::vector<unsigned char> scriptData(ParseHexV(request.params[0], "argument"));
         script = CScript(scriptData.begin(), scriptData.end());
     } else {
         // Empty scripts are valid
@@ -708,7 +706,7 @@ UniValue signrawtransaction(const JSONRPCRequest& request)
 #endif
 
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 4)
-        throw runtime_error(
+        throw std::runtime_error(
             "signrawtransaction \"hexstring\" ( [{\"txid\":\"id\",\"vout\":n,\"scriptPubKey\":\"hex\",\"redeemScript\":\"hex\"},...] [\"privatekey1\",...] sighashtype )\n"
             "\nSign inputs for raw transaction (serialized, hex-encoded).\n"
             "The second optional argument (may be null) is an array of previous transaction outputs that\n"
@@ -773,9 +771,9 @@ UniValue signrawtransaction(const JSONRPCRequest& request)
 #endif
     RPCTypeCheck(request.params, boost::assign::list_of(UniValue::VSTR)(UniValue::VARR)(UniValue::VARR)(UniValue::VSTR), true);
 
-    vector<unsigned char> txData(ParseHexV(request.params[0], "argument 1"));
+    std::vector<unsigned char> txData(ParseHexV(request.params[0], "argument 1"));
     CDataStream ssData(txData, SER_NETWORK, PROTOCOL_VERSION);
-    vector<CMutableTransaction> txVariants;
+    std::vector<CMutableTransaction> txVariants;
     while (!ssData.empty()) {
         try {
             CMutableTransaction tx;
@@ -890,7 +888,7 @@ UniValue signrawtransaction(const JSONRPCRequest& request)
                     });
                 UniValue v = find_value(prevOut, "redeemScript");
                 if (!v.isNull()) {
-                    vector<unsigned char> rsData(ParseHexV(v, "redeemScript"));
+                    std::vector<unsigned char> rsData(ParseHexV(v, "redeemScript"));
                     CScript redeemScript(rsData.begin(), rsData.end());
                     tempKeystore.AddCScript(redeemScript);
                 }
@@ -906,16 +904,16 @@ UniValue signrawtransaction(const JSONRPCRequest& request)
 
     int nHashType = SIGHASH_ALL;
     if (request.params.size() > 3 && !request.params[3].isNull()) {
-        static map<string, int> mapSigHashValues =
+        static std::map<std::string, int> mapSigHashValues =
             boost::assign::map_list_of
-            (string("ALL"), int(SIGHASH_ALL))
-            (string("ALL|ANYONECANPAY"), int(SIGHASH_ALL|SIGHASH_ANYONECANPAY))
-            (string("NONE"), int(SIGHASH_NONE))
-            (string("NONE|ANYONECANPAY"), int(SIGHASH_NONE|SIGHASH_ANYONECANPAY))
-            (string("SINGLE"), int(SIGHASH_SINGLE))
-            (string("SINGLE|ANYONECANPAY"), int(SIGHASH_SINGLE|SIGHASH_ANYONECANPAY))
+            (std::string("ALL"), int(SIGHASH_ALL))
+            (std::string("ALL|ANYONECANPAY"), int(SIGHASH_ALL|SIGHASH_ANYONECANPAY))
+            (std::string("NONE"), int(SIGHASH_NONE))
+            (std::string("NONE|ANYONECANPAY"), int(SIGHASH_NONE|SIGHASH_ANYONECANPAY))
+            (std::string("SINGLE"), int(SIGHASH_SINGLE))
+            (std::string("SINGLE|ANYONECANPAY"), int(SIGHASH_SINGLE|SIGHASH_ANYONECANPAY))
             ;
-        string strHashType = request.params[3].get_str();
+        std::string strHashType = request.params[3].get_str();
         if (mapSigHashValues.count(strHashType))
             nHashType = mapSigHashValues[strHashType];
         else
@@ -975,7 +973,7 @@ UniValue signrawtransaction(const JSONRPCRequest& request)
 UniValue sendrawtransaction(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
-        throw runtime_error(
+        throw std::runtime_error(
             "sendrawtransaction \"hexstring\" ( allowhighfees )\n"
             "\nSubmits raw transaction (serialized, hex-encoded) to local node and network.\n"
             "\nAlso see createrawtransaction and signrawtransaction calls.\n"

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -27,7 +27,6 @@
 #include <unordered_map>
 
 using namespace RPCServer;
-using namespace std;
 
 static bool fRPCRunning = false;
 static bool fRPCInWarmup = true;
@@ -67,7 +66,7 @@ void RPCServer::OnPostCommand(boost::function<void (const CRPCCommand&)> slot)
 }
 
 void RPCTypeCheck(const UniValue& params,
-                  const list<UniValue::VType>& typesExpected,
+                  const std::list<UniValue::VType>& typesExpected,
                   bool fAllowNull)
 {
     unsigned int i = 0;
@@ -92,7 +91,7 @@ void RPCTypeCheckArgument(const UniValue& value, UniValue::VType typeExpected)
 }
 
 void RPCTypeCheckObj(const UniValue& o,
-    const map<string, UniValueType>& typesExpected,
+    const std::map<std::string, UniValueType>& typesExpected,
     bool fAllowNull,
     bool fStrict)
 {
@@ -102,7 +101,7 @@ void RPCTypeCheckObj(const UniValue& o,
             throw JSONRPCError(RPC_TYPE_ERROR, strprintf("Missing %s", t.first));
 
         if (!(t.second.typeAny || v.type() == t.second.type || (fAllowNull && v.isNull()))) {
-            string err = strprintf("Expected type %s for %s, got %s",
+            std::string err = strprintf("Expected type %s for %s, got %s",
                 uvTypeName(t.second.type), t.first, uvTypeName(v.type()));
             throw JSONRPCError(RPC_TYPE_ERROR, err);
         }
@@ -110,11 +109,11 @@ void RPCTypeCheckObj(const UniValue& o,
 
     if (fStrict)
     {
-        BOOST_FOREACH(const string& k, o.getKeys())
+        BOOST_FOREACH(const std::string& k, o.getKeys())
         {
             if (typesExpected.count(k) == 0)
             {
-                string err = strprintf("Unexpected key %s", k);
+                std::string err = strprintf("Unexpected key %s", k);
                 throw JSONRPCError(RPC_TYPE_ERROR, err);
             }
         }
@@ -143,9 +142,9 @@ UniValue ValueFromAmount(const CAmount& amount)
             strprintf("%s%d.%08d", sign ? "-" : "", quotient, remainder));
 }
 
-uint256 ParseHashV(const UniValue& v, string strName)
+uint256 ParseHashV(const UniValue& v, std::string strName)
 {
-    string strHex;
+    std::string strHex;
     if (v.isStr())
         strHex = v.get_str();
     if (!IsHex(strHex)) // Note: IsHex("") is false
@@ -156,20 +155,20 @@ uint256 ParseHashV(const UniValue& v, string strName)
     result.SetHex(strHex);
     return result;
 }
-uint256 ParseHashO(const UniValue& o, string strKey)
+uint256 ParseHashO(const UniValue& o, std::string strKey)
 {
     return ParseHashV(find_value(o, strKey), strKey);
 }
-vector<unsigned char> ParseHexV(const UniValue& v, string strName)
+std::vector<unsigned char> ParseHexV(const UniValue& v, std::string strName)
 {
-    string strHex;
+    std::string strHex;
     if (v.isStr())
         strHex = v.get_str();
     if (!IsHex(strHex))
         throw JSONRPCError(RPC_INVALID_PARAMETER, strName+" must be hexadecimal string (not '"+strHex+"')");
     return ParseHex(strHex);
 }
-vector<unsigned char> ParseHexO(const UniValue& o, string strKey)
+std::vector<unsigned char> ParseHexO(const UniValue& o, std::string strKey)
 {
     return ParseHexV(find_value(o, strKey), strKey);
 }
@@ -227,25 +226,25 @@ bool ParseBoolV(const UniValue& v, const std::string &strName)
 
 std::string CRPCTable::help(const std::string& strCommand, const JSONRPCRequest& helpreq) const
 {
-    string strRet;
-    string category;
-    set<rpcfn_type> setDone;
-    vector<pair<string, const CRPCCommand*> > vCommands;
+    std::string strRet;
+    std::string category;
+    std::set<rpcfn_type> setDone;
+    std::vector<std::pair<std::string, const CRPCCommand*> > vCommands;
 
-    for (map<string, const CRPCCommand*>::const_iterator mi = mapCommands.begin(); mi != mapCommands.end(); ++mi)
+    for (std::map<std::string, const CRPCCommand*>::const_iterator mi = mapCommands.begin(); mi != mapCommands.end(); ++mi)
         vCommands.push_back(make_pair(mi->second->category + mi->first, mi->second));
-    sort(vCommands.begin(), vCommands.end());
+    std::sort(vCommands.begin(), vCommands.end());
 
     JSONRPCRequest jreq(helpreq);
     jreq.fHelp = true;
     jreq.params = UniValue();
 
-    BOOST_FOREACH(const PAIRTYPE(string, const CRPCCommand*)& command, vCommands)
+    BOOST_FOREACH(const PAIRTYPE(std::string, const CRPCCommand*)& command, vCommands)
     {
         const CRPCCommand *pcmd = command.second;
-        string strMethod = pcmd->name;
+        std::string strMethod = pcmd->name;
         // We already filter duplicates, but these deprecated screw up the sort order
-        if (strMethod.find("label") != string::npos)
+        if (strMethod.find("label") != std::string::npos)
             continue;
         if ((strCommand != "" || pcmd->category == "hidden") && strMethod != strCommand)
             continue;
@@ -259,10 +258,10 @@ std::string CRPCTable::help(const std::string& strCommand, const JSONRPCRequest&
         catch (const std::exception& e)
         {
             // Help text is returned in an exception
-            string strHelp = string(e.what());
+            std::string strHelp = std::string(e.what());
             if (strCommand == "")
             {
-                if (strHelp.find('\n') != string::npos)
+                if (strHelp.find('\n') != std::string::npos)
                     strHelp = strHelp.substr(0, strHelp.find('\n'));
 
                 if (category != pcmd->category)
@@ -270,7 +269,7 @@ std::string CRPCTable::help(const std::string& strCommand, const JSONRPCRequest&
                     if (!category.empty())
                         strRet += "\n";
                     category = pcmd->category;
-                    string firstLetter = category.substr(0,1);
+                    std::string firstLetter = category.substr(0,1);
                     boost::to_upper(firstLetter);
                     strRet += "== " + firstLetter + category.substr(1) + " ==\n";
                 }
@@ -287,7 +286,7 @@ std::string CRPCTable::help(const std::string& strCommand, const JSONRPCRequest&
 UniValue help(const JSONRPCRequest& jsonRequest)
 {
     if (jsonRequest.fHelp || jsonRequest.params.size() > 1)
-        throw runtime_error(
+        throw std::runtime_error(
             "help ( \"command\" )\n"
             "\nList all commands, or get help for a specified command.\n"
             "\nArguments:\n"
@@ -296,7 +295,7 @@ UniValue help(const JSONRPCRequest& jsonRequest)
             "\"text\"     (string) The help text\n"
         );
 
-    string strCommand;
+    std::string strCommand;
     if (jsonRequest.params.size() > 0)
         strCommand = jsonRequest.params[0].get_str();
 
@@ -308,7 +307,7 @@ UniValue stop(const JSONRPCRequest& jsonRequest)
 {
     // Accept the deprecated and ignored 'detach' boolean argument
     if (jsonRequest.fHelp || jsonRequest.params.size() > 1)
-        throw runtime_error(
+        throw std::runtime_error(
             "stop\n"
             "\nStop Firo server.");
     // Event loop will exit after current HTTP requests have been handled, so
@@ -353,7 +352,7 @@ CRPCTable::CRPCTable()
 
 const CRPCCommand *CRPCTable::operator[](const std::string &name) const
 {
-    map<string, const CRPCCommand*>::const_iterator it = mapCommands.find(name);
+    std::map<std::string, const CRPCCommand*>::const_iterator it = mapCommands.find(name);
     if (it == mapCommands.end())
         return NULL;
     return (*it).second;
@@ -365,7 +364,7 @@ bool CRPCTable::appendCommand(const std::string& name, const CRPCCommand* pcmd)
         return false;
 
     // don't allow overwriting for now
-    map<string, const CRPCCommand*>::const_iterator it = mapCommands.find(name);
+    std::map<std::string, const CRPCCommand*>::const_iterator it = mapCommands.find(name);
     if (it != mapCommands.end())
         return false;
 

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -13,9 +13,7 @@
 #include "script/script.h"
 #include "uint256.h"
 
-using namespace std;
-
-typedef vector<unsigned char> valtype;
+typedef std::vector<unsigned char> valtype;
 
 namespace {
 
@@ -56,10 +54,10 @@ bool CastToBool(const valtype& vch)
  */
 #define stacktop(i)  (stack.at(stack.size()+(i)))
 #define altstacktop(i)  (altstack.at(altstack.size()+(i)))
-static inline void popstack(vector<valtype>& stack)
+static inline void popstack(std::vector<valtype>& stack)
 {
     if (stack.empty())
-        throw runtime_error("popstack(): stack empty");
+        throw std::runtime_error("popstack(): stack empty");
     stack.pop_back();
 }
 
@@ -194,7 +192,7 @@ bool static IsDefinedHashtypeSignature(const valtype &vchSig) {
     return true;
 }
 
-bool CheckSignatureEncoding(const vector<unsigned char> &vchSig, unsigned int flags, ScriptError* serror) {
+bool CheckSignatureEncoding(const std::vector<unsigned char> &vchSig, unsigned int flags, ScriptError* serror) {
     // Empty signature. Not strictly DER encoded, but allowed to provide a
     // compact way to provide an invalid signature for use with CHECK(MULTI)SIG
     if (vchSig.size() == 0) {
@@ -245,7 +243,7 @@ bool static CheckMinimalPush(const valtype& data, opcodetype opcode) {
     return true;
 }
 
-bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, unsigned int flags, const BaseSignatureChecker& checker, SigVersion sigversion, ScriptError* serror)
+bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& script, unsigned int flags, const BaseSignatureChecker& checker, SigVersion sigversion, ScriptError* serror)
 {
     static const CScriptNum bnZero(0);
     static const CScriptNum bnOne(1);
@@ -260,8 +258,8 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, un
     CScript::const_iterator pbegincodehash = script.begin();
     opcodetype opcode;
     valtype vchPushValue;
-    vector<bool> vfExec;
-    vector<valtype> altstack;
+    std::vector<bool> vfExec;
+    std::vector<valtype> altstack;
     set_error(serror, SCRIPT_ERR_UNKNOWN_ERROR);
     if (script.size() > MAX_SCRIPT_SIZE)
         return set_error(serror, SCRIPT_ERR_SCRIPT_SIZE);
@@ -1253,14 +1251,14 @@ bool TransactionSignatureChecker::VerifySignature(const std::vector<unsigned cha
     return pubkey.Verify(sighash, vchSig);
 }
 
-bool TransactionSignatureChecker::CheckSig(const vector<unsigned char>& vchSigIn, const vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion) const
+bool TransactionSignatureChecker::CheckSig(const std::vector<unsigned char>& vchSigIn, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion) const
 {
     CPubKey pubkey(vchPubKey);
     if (!pubkey.IsValid())
         return false;
 
     // Hash type is one byte tacked on to the end of the signature
-    vector<unsigned char> vchSig(vchSigIn);
+    std::vector<unsigned char> vchSig(vchSigIn);
     if (vchSig.empty())
         return false;
     int nHashType = vchSig.back();
@@ -1358,7 +1356,7 @@ bool TransactionSignatureChecker::CheckSequence(const CScriptNum& nSequence) con
 
 static bool VerifyWitnessProgram(const CScriptWitness& witness, int witversion, const std::vector<unsigned char>& program, unsigned int flags, const BaseSignatureChecker& checker, ScriptError* serror)
 {
-    vector<vector<unsigned char> > stack;
+    std::vector<std::vector<unsigned char> > stack;
     CScript scriptPubKey;
 
     if (witversion == 0) {
@@ -1423,7 +1421,7 @@ bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const C
         return set_error(serror, SCRIPT_ERR_SIG_PUSHONLY);
     }
 
-    vector<vector<unsigned char> > stack, stackCopy;
+    std::vector<std::vector<unsigned char> > stack, stackCopy;
     if (!EvalScript(stack, scriptSig, flags, checker, SIGVERSION_BASE, serror))
         // serror is set
         return false;
@@ -1464,7 +1462,7 @@ bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const C
             return set_error(serror, SCRIPT_ERR_SIG_PUSHONLY);
 
         // Restore stack.
-        swap(stack, stackCopy);
+        std::swap(stack, stackCopy);
 
         // stack cannot be empty here, because if it was the
         // P2SH  HASH <> EQUAL  scriptPubKey would be evaluated with
@@ -1561,7 +1559,7 @@ size_t CountWitnessSigOps(const CScript& scriptSig, const CScript& scriptPubKey,
 
     if (scriptPubKey.IsPayToScriptHash() && scriptSig.IsPushOnly()) {
         CScript::const_iterator pc = scriptSig.begin();
-        vector<unsigned char> data;
+        std::vector<unsigned char> data;
         while (pc < scriptSig.end()) {
             opcodetype opcode;
             scriptSig.GetOp(pc, opcode, data);

--- a/src/script/ismine.cpp
+++ b/src/script/ismine.cpp
@@ -13,11 +13,9 @@
 
 #include <boost/foreach.hpp>
 
-using namespace std;
+typedef std::vector<unsigned char> valtype;
 
-typedef vector<unsigned char> valtype;
-
-unsigned int HaveKeys(const vector<valtype>& pubkeys, const CKeyStore& keystore)
+unsigned int HaveKeys(const std::vector<valtype>& pubkeys, const CKeyStore& keystore)
 {
     unsigned int nResult = 0;
     BOOST_FOREACH(const valtype& pubkey, pubkeys)
@@ -49,7 +47,7 @@ isminetype IsMine(const CKeyStore &keystore, const CTxDestination& dest, bool& i
 
 isminetype IsMine(const CKeyStore &keystore, const CScript& scriptPubKey, bool& isInvalid, SigVersion sigversion)
 {
-    vector<valtype> vSolutions;
+    std::vector<valtype> vSolutions;
     txnouttype whichType;
     if (!Solver(scriptPubKey, whichType, vSolutions)) {
         if (keystore.HaveWatchOnly(scriptPubKey))
@@ -136,7 +134,7 @@ isminetype IsMine(const CKeyStore &keystore, const CScript& scriptPubKey, bool& 
         // partially owned (somebody else has a key that can spend
         // them) enable spend-out-from-under-you attacks, especially
         // in shared-wallet situations.
-        vector<valtype> keys(vSolutions.begin()+1, vSolutions.begin()+vSolutions.size()-1);
+        std::vector<valtype> keys(vSolutions.begin()+1, vSolutions.begin()+vSolutions.size()-1);
         if (sigversion != SIGVERSION_BASE) {
             for (size_t i = 0; i < keys.size(); i++) {
                 if (keys[i].size() != 33) {

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -8,8 +8,6 @@
 #include "tinyformat.h"
 #include "utilstrencodings.h"
 
-using namespace std;
-
 const char* GetOpName(opcodetype opcode)
 {
     switch (opcode)
@@ -197,7 +195,7 @@ unsigned int CScript::GetSigOpCount(const CScript& scriptSig) const
     // get the last item that the scriptSig
     // pushes onto the stack:
     const_iterator pc = scriptSig.begin();
-    vector<unsigned char> data;
+    std::vector<unsigned char> data;
     while (pc < scriptSig.end())
     {
         opcodetype opcode;

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -14,8 +14,6 @@
 
 #include <boost/foreach.hpp>
 
-using namespace std;
-
 typedef std::vector<unsigned char> valtype;
 
 TransactionSignatureCreator::TransactionSignatureCreator(const CKeyStore* keystoreIn, const CTransaction* txToIn, unsigned int nInIn, const CAmount& amountIn, int nHashTypeIn) : BaseSignatureCreator(keystoreIn), txTo(txToIn), nIn(nInIn), nHashType(nHashTypeIn), amount(amountIn), checker(txTo, nIn, amountIn) {}
@@ -39,14 +37,14 @@ bool TransactionSignatureCreator::CreateSig(std::vector<unsigned char>& vchSig, 
 
 static bool Sign1(const CKeyID& address, const BaseSignatureCreator& creator, const CScript& scriptCode, std::vector<valtype>& ret, SigVersion sigversion)
 {
-    vector<unsigned char> vchSig;
+    std::vector<unsigned char> vchSig;
     if (!creator.CreateSig(vchSig, address, scriptCode, sigversion))
         return false;
     ret.push_back(vchSig);
     return true;
 }
 
-static bool SignN(const vector<valtype>& multisigdata, const BaseSignatureCreator& creator, const CScript& scriptCode, std::vector<valtype>& ret, SigVersion sigversion)
+static bool SignN(const std::vector<valtype>& multisigdata, const BaseSignatureCreator& creator, const CScript& scriptCode, std::vector<valtype>& ret, SigVersion sigversion)
 {
     int nSigned = 0;
     int nRequired = multisigdata.front()[0];
@@ -73,7 +71,7 @@ static bool SignStep(const BaseSignatureCreator& creator, const CScript& scriptP
     uint160 h160;
     ret.clear();
 
-    vector<valtype> vSolutions;
+    std::vector<valtype> vSolutions;
     if (!Solver(scriptPubKey, whichTypeRet, vSolutions))
         return false;
 
@@ -129,7 +127,7 @@ static bool SignStep(const BaseSignatureCreator& creator, const CScript& scriptP
     }
 }
 
-static CScript PushAll(const vector<valtype>& values)
+static CScript PushAll(const std::vector<valtype>& values)
 {
     CScript result;
     BOOST_FOREACH(const valtype& v, values) {
@@ -232,12 +230,12 @@ bool SignSignature(const CKeyStore &keystore, const CTransaction& txFrom, CMutab
     return SignSignature(keystore, txout.scriptPubKey, txTo, nIn, txout.nValue, nHashType);
 }
 
-static vector<valtype> CombineMultisig(const CScript& scriptPubKey, const BaseSignatureChecker& checker,
-                               const vector<valtype>& vSolutions,
-                               const vector<valtype>& sigs1, const vector<valtype>& sigs2, SigVersion sigversion)
+static std::vector<valtype> CombineMultisig(const CScript& scriptPubKey, const BaseSignatureChecker& checker,
+                               const std::vector<valtype>& vSolutions,
+                               const std::vector<valtype>& sigs1, const std::vector<valtype>& sigs2, SigVersion sigversion)
 {
     // Combine all the signatures we've got:
-    set<valtype> allsigs;
+    std::set<valtype> allsigs;
     BOOST_FOREACH(const valtype& v, sigs1)
     {
         if (!v.empty())
@@ -253,7 +251,7 @@ static vector<valtype> CombineMultisig(const CScript& scriptPubKey, const BaseSi
     assert(vSolutions.size() > 1);
     unsigned int nSigsRequired = vSolutions.front()[0];
     unsigned int nPubKeys = vSolutions.size()-2;
-    map<valtype, valtype> sigs;
+    std::map<valtype, valtype> sigs;
     BOOST_FOREACH(const valtype& sig, allsigs)
     {
         for (unsigned int i = 0; i < nPubKeys; i++)
@@ -310,7 +308,7 @@ struct Stacks
 }
 
 static Stacks CombineSignatures(const CScript& scriptPubKey, const BaseSignatureChecker& checker,
-                                 const txnouttype txType, const vector<valtype>& vSolutions,
+                                 const txnouttype txType, const std::vector<valtype>& vSolutions,
                                  Stacks sigs1, Stacks sigs2, SigVersion sigversion)
 {
     switch (txType)
@@ -348,7 +346,7 @@ static Stacks CombineSignatures(const CScript& scriptPubKey, const BaseSignature
             CScript pubKey2(spk.begin(), spk.end());
 
             txnouttype txType2;
-            vector<vector<unsigned char> > vSolutions2;
+            std::vector<std::vector<unsigned char> > vSolutions2;
             Solver(pubKey2, txType2, vSolutions2);
             sigs1.script.pop_back();
             sigs2.script.pop_back();
@@ -368,7 +366,7 @@ static Stacks CombineSignatures(const CScript& scriptPubKey, const BaseSignature
             // Recur to combine:
             CScript pubKey2(sigs1.witness.back().begin(), sigs1.witness.back().end());
             txnouttype txType2;
-            vector<valtype> vSolutions2;
+            std::vector<valtype> vSolutions2;
             Solver(pubKey2, txType2, vSolutions2);
             sigs1.witness.pop_back();
             sigs1.script = sigs1.witness;
@@ -391,7 +389,7 @@ SignatureData CombineSignatures(const CScript& scriptPubKey, const BaseSignature
                           const SignatureData& scriptSig1, const SignatureData& scriptSig2)
 {
     txnouttype txType;
-    vector<vector<unsigned char> > vSolutions;
+    std::vector<std::vector<unsigned char> > vSolutions;
     Solver(scriptPubKey, txType, vSolutions);
 
     return CombineSignatures(scriptPubKey, checker, txType, vSolutions, Stacks(scriptSig1), Stacks(scriptSig2), SIGVERSION_BASE).Output();

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -12,9 +12,7 @@
 
 #include <boost/foreach.hpp>
 
-using namespace std;
-
-typedef vector<unsigned char> valtype;
+typedef std::vector<unsigned char> valtype;
 
 bool fAcceptDatacarrier = DEFAULT_ACCEPT_DATACARRIER;
 unsigned nMaxDatacarrierBytes = MAX_OP_RETURN_RELAY;
@@ -45,20 +43,20 @@ const char* GetTxnOutputType(txnouttype t)
 /**
  * Return public keys or hashes from scriptPubKey, for 'standard' transaction types.
  */
-bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, vector<vector<unsigned char> >& vSolutionsRet)
+bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, std::vector<std::vector<unsigned char> >& vSolutionsRet)
 {
     // Templates
-    static multimap<txnouttype, CScript> mTemplates;
+    static std::multimap<txnouttype, CScript> mTemplates;
     if (mTemplates.empty())
     {
         // Standard tx, sender provides pubkey, receiver adds signature
-        mTemplates.insert(make_pair(TX_PUBKEY, CScript() << OP_PUBKEY << OP_CHECKSIG));
+        mTemplates.insert(std::make_pair(TX_PUBKEY, CScript() << OP_PUBKEY << OP_CHECKSIG));
 
         // Bitcoin address tx, sender provides hash of pubkey, receiver provides signature and pubkey
-        mTemplates.insert(make_pair(TX_PUBKEYHASH, CScript() << OP_DUP << OP_HASH160 << OP_PUBKEYHASH << OP_EQUALVERIFY << OP_CHECKSIG));
+        mTemplates.insert(std::make_pair(TX_PUBKEYHASH, CScript() << OP_DUP << OP_HASH160 << OP_PUBKEYHASH << OP_EQUALVERIFY << OP_CHECKSIG));
 
         // Sender provides N pubkeys, receivers provides M signatures
-        mTemplates.insert(make_pair(TX_MULTISIG, CScript() << OP_SMALLINTEGER << OP_PUBKEYS << OP_SMALLINTEGER << OP_CHECKMULTISIG));
+        mTemplates.insert(std::make_pair(TX_MULTISIG, CScript() << OP_SMALLINTEGER << OP_PUBKEYS << OP_SMALLINTEGER << OP_CHECKMULTISIG));
     }
 
     vSolutionsRet.clear();
@@ -68,7 +66,7 @@ bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, vector<vector<unsi
     if (scriptPubKey.IsPayToScriptHash())
     {
         typeRet = TX_SCRIPTHASH;
-        vector<unsigned char> hashBytes(scriptPubKey.begin()+2, scriptPubKey.begin()+22);
+        std::vector<unsigned char> hashBytes(scriptPubKey.begin()+2, scriptPubKey.begin()+22);
         vSolutionsRet.push_back(hashBytes);
         return true;
     }
@@ -76,7 +74,7 @@ bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, vector<vector<unsi
     if (scriptPubKey.IsPayToPublicKeyHash())
     {
         typeRet = TX_PUBKEYHASH;
-        vector<unsigned char> hashBytes(scriptPubKey.begin()+3, scriptPubKey.begin()+23);
+        std::vector<unsigned char> hashBytes(scriptPubKey.begin()+3, scriptPubKey.begin()+23);
         vSolutionsRet.push_back(hashBytes);
         return true;
     }
@@ -86,7 +84,7 @@ bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, vector<vector<unsi
     {
         typeRet = TX_ZEROCOINMINT;
         if(scriptPubKey.size() > 150) return false;
-        vector<unsigned char> hashBytes(scriptPubKey.begin()+2, scriptPubKey.end());
+        std::vector<unsigned char> hashBytes(scriptPubKey.begin()+2, scriptPubKey.end());
         vSolutionsRet.push_back(hashBytes);
         return true;
     }
@@ -96,7 +94,7 @@ bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, vector<vector<unsi
     {
         typeRet = TX_ZEROCOINMINTV3;
         if(scriptPubKey.size() != 35) return false;
-        vector<unsigned char> hashBytes(scriptPubKey.begin()+1, scriptPubKey.end());
+        std::vector<unsigned char> hashBytes(scriptPubKey.begin()+1, scriptPubKey.end());
         vSolutionsRet.push_back(hashBytes);
         return true;
     }
@@ -152,7 +150,7 @@ bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, vector<vector<unsi
         vSolutionsRet.clear();
 
         opcodetype opcode1, opcode2;
-        vector<unsigned char> vch1, vch2;
+        std::vector<unsigned char> vch1, vch2;
 
         // Compare
         CScript::const_iterator pc1 = script1.begin();
@@ -231,7 +229,7 @@ bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, vector<vector<unsi
 
 bool ExtractDestination(const CScript& scriptPubKey, CTxDestination& addressRet)
 {
-    vector<valtype> vSolutions;
+    std::vector<valtype> vSolutions;
     txnouttype whichType;
     if (!Solver(scriptPubKey, whichType, vSolutions))
         return false;
@@ -259,11 +257,11 @@ bool ExtractDestination(const CScript& scriptPubKey, CTxDestination& addressRet)
     return false;
 }
 
-bool ExtractDestinations(const CScript& scriptPubKey, txnouttype& typeRet, vector<CTxDestination>& addressRet, int& nRequiredRet)
+bool ExtractDestinations(const CScript& scriptPubKey, txnouttype& typeRet, std::vector<CTxDestination>& addressRet, int& nRequiredRet)
 {
     addressRet.clear();
     typeRet = TX_NONSTANDARD;
-    vector<valtype> vSolutions;
+    std::vector<valtype> vSolutions;
     if (!Solver(scriptPubKey, typeRet, vSolutions))
         return false;
     if (typeRet == TX_NULL_DATA){

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -27,7 +27,6 @@
 #include <memory>
 #include "definition.h"
 #include <boost/optional.hpp>
-using namespace std;
 
 
 static const unsigned int MAX_SIZE = 0x02000000;

--- a/src/sigma.cpp
+++ b/src/sigma.cpp
@@ -179,7 +179,7 @@ bool CheckSigmaBlock(CValidationState &state, const CBlock& block) {
 // Mixing V2 and sigma spends into the same transaction will fail.
 bool CheckSigmaSpendTransaction(
         const CTransaction &tx,
-        const vector<sigma::CoinDenomination>& targetDenominations,
+        const std::vector<sigma::CoinDenomination>& targetDenominations,
         CValidationState &state,
         uint256 hashTx,
         bool isVerifyDB,
@@ -253,7 +253,7 @@ bool CheckSigmaSpendTransaction(
 
         bool passVerify = false;
         CBlockIndex *index = coinGroup.lastBlock;
-        pair<sigma::CoinDenomination, int> denominationAndId = std::make_pair(
+        std::pair<sigma::CoinDenomination, int> denominationAndId = std::make_pair(
             targetDenominations[vinIndex], coinGroupId);
 
         uint256 accumulatorBlockHash = spend->getAccumulatorBlockHash();
@@ -479,7 +479,7 @@ bool CheckSigmaTransaction(
                 "bad-txns-spend-invalid");
         }
 
-        vector<sigma::CoinDenomination> denominations;
+        std::vector<sigma::CoinDenomination> denominations;
         uint64_t totalValue = 0;
         BOOST_FOREACH(const CTxIn &txin, tx.vin){
             if(!txin.scriptSig.IsSigmaSpend()) {
@@ -662,7 +662,7 @@ bool GetOutPointFromBlock(COutPoint& outPoint, const GroupElement &pubCoinValue,
 
                 // If you wonder why +1, go to file wallet.cpp and read the comments in function
                 // CWallet::CreateZerocoinMintModelV3 around "scriptSerializedCoin << OP_ZEROCOINMINTV3";
-                vector<unsigned char> coin_serialised(txout.scriptPubKey.begin() + 1,
+                std::vector<unsigned char> coin_serialised(txout.scriptPubKey.begin() + 1,
                                                       txout.scriptPubKey.end());
                 txPubCoinValue.deserialize(&coin_serialised[0]);
                 if(pubCoinValue==txPubCoinValue){
@@ -874,7 +874,7 @@ void CSigmaState::AddMintsToStateAndBlockIndex(
         auto mintCoinGroupId = latestCoinIds[denomination];
 
 
-        SigmaCoinGroupInfo &coinGroup = coinGroups[make_pair(denomination, mintCoinGroupId)];
+        SigmaCoinGroupInfo &coinGroup = coinGroups[std::make_pair(denomination, mintCoinGroupId)];
 
         if (coinGroup.nCoins + mintsWithThisDenom.size() <= ZC_SPEND_V3_COINSPERID_LIMIT) {
             if (coinGroup.nCoins == 0) {
@@ -914,7 +914,7 @@ void CSigmaState::AddSpend(const Scalar &serial, CoinDenomination denom, int coi
 
 void CSigmaState::AddBlock(CBlockIndex *index) {
     BOOST_FOREACH(
-        const PAIRTYPE(PAIRTYPE(sigma::CoinDenomination, int), vector<sigma::PublicCoin>) &pubCoins,
+        const PAIRTYPE(PAIRTYPE(sigma::CoinDenomination, int), std::vector<sigma::PublicCoin>) &pubCoins,
             index->sigmaMintedPubCoins) {
 
         if (pubCoins.second.empty())
@@ -941,7 +941,7 @@ void CSigmaState::AddBlock(CBlockIndex *index) {
 void CSigmaState::RemoveBlock(CBlockIndex *index) {
     // roll back accumulator updates
     BOOST_FOREACH(
-        const PAIRTYPE(PAIRTYPE(sigma::CoinDenomination, int),vector<sigma::PublicCoin>) &coin,
+        const PAIRTYPE(PAIRTYPE(sigma::CoinDenomination, int),std::vector<sigma::PublicCoin>) &coin,
         index->sigmaMintedPubCoins)
     {
         SigmaCoinGroupInfo   &coinGroup = coinGroups[coin.first];
@@ -974,7 +974,7 @@ void CSigmaState::RemoveBlock(CBlockIndex *index) {
     }
 
     // roll back mints
-    BOOST_FOREACH(const PAIRTYPE(PAIRTYPE(sigma::CoinDenomination, int),vector<sigma::PublicCoin>) &pubCoins,
+    BOOST_FOREACH(const PAIRTYPE(PAIRTYPE(sigma::CoinDenomination, int),std::vector<sigma::PublicCoin>) &pubCoins,
                   index->sigmaMintedPubCoins) {
         BOOST_FOREACH(const sigma::PublicCoin &coin, pubCoins.second) {
             auto coins = containers.GetMints().equal_range(coin);
@@ -1047,7 +1047,7 @@ int CSigmaState::GetCoinSetForSpend(
 
     coins_out.clear();
 
-    pair<sigma::CoinDenomination, int> denomAndId = std::make_pair(denomination, coinGroupID);
+    std::pair<sigma::CoinDenomination, int> denomAndId = std::make_pair(denomination, coinGroupID);
 
     if (coinGroups.count(denomAndId) == 0)
         return 0;
@@ -1094,7 +1094,7 @@ void CSigmaState::GetAnonymitySet(
 
     coins_out.clear();
 
-    pair<sigma::CoinDenomination, int> denomAndId = std::make_pair(denomination, coinGroupID);
+    std::pair<sigma::CoinDenomination, int> denomAndId = std::make_pair(denomination, coinGroupID);
 
     if (coinGroups.count(denomAndId) == 0)
         return;
@@ -1137,7 +1137,7 @@ std::pair<int, int> CSigmaState::GetMintedCoinHeightAndId(
     return std::make_pair(-1, -1);
 }
 
-bool CSigmaState::AddSpendToMempool(const vector<Scalar> &coinSerials, uint256 txHash) {
+bool CSigmaState::AddSpendToMempool(const std::vector<Scalar> &coinSerials, uint256 txHash) {
     BOOST_FOREACH(Scalar coinSerial, coinSerials){
         if (IsUsedCoinSerial(coinSerial) || mempoolCoinSerials.count(coinSerial))
             return false;
@@ -1160,7 +1160,7 @@ void CSigmaState::RemoveSpendFromMempool(const Scalar& coinSerial) {
     mempoolCoinSerials.erase(coinSerial);
 }
 
-void CSigmaState::AddMintsToMempool(const vector<GroupElement>& pubCoins){
+void CSigmaState::AddMintsToMempool(const std::vector<GroupElement>& pubCoins){
     BOOST_FOREACH(const GroupElement& pubCoin, pubCoins){
         mempoolMints.insert(pubCoin);
     }
@@ -1218,7 +1218,7 @@ spend_info_container const & CSigmaState::GetSpends() const {
     return containers.GetSpends();
 }
 
-std::unordered_map<pair<CoinDenomination, int>, CSigmaState::SigmaCoinGroupInfo, CSigmaState::pairhash> const & CSigmaState::GetCoinGroups() const {
+std::unordered_map<std::pair<CoinDenomination, int>, CSigmaState::SigmaCoinGroupInfo, CSigmaState::pairhash> const & CSigmaState::GetCoinGroups() const {
     return coinGroups;
 }
 

--- a/src/sigma.h
+++ b/src/sigma.h
@@ -98,7 +98,7 @@ CAmount GetSigmaSpendInput(const CTransaction &tx);
  * State of minted/spent coins as extracted from the index
  */
 class CSigmaState {
-friend bool BuildSigmaStateFromIndex(CChain *, set<CBlockIndex *> &);
+friend bool BuildSigmaStateFromIndex(CChain *, std::set<CBlockIndex *> &);
 public:
     // First and last block where mint with given denomination and id was seen
     struct SigmaCoinGroupInfo {
@@ -182,9 +182,9 @@ public:
 
     // Add spend into the mempool.
     // Check if there is a coin with such serial in either blockchain or mempool
-    bool AddSpendToMempool(const vector<Scalar> &coinSerials, uint256 txHash);
+    bool AddSpendToMempool(const std::vector<Scalar> &coinSerials, uint256 txHash);
 
-    void AddMintsToMempool(const vector<GroupElement>& pubCoins);
+    void AddMintsToMempool(const std::vector<GroupElement>& pubCoins);
 
     void RemoveMintFromMempool(const GroupElement& pubCoin);
 
@@ -202,7 +202,7 @@ public:
 
     mint_info_container const & GetMints() const;
     spend_info_container const & GetSpends() const;
-    std::unordered_map<pair<CoinDenomination, int>, SigmaCoinGroupInfo, pairhash> const & GetCoinGroups() const ;
+    std::unordered_map<std::pair<CoinDenomination, int>, SigmaCoinGroupInfo, pairhash> const & GetCoinGroups() const ;
     std::unordered_map<CoinDenomination, int> const & GetLatestCoinIds() const;
     std::unordered_map<Scalar, uint256, sigma::CScalarHash> const & GetMempoolCoinSerials() const;
 
@@ -212,7 +212,7 @@ public:
 
 private:
     // Collection of coin groups. Map from <denomination,id> to SigmaCoinGroupInfo structure
-    std::unordered_map<pair<CoinDenomination, int>, SigmaCoinGroupInfo, pairhash> coinGroups;
+    std::unordered_map<std::pair<CoinDenomination, int>, SigmaCoinGroupInfo, pairhash> coinGroups;
 
     // Latest IDs of coins by denomination
     std::unordered_map<CoinDenomination, int> latestCoinIds;

--- a/src/sigma/sigmaplus_verifier.h
+++ b/src/sigma/sigmaplus_verifier.h
@@ -19,25 +19,25 @@ public:
 
     bool batch_verify(const std::vector<GroupElement>& commits,
                       const std::vector<Exponent>& serials,
-                      const vector<bool>& fPadding,
+                      const std::vector<bool>& fPadding,
                       const std::vector<size_t>& setSizes,
-                      const vector<SigmaPlusProof<Exponent, GroupElement>>& proofs) const;
+                      const std::vector<SigmaPlusProof<Exponent, GroupElement>>& proofs) const;
 
     bool membership_checks(const SigmaPlusProof<Exponent, GroupElement>& proof) const;
     bool compute_fs(const SigmaPlusProof<Exponent, GroupElement>& proof, const Exponent& x, std::vector<Exponent>& f_) const;
     bool abcd_checks(const SigmaPlusProof<Exponent, GroupElement>& proof, const Exponent& x, const std::vector<Exponent>& f_) const;
 
     void compute_fis(int j, const std::vector<Exponent>& f, std::vector<Exponent>& f_i_) const;
-    void compute_fis(const Exponent& f_i, int j, const std::vector<Exponent>& f, typename vector<Exponent>::iterator& ptr, typename vector<Exponent>::iterator end_ptr) const;
+    void compute_fis(const Exponent& f_i, int j, const std::vector<Exponent>& f, typename std::vector<Exponent>::iterator& ptr, typename std::vector<Exponent>::iterator end_ptr) const;
     void compute_batch_fis(
             const Exponent& f_i,
             int j,
             const std::vector<Exponent>& f,
             const Exponent& y,
             Exponent& e,
-            typename vector<Exponent>::iterator& ptr,
-            typename vector<Exponent>::iterator start_ptr,
-            typename vector<Exponent>::iterator end_ptr) const;
+            typename std::vector<Exponent>::iterator& ptr,
+            typename std::vector<Exponent>::iterator start_ptr,
+            typename std::vector<Exponent>::iterator end_ptr) const;
 
 
 private:

--- a/src/sigma/sigmaplus_verifier.hpp
+++ b/src/sigma/sigmaplus_verifier.hpp
@@ -89,7 +89,7 @@ bool SigmaPlusVerifier<Exponent, GroupElement>::verify(
 
         Exponent pow(uint64_t(1));
         std::vector<uint64_t> I = SigmaPrimitives<Exponent, GroupElement>::convert_to_nal(N - 1, n, m);
-        vector<Exponent> f_part_product;    // partial product of f array elements for lastIndex
+        std::vector<Exponent> f_part_product;    // partial product of f array elements for lastIndex
         for (int j = m - 1; j >= 0; j--) {
             f_part_product.push_back(pow);
             pow *= f[j * n + I[j]];
@@ -129,9 +129,9 @@ template<class Exponent, class GroupElement>
 bool SigmaPlusVerifier<Exponent, GroupElement>::batch_verify(
         const std::vector<GroupElement>& commits,
         const std::vector<Exponent>& serials,
-        const vector<bool>& fPadding,
+        const std::vector<bool>& fPadding,
         const std::vector<size_t>& setSizes,
-        const vector<SigmaPlusProof<Exponent, GroupElement>>& proofs) const {
+        const std::vector<SigmaPlusProof<Exponent, GroupElement>>& proofs) const {
 
     int M = proofs.size();
     int N = commits.size();
@@ -187,7 +187,7 @@ bool SigmaPlusVerifier<Exponent, GroupElement>::batch_verify(
         size_t start = N - size;
 
         Scalar f_i(uint64_t(1));
-        vector<Scalar>::iterator ptr = f_i_t.begin() + start;
+        std::vector<Scalar>::iterator ptr = f_i_t.begin() + start;
         compute_batch_fis(f_i, m, f_[t], y[t], e, ptr, ptr, ptr + size - 1);
 
         if(fPadding[t]) {
@@ -207,7 +207,7 @@ bool SigmaPlusVerifier<Exponent, GroupElement>::batch_verify(
             */
 
             Scalar pow(uint64_t(1));
-            vector <Scalar> f_part_product;    // partial product of f array elements for lastIndex
+            std::vector <Scalar> f_part_product;    // partial product of f array elements for lastIndex
             for (int j = m - 1; j >= 0; j--) {
                 f_part_product.push_back(pow);
                 pow *= f_[t][j * n + I_[size - 1][j]];
@@ -356,12 +356,12 @@ bool SigmaPlusVerifier<Exponent, GroupElement>::abcd_checks(
 template<class Exponent, class GroupElement>
 void SigmaPlusVerifier<Exponent, GroupElement>::compute_fis(int j, const std::vector<Exponent>& f, std::vector<Exponent>& f_i_) const {
     Exponent f_i(uint64_t(1));
-    typename vector<Exponent>::iterator ptr = f_i_.begin();
+    typename std::vector<Exponent>::iterator ptr = f_i_.begin();
     compute_fis(f_i, m, f, ptr, f_i_.end());
 }
 
 template<class Exponent, class GroupElement>
-void SigmaPlusVerifier<Exponent, GroupElement>::compute_fis(const Exponent& f_i, int j, const std::vector<Exponent>& f, typename vector<Exponent>::iterator& ptr, typename vector<Exponent>::iterator end_ptr) const {
+void SigmaPlusVerifier<Exponent, GroupElement>::compute_fis(const Exponent& f_i, int j, const std::vector<Exponent>& f, typename std::vector<Exponent>::iterator& ptr, typename std::vector<Exponent>::iterator end_ptr) const {
     j--;
     if (j == -1)
     {
@@ -388,9 +388,9 @@ void SigmaPlusVerifier<Exponent, GroupElement>::compute_batch_fis(
         const std::vector<Exponent>& f,
         const Exponent& y,
         Exponent& e,
-        typename vector<Exponent>::iterator& ptr,
-        typename vector<Exponent>::iterator start_ptr,
-        typename vector<Exponent>::iterator end_ptr)const {
+        typename std::vector<Exponent>::iterator& ptr,
+        typename std::vector<Exponent>::iterator start_ptr,
+        typename std::vector<Exponent>::iterator end_ptr)const {
     j--;
     if (j == -1)
     {

--- a/src/test/bloom_tests.cpp
+++ b/src/test/bloom_tests.cpp
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE(bloom_create_insert_serialize_with_tweak)
 
 BOOST_AUTO_TEST_CASE(bloom_create_insert_key)
 {
-    std::string strSecret = bitcoin_address_to_firo(string("5Kg1gnAjaLfKiwhhPpGS3QfRg2m6awQvaj98JCZBZQ5SuS2F15C"));
+    std::string strSecret = bitcoin_address_to_firo(std::string("5Kg1gnAjaLfKiwhhPpGS3QfRg2m6awQvaj98JCZBZQ5SuS2F15C"));
     CBitcoinSecret vchSecret;
     BOOST_CHECK(vchSecret.SetString(strSecret));
 

--- a/src/test/evospork_tests.cpp
+++ b/src/test/evospork_tests.cpp
@@ -302,7 +302,7 @@ BOOST_AUTO_TEST_CASE(limit)
     ::mempool.removeRecursive(jsTx);
 
     auto joinsplit = lelantus::ParseLelantusJoinSplit(jsTx.vin[0]);
-    vector<Scalar> serials = joinsplit->getCoinSerialNumbers();
+    std::vector<Scalar> serials = joinsplit->getCoinSerialNumbers();
 
     // generate two smaller joinsplit txs
     CWalletTx jsSmallWalletTxs[2];

--- a/src/test/fixtures.cpp
+++ b/src/test/fixtures.cpp
@@ -95,7 +95,7 @@ void ZerocoinTestingSetupBase::CreateAndProcessEmptyBlocks(size_t block_numbers,
     {
         BOOST_CHECK(pwalletMain->GetKeyFromPool(pubkey));
 
-        string strAddress = CBitcoinAddress(pubkey.GetID()).ToString();
+        std::string strAddress = CBitcoinAddress(pubkey.GetID()).ToString();
         pwalletMain->SetAddressBook(CBitcoinAddress(strAddress).Get(), "",
                                ( "receive"));
 
@@ -124,7 +124,7 @@ void ZerocoinTestingSetupBase::CreateAndProcessEmptyBlocks(size_t block_numbers,
         CPubKey newKey;
         BOOST_CHECK(pwalletMain->GetKeyFromPool(newKey));
 
-        string strAddress = CBitcoinAddress(newKey.GetID()).ToString();
+        std::string strAddress = CBitcoinAddress(newKey.GetID()).ToString();
         pwalletMain->SetAddressBook(CBitcoinAddress(strAddress).Get(), "",
                                ( "receive"));
 
@@ -147,7 +147,7 @@ MtpMalformedTestingSetup::MtpMalformedTestingSetup()
     CPubKey newKey;
     BOOST_CHECK(pwalletMain->GetKeyFromPool(newKey));
 
-    string strAddress = CBitcoinAddress(newKey.GetID()).ToString();
+    std::string strAddress = CBitcoinAddress(newKey.GetID()).ToString();
     pwalletMain->SetAddressBook(CBitcoinAddress(strAddress).Get(), "",
                             ( "receive"));
 

--- a/src/test/mtp_malformed_tests.cpp
+++ b/src/test/mtp_malformed_tests.cpp
@@ -77,7 +77,7 @@ BOOST_AUTO_TEST_CASE(mtp_malformed)
     BOOST_CHECK_MESSAGE(previousHeight == chainActive.Height(), "Block connected with incorrect proof");
 
     bMtp = CreateBlock(scriptPubKey, mtp);
-    bMtp.mtpHashData = make_shared<CMTPHashData>();
+    bMtp.mtpHashData = std::make_shared<CMTPHashData>();
     ProcessBlock(bMtp);
     BOOST_CHECK_MESSAGE(previousHeight == chainActive.Height(), "Block connected with missing proof");
 

--- a/src/test/random_tests.cpp
+++ b/src/test/random_tests.cpp
@@ -50,4 +50,57 @@ BOOST_AUTO_TEST_CASE(fastrandom_randbits)
     }
 }
 
+/** Does-it-compile test for compatibility with standard C++11 RNG interface. */
+BOOST_AUTO_TEST_CASE(stdrandom_test)
+{
+    FastRandomContext ctx;
+    std::uniform_int_distribution<int> distribution(3, 9);
+    for (int i = 0; i < 100; ++i) {
+        int x = distribution(ctx);
+        BOOST_CHECK(x >= 3);
+        BOOST_CHECK(x <= 9);
+
+        std::vector<int> test{1,2,3,4,5,6,7,8,9,10};
+        std::shuffle(test.begin(), test.end(), ctx);
+        for (int j = 1; j <= 10; ++j) {
+            BOOST_CHECK(std::find(test.begin(), test.end(), j) != test.end());
+        }
+        Shuffle(test.begin(), test.end(), ctx);
+        for (int j = 1; j <= 10; ++j) {
+            BOOST_CHECK(std::find(test.begin(), test.end(), j) != test.end());
+        }
+    }
+
+}
+
+/** Test that Shuffle reaches every permutation with equal probability. */
+BOOST_AUTO_TEST_CASE(shuffle_stat_test)
+{
+    FastRandomContext ctx(true);
+    uint32_t counts[5 * 5 * 5 * 5 * 5] = {0};
+    for (int i = 0; i < 12000; ++i) {
+        int data[5] = {0, 1, 2, 3, 4};
+        Shuffle(std::begin(data), std::end(data), ctx);
+        int pos = data[0] + data[1] * 5 + data[2] * 25 + data[3] * 125 + data[4] * 625;
+        ++counts[pos];
+    }
+    unsigned int sum = 0;
+    double chi_score = 0.0;
+    for (int i = 0; i < 5 * 5 * 5 * 5 * 5; ++i) {
+        int i1 = i % 5, i2 = (i / 5) % 5, i3 = (i / 25) % 5, i4 = (i / 125) % 5, i5 = i / 625;
+        uint32_t count = counts[i];
+        if (i1 == i2 || i1 == i3 || i1 == i4 || i1 == i5 || i2 == i3 || i2 == i4 || i2 == i5 || i3 == i4 || i3 == i5 || i4 == i5) {
+            BOOST_CHECK(count == 0);
+        } else {
+            chi_score += ((count - 100.0) * (count - 100.0)) / 100.0;
+            BOOST_CHECK(count > 50);
+            BOOST_CHECK(count < 150);
+            sum += count;
+        }
+    }
+    BOOST_CHECK(chi_score > 58.1411); // 99.9999% confidence interval
+    BOOST_CHECK(chi_score < 210.275);
+    BOOST_CHECK_EQUAL(sum, 12000);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/sigma_lelantus_transition.cpp
+++ b/src/test/sigma_lelantus_transition.cpp
@@ -20,6 +20,8 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/thread.hpp>
 
+using namespace std;
+
 BOOST_FIXTURE_TEST_SUITE(sigma_lelantus_transition, LelantusTestingSetup)
 
 BOOST_AUTO_TEST_CASE(sigma_lelantus_transition_test)

--- a/src/test/sigma_manymintspend_test.cpp
+++ b/src/test/sigma_manymintspend_test.cpp
@@ -22,6 +22,8 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/thread.hpp>
 
+using namespace std;
+
 BOOST_FIXTURE_TEST_SUITE(sigma_mintspend_many, ZerocoinTestingSetup200)
 
 BOOST_AUTO_TEST_CASE(sigma_mintspend_many)

--- a/src/test/sigma_mintspend_numinputs.cpp
+++ b/src/test/sigma_mintspend_numinputs.cpp
@@ -22,6 +22,8 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/thread.hpp>
 
+using namespace std;
+
 BOOST_FIXTURE_TEST_SUITE(sigma_mintspend_numinputs, ZerocoinTestingSetup200)
 
 BOOST_AUTO_TEST_CASE(sigma_mintspend_numinputs)

--- a/src/test/sigma_mintspend_test.cpp
+++ b/src/test/sigma_mintspend_test.cpp
@@ -22,6 +22,8 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/thread.hpp>
 
+using namespace std;
+
 BOOST_FIXTURE_TEST_SUITE(sigma_mintspend, ZerocoinTestingSetup200)
 
 /*

--- a/src/test/sigma_partialspend_mempool_tests.cpp
+++ b/src/test/sigma_partialspend_mempool_tests.cpp
@@ -22,6 +22,8 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/thread.hpp>
 
+using namespace std;
+
 static bool addToMempool(const CWalletTx& tx) {
     CValidationState state;
     bool fMissingInputs;

--- a/src/test/sigma_state_tests.cpp
+++ b/src/test/sigma_state_tests.cpp
@@ -14,6 +14,8 @@
 
 #include <stdlib.h>
 
+using namespace std;
+
 BOOST_FIXTURE_TEST_SUITE(sigma_state_tests, ZerocoinTestingSetup200)
 
 static const uint256 txHash = uint256S("a64bf7b459d3bb09653e444d75a942e9848ed8e1f30e2890f999426ed6dd4a2c");

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -95,7 +95,7 @@ TestingSetup::TestingSetup(const std::string& chainName, std::string suf) : Basi
         pcoinsdbview = new CCoinsViewDB(1 << 23, true);
         llmq::InitLLMQSystem(*evoDb, nullptr, true);
         pcoinsTip = new CCoinsViewCache(pcoinsdbview);
-        pwalletMain = new CWallet(string("wallet_test.dat"));
+        pwalletMain = new CWallet(std::string("wallet_test.dat"));
         static bool fFirstRun = true;
         pwalletMain->LoadWallet(fFirstRun);
 

--- a/src/tor/configure.ac
+++ b/src/tor/configure.ac
@@ -321,7 +321,6 @@ AM_CONDITIONAL(BUILD_MANPAGE, [test "x$enable_manpage" != "xno"])
 AM_CONDITIONAL(BUILD_HTML_DOCS, [test "x$enable_html_manual" != "xno"])
 
 AM_PROG_CC_C_O
-AC_PROG_CC_C99
 
 AC_ARG_VAR([PYTHON], [path to Python binary])
 AC_CHECK_PROGS(PYTHON, [ \

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -207,16 +207,16 @@ bool CBlockTreeDB::WriteTxIndex(const std::vector<std::pair<uint256, CDiskTxPos>
 }
 
 bool CBlockTreeDB::ReadSpentIndex(CSpentIndexKey &key, CSpentIndexValue &value) {
-    return Read(make_pair(DB_SPENTINDEX, key), value);
+    return Read(std::make_pair(DB_SPENTINDEX, key), value);
 }
 
 bool CBlockTreeDB::UpdateSpentIndex(const std::vector<std::pair<CSpentIndexKey, CSpentIndexValue> >&vect) {
     CDBBatch batch(*this);
     for (std::vector<std::pair<CSpentIndexKey,CSpentIndexValue> >::const_iterator it=vect.begin(); it!=vect.end(); it++) {
         if (it->second.IsNull()) {
-            batch.Erase(make_pair(DB_SPENTINDEX, it->first));
+            batch.Erase(std::make_pair(DB_SPENTINDEX, it->first));
         } else {
-            batch.Write(make_pair(DB_SPENTINDEX, it->first), it->second);
+            batch.Write(std::make_pair(DB_SPENTINDEX, it->first), it->second);
         }
     }
     return WriteBatch(batch);
@@ -226,9 +226,9 @@ bool CBlockTreeDB::UpdateAddressUnspentIndex(const std::vector<std::pair<CAddres
     CDBBatch batch(*this);
     for (std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue> >::const_iterator it=vect.begin(); it!=vect.end(); it++) {
         if (it->second.IsNull()) {
-            batch.Erase(make_pair(DB_ADDRESSUNSPENTINDEX, it->first));
+            batch.Erase(std::make_pair(DB_ADDRESSUNSPENTINDEX, it->first));
         } else {
-            batch.Write(make_pair(DB_ADDRESSUNSPENTINDEX, it->first), it->second);
+            batch.Write(std::make_pair(DB_ADDRESSUNSPENTINDEX, it->first), it->second);
         }
     }
     return WriteBatch(batch);
@@ -239,7 +239,7 @@ bool CBlockTreeDB::ReadAddressUnspentIndex(uint160 addressHash, AddressType type
 
     boost::scoped_ptr<CDBIterator> pcursor(NewIterator());
 
-    pcursor->Seek(make_pair(DB_ADDRESSUNSPENTINDEX, CAddressIndexIteratorKey(type, addressHash)));
+    pcursor->Seek(std::make_pair(DB_ADDRESSUNSPENTINDEX, CAddressIndexIteratorKey(type, addressHash)));
 
     while (pcursor->Valid()) {
         boost::this_thread::interruption_point();
@@ -247,7 +247,7 @@ bool CBlockTreeDB::ReadAddressUnspentIndex(uint160 addressHash, AddressType type
         if (pcursor->GetKey(key) && key.first == DB_ADDRESSUNSPENTINDEX && key.second.hashBytes == addressHash) {
             CAddressUnspentValue nValue;
             if (pcursor->GetValue(nValue)) {
-                unspentOutputs.push_back(make_pair(key.second, nValue));
+                unspentOutputs.push_back(std::make_pair(key.second, nValue));
                 pcursor->Next();
             } else {
                 return error("failed to get address unspent value");
@@ -263,7 +263,7 @@ bool CBlockTreeDB::ReadAddressUnspentIndex(uint160 addressHash, AddressType type
 bool CBlockTreeDB::WriteAddressIndex(const std::vector<std::pair<CAddressIndexKey, CAmount > >&vect) {
     CDBBatch batch(*this);
     for (std::vector<std::pair<CAddressIndexKey, CAmount> >::const_iterator it=vect.begin(); it!=vect.end(); it++) {
-        batch.Write(make_pair(DB_ADDRESSINDEX, it->first), it->second);
+        batch.Write(std::make_pair(DB_ADDRESSINDEX, it->first), it->second);
     }
     return WriteBatch(batch);
 }
@@ -271,7 +271,7 @@ bool CBlockTreeDB::WriteAddressIndex(const std::vector<std::pair<CAddressIndexKe
 bool CBlockTreeDB::EraseAddressIndex(const std::vector<std::pair<CAddressIndexKey, CAmount > >&vect) {
     CDBBatch batch(*this);
     for (std::vector<std::pair<CAddressIndexKey, CAmount> >::const_iterator it=vect.begin(); it!=vect.end(); it++)
-    batch.Erase(make_pair(DB_ADDRESSINDEX, it->first));
+    batch.Erase(std::make_pair(DB_ADDRESSINDEX, it->first));
     return WriteBatch(batch);
 }
 
@@ -282,9 +282,9 @@ bool CBlockTreeDB::ReadAddressIndex(uint160 addressHash, AddressType type,
     boost::scoped_ptr<CDBIterator> pcursor(NewIterator());
 
     if (start > 0 && end > 0) {
-        pcursor->Seek(make_pair(DB_ADDRESSINDEX, CAddressIndexIteratorHeightKey(type, addressHash, start)));
+        pcursor->Seek(std::make_pair(DB_ADDRESSINDEX, CAddressIndexIteratorHeightKey(type, addressHash, start)));
     } else {
-        pcursor->Seek(make_pair(DB_ADDRESSINDEX, CAddressIndexIteratorKey(type, addressHash)));
+        pcursor->Seek(std::make_pair(DB_ADDRESSINDEX, CAddressIndexIteratorKey(type, addressHash)));
     }
 
     while (pcursor->Valid()) {
@@ -296,7 +296,7 @@ bool CBlockTreeDB::ReadAddressIndex(uint160 addressHash, AddressType type,
             }
             CAmount nValue;
             if (pcursor->GetValue(nValue)) {
-                addressIndex.push_back(make_pair(key.second, nValue));
+                addressIndex.push_back(std::make_pair(key.second, nValue));
                 pcursor->Next();
             } else {
                 return error("failed to get address index value");
@@ -312,7 +312,7 @@ bool CBlockTreeDB::ReadAddressIndex(uint160 addressHash, AddressType type,
 
 bool CBlockTreeDB::WriteTimestampIndex(const CTimestampIndexKey &timestampIndex) {
     CDBBatch batch(*this);
-    batch.Write(make_pair(DB_TIMESTAMPINDEX, timestampIndex), 0);
+    batch.Write(std::make_pair(DB_TIMESTAMPINDEX, timestampIndex), 0);
     return WriteBatch(batch);
 }
 
@@ -320,7 +320,7 @@ bool CBlockTreeDB::ReadTimestampIndex(const unsigned int &high, const unsigned i
 
     boost::scoped_ptr<CDBIterator> pcursor(NewIterator());
 
-    pcursor->Seek(make_pair(DB_TIMESTAMPINDEX, CTimestampIndexIteratorKey(low)));
+    pcursor->Seek(std::make_pair(DB_TIMESTAMPINDEX, CTimestampIndexIteratorKey(low)));
 
     while (pcursor->Valid()) {
         boost::this_thread::interruption_point();
@@ -421,7 +421,7 @@ int CBlockTreeDB::GetBlockIndexVersion()
 int CBlockTreeDB::GetBlockIndexVersion(uint256 const & blockHash)
 {
     boost::scoped_ptr<CDBIterator> pcursor(NewIterator());
-    pcursor->Seek(make_pair(DB_BLOCK_INDEX, blockHash));
+    pcursor->Seek(std::make_pair(DB_BLOCK_INDEX, blockHash));
     uint256 const zero_hash = uint256();
     while (pcursor->Valid()) {
         boost::this_thread::interruption_point();
@@ -479,7 +479,7 @@ using AddressIndexPtr = boost::optional<CDbIndexHelper::AddressIndex>;
 using AddressUnspentIndexPtr = boost::optional<CDbIndexHelper::AddressUnspentIndex>;
 using SpentIndexPtr = boost::optional<CDbIndexHelper::SpentIndex>;
 
-std::pair<AddressType, uint160> classifyAddress(txnouttype type, vector<vector<unsigned char> > const & addresses)
+std::pair<AddressType, uint160> classifyAddress(txnouttype type, std::vector<std::vector<unsigned char> > const & addresses)
 {
     std::pair<AddressType, uint160> result(AddressType::unknown, uint160());
     if(type == TX_PUBKEY) {
@@ -503,7 +503,7 @@ void handleInput(CTxIn const & input, size_t inputNo, uint256 const & txHash, in
     const CTxOut &prevout = coin.out;
 
     txnouttype type;
-    vector<vector<unsigned char> > addresses;
+    std::vector<std::vector<unsigned char> > addresses;
 
     if(!Solver(prevout.scriptPubKey, type, addresses)) {
         LogPrint("CDbIndexHelper", "Encountered an unsoluble script in block:%i, txHash: %s, inputNo: %i\n", height, txHash.ToString().c_str(), inputNo);
@@ -517,12 +517,12 @@ void handleInput(CTxIn const & input, size_t inputNo, uint256 const & txHash, in
     }
 
     if (addressIndex) {
-        addressIndex->push_back(make_pair(CAddressIndexKey(addrType.first, addrType.second, height, txNumber, txHash, inputNo, true), prevout.nValue * -1));
-        addressUnspentIndex->push_back(make_pair(CAddressUnspentKey(addrType.first, addrType.second, input.prevout.hash, input.prevout.n), CAddressUnspentValue()));
+        addressIndex->push_back(std::make_pair(CAddressIndexKey(addrType.first, addrType.second, height, txNumber, txHash, inputNo, true), prevout.nValue * -1));
+        addressUnspentIndex->push_back(std::make_pair(CAddressUnspentKey(addrType.first, addrType.second, input.prevout.hash, input.prevout.n), CAddressUnspentValue()));
     }
 
     if (spentIndex)
-        spentIndex->push_back(make_pair(CSpentIndexKey(input.prevout.hash, input.prevout.n), CSpentIndexValue(txHash, inputNo, height, prevout.nValue, addrType.first, addrType.second)));
+        spentIndex->push_back(std::make_pair(CSpentIndexKey(input.prevout.hash, input.prevout.n), CSpentIndexValue(txHash, inputNo, height, prevout.nValue, addrType.first, addrType.second)));
 }
 
 void handleRemint(CTxIn const & input, uint256 const & txHash, int height, int txNumber, CAmount nValue,
@@ -532,12 +532,12 @@ void handleRemint(CTxIn const & input, uint256 const & txHash, int height, int t
         return;
 
     if (addressIndex) {
-        addressIndex->push_back(make_pair(CAddressIndexKey(AddressType::zerocoinRemint, uint160(), height, txNumber, txHash, 0, true), nValue * -1));
-        addressUnspentIndex->push_back(make_pair(CAddressUnspentKey(AddressType::zerocoinRemint, uint160(), input.prevout.hash, input.prevout.n), CAddressUnspentValue()));
+        addressIndex->push_back(std::make_pair(CAddressIndexKey(AddressType::zerocoinRemint, uint160(), height, txNumber, txHash, 0, true), nValue * -1));
+        addressUnspentIndex->push_back(std::make_pair(CAddressUnspentKey(AddressType::zerocoinRemint, uint160(), input.prevout.hash, input.prevout.n), CAddressUnspentValue()));
     }
 
     if (spentIndex)
-        spentIndex->push_back(make_pair(CSpentIndexKey(input.prevout.hash, input.prevout.n), CSpentIndexValue(txHash, 0, height, nValue, AddressType::zerocoinRemint, uint160())));
+        spentIndex->push_back(std::make_pair(CSpentIndexKey(input.prevout.hash, input.prevout.n), CSpentIndexValue(txHash, 0, height, nValue, AddressType::zerocoinRemint, uint160())));
 }
 
 
@@ -559,7 +559,7 @@ void handleZerocoinSpend(Iterator const begin, Iterator const end, uint256 const
         addrType = AddressType::sigmaSpend;
     }
 
-    addressIndex->push_back(make_pair(CAddressIndexKey(addrType, uint160(), height, txNumber, txHash, 0, true), -spendAmount));
+    addressIndex->push_back(std::make_pair(CAddressIndexKey(addrType, uint160(), height, txNumber, txHash, 0, true), -spendAmount));
 }
 
 void handleOutput(const CTxOut &out, size_t outNo, uint256 const & txHash, int height, int txNumber, CCoinsViewCache const & view, bool coinbase,
@@ -569,20 +569,20 @@ void handleOutput(const CTxOut &out, size_t outNo, uint256 const & txHash, int h
         return;
 
     if(out.scriptPubKey.IsZerocoinMint())
-        addressIndex->push_back(make_pair(CAddressIndexKey(AddressType::zerocoinMint, uint160(), height, txNumber, txHash, outNo, false), out.nValue));
+        addressIndex->push_back(std::make_pair(CAddressIndexKey(AddressType::zerocoinMint, uint160(), height, txNumber, txHash, outNo, false), out.nValue));
 
     if(out.scriptPubKey.IsSigmaMint())
-        addressIndex->push_back(make_pair(CAddressIndexKey(AddressType::sigmaMint, uint160(), height, txNumber, txHash, outNo, false), out.nValue));
+        addressIndex->push_back(std::make_pair(CAddressIndexKey(AddressType::sigmaMint, uint160(), height, txNumber, txHash, outNo, false), out.nValue));
 
     if(out.scriptPubKey.IsLelantusMint())
-        addressIndex->push_back(make_pair(CAddressIndexKey(AddressType::lelantusMint, uint160(), height, txNumber, txHash, outNo, false), out.nValue));
+        addressIndex->push_back(std::make_pair(CAddressIndexKey(AddressType::lelantusMint, uint160(), height, txNumber, txHash, outNo, false), out.nValue));
 
     if(out.scriptPubKey.IsLelantusJMint())
-        addressIndex->push_back(make_pair(CAddressIndexKey(AddressType::lelantusJMint, uint160(), height, txNumber, txHash, outNo, false), out.nValue));
+        addressIndex->push_back(std::make_pair(CAddressIndexKey(AddressType::lelantusJMint, uint160(), height, txNumber, txHash, outNo, false), out.nValue));
 
 
     txnouttype type;
-    vector<vector<unsigned char> > addresses;
+    std::vector<std::vector<unsigned char> > addresses;
 
     if(!Solver(out.scriptPubKey, type, addresses)) {
         LogPrint("CDbIndexHelper", "Encountered an unsoluble script in block:%i, txHash: %s, outNo: %i\n", height, txHash.ToString().c_str(), outNo);
@@ -595,8 +595,8 @@ void handleOutput(const CTxOut &out, size_t outNo, uint256 const & txHash, int h
         return;
     }
 
-    addressIndex->push_back(make_pair(CAddressIndexKey(addrType.first, addrType.second, height, txNumber, txHash, outNo, false), out.nValue));
-    addressUnspentIndex->push_back(make_pair(CAddressUnspentKey(addrType.first, addrType.second, txHash, outNo), CAddressUnspentValue(out.nValue, out.scriptPubKey, height)));
+    addressIndex->push_back(std::make_pair(CAddressIndexKey(addrType.first, addrType.second, height, txNumber, txHash, outNo, false), out.nValue));
+    addressUnspentIndex->push_back(std::make_pair(CAddressUnspentKey(addrType.first, addrType.second, txHash, outNo), CAddressUnspentValue(out.nValue, out.scriptPubKey, height)));
 }
 }
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -635,16 +635,16 @@ void CTxMemPool::addAddressIndex(const CTxMemPoolEntry &entry, const CCoinsViewC
 
         const CTxOut &prevout = view.AccessCoin(input.prevout).out;
         if (prevout.scriptPubKey.IsPayToScriptHash()) {
-            vector<unsigned char> hashBytes(prevout.scriptPubKey.begin()+2, prevout.scriptPubKey.begin()+22);
+            std::vector<unsigned char> hashBytes(prevout.scriptPubKey.begin()+2, prevout.scriptPubKey.begin()+22);
             CMempoolAddressDeltaKey key(AddressType::payToScriptHash, uint160(hashBytes), txhash, j, 1);
             CMempoolAddressDelta delta(entry.GetTime(), prevout.nValue * -1, input.prevout.hash, input.prevout.n);
-            mapAddress.insert(make_pair(key, delta));
+            mapAddress.insert(std::make_pair(key, delta));
             inserted.push_back(key);
         } else if (prevout.scriptPubKey.IsPayToPublicKeyHash()) {
-            vector<unsigned char> hashBytes(prevout.scriptPubKey.begin()+3, prevout.scriptPubKey.begin()+23);
+            std::vector<unsigned char> hashBytes(prevout.scriptPubKey.begin()+3, prevout.scriptPubKey.begin()+23);
             CMempoolAddressDeltaKey key(AddressType::payToPubKeyHash, uint160(hashBytes), txhash, j, 1);
             CMempoolAddressDelta delta(entry.GetTime(), prevout.nValue * -1, input.prevout.hash, input.prevout.n);
-            mapAddress.insert(make_pair(key, delta));
+            mapAddress.insert(std::make_pair(key, delta));
             inserted.push_back(key);
         }
     }
@@ -652,15 +652,15 @@ void CTxMemPool::addAddressIndex(const CTxMemPoolEntry &entry, const CCoinsViewC
     for (unsigned int k = 0; k < tx.vout.size(); k++) {
         const CTxOut &out = tx.vout[k];
         if (out.scriptPubKey.IsPayToScriptHash()) {
-            vector<unsigned char> hashBytes(out.scriptPubKey.begin()+2, out.scriptPubKey.begin()+22);
+            std::vector<unsigned char> hashBytes(out.scriptPubKey.begin()+2, out.scriptPubKey.begin()+22);
             CMempoolAddressDeltaKey key(AddressType::payToScriptHash, uint160(hashBytes), txhash, k, 0);
-            mapAddress.insert(make_pair(key, CMempoolAddressDelta(entry.GetTime(), out.nValue)));
+            mapAddress.insert(std::make_pair(key, CMempoolAddressDelta(entry.GetTime(), out.nValue)));
             inserted.push_back(key);
         } else if (out.scriptPubKey.IsPayToPublicKeyHash()) {
-            vector<unsigned char> hashBytes(out.scriptPubKey.begin()+3, out.scriptPubKey.begin()+23);
+            std::vector<unsigned char> hashBytes(out.scriptPubKey.begin()+3, out.scriptPubKey.begin()+23);
             std::pair<addressDeltaMap::iterator,bool> ret;
             CMempoolAddressDeltaKey key(AddressType::payToPubKeyHash, uint160(hashBytes), txhash, k, 0);
-            mapAddress.insert(make_pair(key, CMempoolAddressDelta(entry.GetTime(), out.nValue)));
+            mapAddress.insert(std::make_pair(key, CMempoolAddressDelta(entry.GetTime(), out.nValue)));
             inserted.push_back(key);
         }
     }
@@ -717,10 +717,10 @@ void CTxMemPool::addSpentIndex(const CTxMemPoolEntry &entry, const CCoinsViewCac
         AddressType addressType;
 
         if (prevout.scriptPubKey.IsPayToScriptHash()) {
-            addressHash = uint160(vector<unsigned char> (prevout.scriptPubKey.begin()+2, prevout.scriptPubKey.begin()+22));
+            addressHash = uint160(std::vector<unsigned char> (prevout.scriptPubKey.begin()+2, prevout.scriptPubKey.begin()+22));
             addressType = AddressType::payToScriptHash;
         } else if (prevout.scriptPubKey.IsPayToPublicKeyHash()) {
-            addressHash = uint160(vector<unsigned char> (prevout.scriptPubKey.begin()+3, prevout.scriptPubKey.begin()+23));
+            addressHash = uint160(std::vector<unsigned char> (prevout.scriptPubKey.begin()+3, prevout.scriptPubKey.begin()+23));
             addressType = AddressType::payToPubKeyHash;
         } else {
             addressHash.SetNull();
@@ -730,7 +730,7 @@ void CTxMemPool::addSpentIndex(const CTxMemPoolEntry &entry, const CCoinsViewCac
         CSpentIndexKey key = CSpentIndexKey(input.prevout.hash, input.prevout.n);
         CSpentIndexValue value = CSpentIndexValue(txhash, j, -1, prevout.nValue, addressType, addressHash);
 
-        mapSpent.insert(make_pair(key, value));
+        mapSpent.insert(std::make_pair(key, value));
         inserted.push_back(key);
 
     }
@@ -1731,7 +1731,7 @@ void CTxPoolAggregate::removeForReorg(const CCoinsViewCache *pcoins, unsigned in
     stemTxPool.removeForReorg(pcoins, nMemPoolHeight, flags);
 }
 
-void CTxPoolAggregate::PrioritiseTransaction(const uint256 hash, const string strHash, double dPriorityDelta,
+void CTxPoolAggregate::PrioritiseTransaction(const uint256 hash, const std::string strHash, double dPriorityDelta,
                                        const CAmount &nFeeDelta) {
     mempool.PrioritiseTransaction(hash, strHash, dPriorityDelta, nFeeDelta);
     stemTxPool.PrioritiseTransaction(hash, strHash, dPriorityDelta, nFeeDelta);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -820,7 +820,7 @@ public:
 public:
     void UpdateTransactionsFromBlock(const std::vector <uint256> &vHashesToUpdate);
     void AddTransactionsUpdated(unsigned int n);
-    void PrioritiseTransaction(const uint256 hash, const string strHash, double dPriorityDelta, const CAmount &nFeeDelta);
+    void PrioritiseTransaction(const uint256 hash, const std::string strHash, double dPriorityDelta, const CAmount &nFeeDelta);
     void setSanityCheck(double dFrequency = 1.0);
     void getTransactions(std::set<uint256>& setTxid);
     void check(const CCoinsViewCache *pcoins) const;

--- a/src/univalue/lib/univalue.cpp
+++ b/src/univalue/lib/univalue.cpp
@@ -73,8 +73,6 @@ bool ParseDouble(const std::string& str, double *out)
 }
 }
 
-using namespace std;
-
 const UniValue NullUniValue;
 
 void UniValue::clear()
@@ -100,15 +98,15 @@ bool UniValue::setBool(bool val_)
     return true;
 }
 
-static bool validNumStr(const string& s)
+static bool validNumStr(const std::string& s)
 {
-    string tokenVal;
+    std::string tokenVal;
     unsigned int consumed;
     enum jtokentype tt = getJsonToken(tokenVal, consumed, s.c_str());
     return (tt == JTOK_NUMBER);
 }
 
-bool UniValue::setNumStr(const string& val_)
+bool UniValue::setNumStr(const std::string& val_)
 {
     if (!validNumStr(val_))
         return false;
@@ -121,7 +119,7 @@ bool UniValue::setNumStr(const string& val_)
 
 bool UniValue::setInt(uint64_t val_)
 {
-    ostringstream oss;
+    std::ostringstream oss;
 
     oss << val_;
 
@@ -130,7 +128,7 @@ bool UniValue::setInt(uint64_t val_)
 
 bool UniValue::setInt(int64_t val_)
 {
-    ostringstream oss;
+    std::ostringstream oss;
 
     oss << val_;
 
@@ -139,7 +137,7 @@ bool UniValue::setInt(int64_t val_)
 
 bool UniValue::setFloat(double val_)
 {
-    ostringstream oss;
+    std::ostringstream oss;
 
     oss << std::setprecision(16) << val_;
 
@@ -148,7 +146,7 @@ bool UniValue::setFloat(double val_)
     return ret;
 }
 
-bool UniValue::setStr(const string& val_)
+bool UniValue::setStr(const std::string& val_)
 {
     clear();
     typ = VSTR;

--- a/src/univalue/lib/univalue_read.cpp
+++ b/src/univalue/lib/univalue_read.cpp
@@ -8,8 +8,6 @@
 #include "univalue.h"
 #include "univalue_utffilter.h"
 
-using namespace std;
-
 static bool json_isdigit(int ch)
 {
     return ((ch >= '0') && (ch <= '9'));
@@ -42,7 +40,7 @@ static const char *hatoui(const char *first, const char *last,
     return first;
 }
 
-enum jtokentype getJsonToken(string& tokenVal, unsigned int& consumed,
+enum jtokentype getJsonToken(std::string& tokenVal, unsigned int& consumed,
                             const char *raw)
 {
     tokenVal.clear();
@@ -114,7 +112,7 @@ enum jtokentype getJsonToken(string& tokenVal, unsigned int& consumed,
     case '8':
     case '9': {
         // part 1: int
-        string numStr;
+        std::string numStr;
 
         const char *first = raw;
 
@@ -174,7 +172,7 @@ enum jtokentype getJsonToken(string& tokenVal, unsigned int& consumed,
     case '"': {
         raw++;                                // skip "
 
-        string valStr;
+        std::string valStr;
         JSONUTF8StringFilter writer(valStr);
 
         while (*raw) {
@@ -251,9 +249,9 @@ bool UniValue::read(const char *raw)
     clear();
 
     uint32_t expectMask = 0;
-    vector<UniValue*> stack;
+    std::vector<UniValue*> stack;
 
-    string tokenVal;
+    std::string tokenVal;
     unsigned int consumed;
     enum jtokentype tok = JTOK_NONE;
     enum jtokentype last_tok = JTOK_NONE;

--- a/src/univalue/lib/univalue_write.cpp
+++ b/src/univalue/lib/univalue_write.cpp
@@ -8,11 +8,9 @@
 #include "univalue.h"
 #include "univalue_escapes.h"
 
-using namespace std;
-
-static string json_escape(const string& inS)
+static std::string json_escape(const std::string& inS)
 {
-    string outS;
+    std::string outS;
     outS.reserve(inS.size() * 2);
 
     for (unsigned int i = 0; i < inS.size(); i++) {
@@ -28,10 +26,10 @@ static string json_escape(const string& inS)
     return outS;
 }
 
-string UniValue::write(unsigned int prettyIndent,
+std::string UniValue::write(unsigned int prettyIndent,
                        unsigned int indentLevel) const
 {
-    string s;
+    std::string s;
     s.reserve(1024);
 
     unsigned int modIndent = indentLevel;
@@ -62,12 +60,12 @@ string UniValue::write(unsigned int prettyIndent,
     return s;
 }
 
-static void indentStr(unsigned int prettyIndent, unsigned int indentLevel, string& s)
+static void indentStr(unsigned int prettyIndent, unsigned int indentLevel, std::string& s)
 {
     s.append(prettyIndent * indentLevel, ' ');
 }
 
-void UniValue::writeArray(unsigned int prettyIndent, unsigned int indentLevel, string& s) const
+void UniValue::writeArray(unsigned int prettyIndent, unsigned int indentLevel, std::string& s) const
 {
     s += "[";
     if (prettyIndent)
@@ -91,7 +89,7 @@ void UniValue::writeArray(unsigned int prettyIndent, unsigned int indentLevel, s
     s += "]";
 }
 
-void UniValue::writeObject(unsigned int prettyIndent, unsigned int indentLevel, string& s) const
+void UniValue::writeObject(unsigned int prettyIndent, unsigned int indentLevel, std::string& s) const
 {
     s += "{";
     if (prettyIndent)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -104,8 +104,6 @@ namespace boost {
 
 } // namespace boost
 
-using namespace std;
-
 // znode fZnode
 bool fMasternodeMode = false;
 bool fLiteMode = false;
@@ -115,9 +113,9 @@ const char * const BITCOIN_CONF_FILENAME = "firo.conf";
 const char * const BITCOIN_PID_FILENAME = "firod.pid";
 
 CCriticalSection cs_args;
-map<string, string> mapArgs;
-static map<string, vector<string> > _mapMultiArgs;
-const map<string, vector<string> >& mapMultiArgs = _mapMultiArgs;
+std::map<std::string, std::string> mapArgs;
+static std::map<std::string, std::vector<std::string> > _mapMultiArgs;
+const std::map<std::string, std::vector<std::string> >& mapMultiArgs = _mapMultiArgs;
 bool fDebug = false;
 bool fPrintToConsole = false;
 bool fPrintToDebugLog = true;
@@ -210,7 +208,7 @@ static boost::once_flag debugPrintInitFlag = BOOST_ONCE_INIT;
  */
 static FILE* fileout = NULL;
 static boost::mutex* mutexDebugLog = NULL;
-static list<string> *vMsgsBeforeOpenLog;
+static std::list<std::string> *vMsgsBeforeOpenLog;
 
 static int FileWriteStr(const std::string &str, FILE *fp)
 {
@@ -221,7 +219,7 @@ static void DebugPrintInit()
 {
     assert(mutexDebugLog == NULL);
     mutexDebugLog = new boost::mutex();
-    vMsgsBeforeOpenLog = new list<string>;
+    vMsgsBeforeOpenLog = new std::list<std::string>;
 }
 
 void OpenDebugLog()
@@ -257,22 +255,22 @@ bool LogAcceptCategory(const char* category)
         // This helps prevent issues debugging global destructors,
         // where mapMultiArgs might be deleted before another
         // global destructor calls LogPrint()
-        static boost::thread_specific_ptr<set<string> > ptrCategory;
+        static boost::thread_specific_ptr<std::set<std::string> > ptrCategory;
         if (ptrCategory.get() == NULL)
         {
             if (mapMultiArgs.count("-debug")) {
-                const vector<string>& categories = mapMultiArgs.at("-debug");
-                ptrCategory.reset(new set<string>(categories.begin(), categories.end()));
+                const std::vector<std::string>& categories = mapMultiArgs.at("-debug");
+                ptrCategory.reset(new std::set<std::string>(categories.begin(), categories.end()));
                 // thread_specific_ptr automatically deletes the set when the thread ends.
             } else
-                ptrCategory.reset(new set<string>());
+                ptrCategory.reset(new std::set<std::string>());
         }
-        const set<string>& setCategories = *ptrCategory.get();
+        const std::set<std::string>& setCategories = *ptrCategory.get();
 
         // if not debugging everything and not debugging specific category, LogPrint does nothing.
-        if (setCategories.count(string("")) == 0 &&
-            setCategories.count(string("1")) == 0 &&
-            setCategories.count(string(category)) == 0)
+        if (setCategories.count(std::string("")) == 0 &&
+            setCategories.count(std::string("1")) == 0 &&
+            setCategories.count(std::string(category)) == 0)
             return false;
     }
     return true;
@@ -285,7 +283,7 @@ bool LogAcceptCategory(const char* category)
  */
 static std::string LogTimestampStr(const std::string &str, std::atomic_bool *fStartedNewLine)
 {
-    string strStamped;
+    std::string strStamped;
 
     if (!fLogTimestamps)
         return str;
@@ -316,7 +314,7 @@ int LogPrintStr(const std::string &str)
     int ret = 0; // Returns total number of characters written
     static std::atomic_bool fStartedNewLine(true);
 
-    string strTimestamped = LogTimestampStr(str, &fStartedNewLine);
+    std::string strTimestamped = LogTimestampStr(str, &fStartedNewLine);
 
     if (fPrintToConsole)
     {
@@ -640,14 +638,14 @@ void ReadConfigFile(const std::string& confPath)
 
     {
         LOCK(cs_args);
-        set<string> setOptions;
+        std::set<std::string> setOptions;
         setOptions.insert("*");
 
         for (boost::program_options::detail::config_file_iterator it(streamConfig, setOptions), end; it != end; ++it)
         {
             // Don't overwrite existing settings so command line settings override bitcoin.conf
-            string strKey = string("-") + it->string_key;
-            string strValue = it->value[0];
+            std::string strKey = std::string("-") + it->string_key;
+            std::string strValue = it->value[0];
             InterpretNegativeSetting(strKey, strValue);
             if (mapArgs.count(strKey) == 0)
                 mapArgs[strKey] = strValue;

--- a/src/utilmoneystr.cpp
+++ b/src/utilmoneystr.cpp
@@ -9,8 +9,6 @@
 #include "tinyformat.h"
 #include "utilstrencodings.h"
 
-using namespace std;
-
 std::string FormatMoney(const CAmount& n)
 {
     // Note: not using straight sprintf here because we do NOT want
@@ -18,7 +16,7 @@ std::string FormatMoney(const CAmount& n)
     int64_t n_abs = (n > 0 ? n : -n);
     int64_t quotient = n_abs/COIN;
     int64_t remainder = n_abs%COIN;
-    string str = strprintf("%d.%08d", quotient, remainder);
+    std::string str = strprintf("%d.%08d", quotient, remainder);
 
     // Right-trim excess zeros before the decimal point:
     int nTrim = 0;
@@ -33,14 +31,14 @@ std::string FormatMoney(const CAmount& n)
 }
 
 
-bool ParseMoney(const string& str, CAmount& nRet)
+bool ParseMoney(const std::string& str, CAmount& nRet)
 {
     return ParseMoney(str.c_str(), nRet);
 }
 
 bool ParseMoney(const char* pszIn, CAmount& nRet)
 {
-    string strWhole;
+    std::string strWhole;
     int64_t nUnits = 0;
     const char* p = pszIn;
     while (isspace(*p))

--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -12,20 +12,18 @@
 #include <errno.h>
 #include <limits>
 
-using namespace std;
+static const std::string CHARS_ALPHA_NUM = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 
-static const string CHARS_ALPHA_NUM = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-
-static const string SAFE_CHARS[] =
+static const std::string SAFE_CHARS[] =
 {
     CHARS_ALPHA_NUM + " .,;-_/:?@()", // SAFE_CHARS_DEFAULT
     CHARS_ALPHA_NUM + " .,;-_?@", // SAFE_CHARS_UA_COMMENT
     CHARS_ALPHA_NUM + ".-_", // SAFE_CHARS_FILENAME
 };
 
-string SanitizeString(const string& str, int rule)
+std::string SanitizeString(const std::string& str, int rule)
 {
-    string strResult;
+    std::string strResult;
     for (std::string::size_type i = 0; i < str.size(); i++)
     {
         if (SAFE_CHARS[rule].find(str[i]) != std::string::npos)
@@ -57,7 +55,7 @@ signed char HexDigit(char c)
     return p_util_hexdigit[(unsigned char)c];
 }
 
-bool IsHex(const string& str)
+bool IsHex(const std::string& str)
 {
     for(std::string::const_iterator it(str.begin()); it != str.end(); ++it)
     {
@@ -67,10 +65,10 @@ bool IsHex(const string& str)
     return (str.size() > 0) && (str.size()%2 == 0);
 }
 
-vector<unsigned char> ParseHex(const char* psz)
+std::vector<unsigned char> ParseHex(const char* psz)
 {
     // convert hex dump to vector
-    vector<unsigned char> vch;
+    std::vector<unsigned char> vch;
     while (true)
     {
         while (isspace(*psz))
@@ -88,16 +86,16 @@ vector<unsigned char> ParseHex(const char* psz)
     return vch;
 }
 
-vector<unsigned char> ParseHex(const string& str)
+std::vector<unsigned char> ParseHex(const std::string& str)
 {
     return ParseHex(str.c_str());
 }
 
-string EncodeBase64(const unsigned char* pch, size_t len)
+std::string EncodeBase64(const unsigned char* pch, size_t len)
 {
     static const char *pbase64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
-    string strRet="";
+    std::string strRet="";
     strRet.reserve((len+2)/3*4);
 
     int mode=0, left=0;
@@ -139,12 +137,12 @@ string EncodeBase64(const unsigned char* pch, size_t len)
     return strRet;
 }
 
-string EncodeBase64(const string& str)
+std::string EncodeBase64(const std::string& str)
 {
     return EncodeBase64((const unsigned char*)str.c_str(), str.size());
 }
 
-vector<unsigned char> DecodeBase64(const char* p, bool* pfInvalid)
+std::vector<unsigned char> DecodeBase64(const char* p, bool* pfInvalid)
 {
     static const int decode64_table[256] =
     {
@@ -166,7 +164,7 @@ vector<unsigned char> DecodeBase64(const char* p, bool* pfInvalid)
     if (pfInvalid)
         *pfInvalid = false;
 
-    vector<unsigned char> vchRet;
+    std::vector<unsigned char> vchRet;
     vchRet.reserve(strlen(p)*3/4);
 
     int mode = 0;
@@ -227,17 +225,17 @@ vector<unsigned char> DecodeBase64(const char* p, bool* pfInvalid)
     return vchRet;
 }
 
-string DecodeBase64(const string& str)
+std::string DecodeBase64(const std::string& str)
 {
-    vector<unsigned char> vchRet = DecodeBase64(str.c_str());
-    return (vchRet.size() == 0) ? string() : string((const char*)&vchRet[0], vchRet.size());
+    std::vector<unsigned char> vchRet = DecodeBase64(str.c_str());
+    return (vchRet.size() == 0) ? std::string() : std::string((const char*)&vchRet[0], vchRet.size());
 }
 
-string EncodeBase32(const unsigned char* pch, size_t len)
+std::string EncodeBase32(const unsigned char* pch, size_t len)
 {
     static const char *pbase32 = "abcdefghijklmnopqrstuvwxyz234567";
 
-    string strRet="";
+    std::string strRet="";
     strRet.reserve((len+4)/5*8);
 
     int mode=0, left=0;
@@ -292,12 +290,12 @@ string EncodeBase32(const unsigned char* pch, size_t len)
     return strRet;
 }
 
-string EncodeBase32(const string& str)
+std::string EncodeBase32(const std::string& str)
 {
     return EncodeBase32((const unsigned char*)str.c_str(), str.size());
 }
 
-vector<unsigned char> DecodeBase32(const char* p, bool* pfInvalid)
+std::vector<unsigned char> DecodeBase32(const char* p, bool* pfInvalid)
 {
     static const int decode32_table[256] =
     {
@@ -319,7 +317,7 @@ vector<unsigned char> DecodeBase32(const char* p, bool* pfInvalid)
     if (pfInvalid)
         *pfInvalid = false;
 
-    vector<unsigned char> vchRet;
+    std::vector<unsigned char> vchRet;
     vchRet.reserve((strlen(p))*5/8);
 
     int mode = 0;
@@ -414,10 +412,10 @@ vector<unsigned char> DecodeBase32(const char* p, bool* pfInvalid)
     return vchRet;
 }
 
-string DecodeBase32(const string& str)
+std::string DecodeBase32(const std::string& str)
 {
-    vector<unsigned char> vchRet = DecodeBase32(str.c_str());
-    return (vchRet.size() == 0) ? string() : string((const char*)&vchRet[0], vchRet.size());
+    std::vector<unsigned char> vchRet = DecodeBase32(str.c_str());
+    return (vchRet.size() == 0) ? std::string() : std::string((const char*)&vchRet[0], vchRet.size());
 }
 
 static bool ParsePrechecks(const std::string& str)

--- a/src/utiltime.cpp
+++ b/src/utiltime.cpp
@@ -13,8 +13,6 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/thread.hpp>
 
-using namespace std;
-
 static int64_t nMockTime = 0; //!< For unit testing
 
 int64_t GetTime()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -138,7 +138,7 @@ static void CheckBlockIndex(const Consensus::Params& consensusParams);
 /** Constant stuff for coinbase transactions we create: */
 CScript COINBASE_FLAGS;
 
-const string strMessageMagic = "Zcoin Signed Message:\n";
+const std::string strMessageMagic = "Zcoin Signed Message:\n";
 
 // Internal stuff
 namespace {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -130,7 +130,7 @@ FeeFilterRounder filterRounder(::minRelayTxFee);
 CTxPoolAggregate txpools(::minRelayTxFee);
 
 // Firo znode
-map <uint256, int64_t> mapRejectedBlocks GUARDED_BY(cs_main);
+std::map <uint256, int64_t> mapRejectedBlocks GUARDED_BY(cs_main);
 
 
 static void CheckBlockIndex(const Consensus::Params& consensusParams);
@@ -791,14 +791,14 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
 
     // V3 sigma spends.
     sigma::CSigmaState *sigmaState = sigma::CSigmaState::GetState();
-    vector<Scalar> zcSpendSerialsV3;
-    vector<GroupElement> zcMintPubcoinsV3;
+    std::vector<Scalar> zcSpendSerialsV3;
+    std::vector<GroupElement> zcMintPubcoinsV3;
 
     //lelantus
     lelantus::CLelantusState *lelantusState = lelantus::CLelantusState::GetState();
-    vector<Scalar> lelantusSpendSerials;
-    vector<GroupElement> lelantusMintPubcoins;
-    vector<uint64_t> lelantusAmounts;
+    std::vector<Scalar> lelantusSpendSerials;
+    std::vector<GroupElement> lelantusMintPubcoins;
+    std::vector<uint64_t> lelantusAmounts;
     {
         LOCK(pool.cs);
         if (tx.IsSigmaSpend()) {
@@ -2650,7 +2650,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     std::vector<PrecomputedTransactionData> txdata;
     txdata.reserve(block.vtx.size()); // Required so that pointers to individual PrecomputedTransactionData don't get invalidated
 
-    set<uint256> txIds;
+    std::set<uint256> txIds;
     bool isMainNet = chainparams.GetConsensus().IsMain();
     // batch verify Lelantus/Sigma if block is older than a day, that means we are syncing or reindexing
     BatchProofContainer* batchProofContainer = BatchProofContainer::get_instance();

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -21,8 +21,6 @@
 #include <boost/thread.hpp>
 #include <boost/version.hpp>
 
-using namespace std;
-
 
 //
 // CDB
@@ -116,7 +114,7 @@ bool CDBEnv::Open(const boost::filesystem::path& pathIn)
 void CDBEnv::MakeMock()
 {
     if (fDbEnvInit)
-        throw runtime_error("CDBEnv::MakeMock: Already initialized");
+        throw std::runtime_error("CDBEnv::MakeMock: Already initialized");
 
     boost::this_thread::interruption_point();
 
@@ -139,7 +137,7 @@ void CDBEnv::MakeMock()
                              DB_PRIVATE,
                          S_IRUSR | S_IWUSR);
     if (ret > 0)
-        throw runtime_error(strprintf("CDBEnv::MakeMock: Error %d opening database environment.", ret));
+        throw std::runtime_error(strprintf("CDBEnv::MakeMock: Error %d opening database environment.", ret));
 
     fDbEnvInit = true;
     fMockDb = true;
@@ -176,7 +174,7 @@ bool CDBEnv::Salvage(const std::string& strFile, bool fAggressive, std::vector<C
     if (fAggressive)
         flags |= DB_AGGRESSIVE;
 
-    stringstream strDump;
+    std::stringstream strDump;
 
     Db db(dbenv, 0);
     int result = db.verify(strFile.c_str(), NULL, &strDump, flags);
@@ -200,7 +198,7 @@ bool CDBEnv::Salvage(const std::string& strFile, bool fAggressive, std::vector<C
     //  ... repeated
     // DATA=END
 
-    string strLine;
+    std::string strLine;
     while (!strDump.eof() && strLine != HEADER_END)
         getline(strDump, strLine); // Skip past header
 
@@ -253,7 +251,7 @@ CDB::CDB(const std::string& strFilename, const char* pszMode, bool fFlushOnClose
     {
         LOCK(bitdb.cs_db);
         if (!bitdb.Open(GetDataDir()))
-            throw runtime_error("CDB: Failed to open database environment.");
+            throw std::runtime_error("CDB: Failed to open database environment.");
 
         strFile = strFilename;
         ++bitdb.mapFileUseCount[strFile];
@@ -266,7 +264,7 @@ CDB::CDB(const std::string& strFilename, const char* pszMode, bool fFlushOnClose
                 DbMpoolFile* mpf = pdb->get_mpf();
                 ret = mpf->set_flags(DB_MPOOL_NOFILE, 1);
                 if (ret != 0)
-                    throw runtime_error(strprintf("CDB: Failed to configure for no temp file backing for database %s", strFile));
+                    throw std::runtime_error(strprintf("CDB: Failed to configure for no temp file backing for database %s", strFile));
             }
 
             ret = pdb->open(NULL,                               // Txn pointer
@@ -281,10 +279,10 @@ CDB::CDB(const std::string& strFilename, const char* pszMode, bool fFlushOnClose
                 pdb = NULL;
                 --bitdb.mapFileUseCount[strFile];
                 strFile = "";
-                throw runtime_error(strprintf("CDB: Error %d, can't open database %s", ret, strFilename));
+                throw std::runtime_error(strprintf("CDB: Error %d, can't open database %s", ret, strFilename));
             }
 
-            if (fCreate && !Exists(string("version"))) {
+            if (fCreate && !Exists(std::string("version"))) {
                 bool fTmp = fReadOnly;
                 fReadOnly = false;
                 WriteVersion(CLIENT_VERSION);
@@ -327,7 +325,7 @@ void CDB::Close()
     }
 }
 
-void CDBEnv::CloseDb(const string& strFile)
+void CDBEnv::CloseDb(const std::string& strFile)
 {
     {
         LOCK(cs_db);
@@ -341,7 +339,7 @@ void CDBEnv::CloseDb(const string& strFile)
     }
 }
 
-bool CDBEnv::RemoveDb(const string& strFile)
+bool CDBEnv::RemoveDb(const std::string& strFile)
 {
     this->CloseDb(strFile);
 
@@ -350,7 +348,7 @@ bool CDBEnv::RemoveDb(const string& strFile)
     return (rc == 0);
 }
 
-bool CDB::Rewrite(const string& strFile, const char* pszSkip)
+bool CDB::Rewrite(const std::string& strFile, const char* pszSkip)
 {
     while (true) {
         {
@@ -363,7 +361,7 @@ bool CDB::Rewrite(const string& strFile, const char* pszSkip)
 
                 bool fSuccess = true;
                 LogPrintf("CDB::Rewrite: Rewriting %s...\n", strFile);
-                string strFileRes = strFile + ".rewrite";
+                std::string strFileRes = strFile + ".rewrite";
                 { // surround usage of db with extra {}
                     CDB db(strFile.c_str(), "r");
                     Db* pdbCopy = new Db(bitdb.dbenv, 0);
@@ -443,9 +441,9 @@ void CDBEnv::Flush(bool fShutdown)
         return;
     {
         LOCK(cs_db);
-        map<string, int>::iterator mi = mapFileUseCount.begin();
+        std::map<std::string, int>::iterator mi = mapFileUseCount.begin();
         while (mi != mapFileUseCount.end()) {
-            string strFile = (*mi).first;
+            std::string strFile = (*mi).first;
             int nRefCount = (*mi).second;
             LogPrint("db", "CDBEnv::Flush: Flushing %s (refcount = %d)...\n", strFile, nRefCount);
             if (nRefCount == 0) {

--- a/src/wallet/lelantusjoinsplitbuilder.cpp
+++ b/src/wallet/lelantusjoinsplitbuilder.cpp
@@ -451,7 +451,7 @@ void LelantusJoinSplitBuilder::CreateJoinSplit(
             throw std::runtime_error(_("One of the lelantus coins has not been found in the chain!"));
         }
 
-        coins.emplace_back(make_pair(priv, groupId));
+        coins.emplace_back(std::make_pair(priv, groupId));
         std::vector<unsigned char> setHash;
         if (anonymity_sets.count(groupId) == 0) {
             std::vector<lelantus::PublicCoin> set;
@@ -499,7 +499,7 @@ void LelantusJoinSplitBuilder::CreateJoinSplit(
 
         //this way we are remembering denomination and group id in one field as we have no demomination in Lelantus
         // with dividing by 1000 we just making maximum denomiation fit into uint32
-        coins.emplace_back(make_pair(priv, denom / 1000 + groupId));
+        coins.emplace_back(std::make_pair(priv, denom / 1000 + groupId));
 
 
         if (anonymity_sets.count(denom / 1000 + groupId) == 0) {

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -30,8 +30,6 @@
 #include <boost/assign/list_of.hpp>
 #include <boost/foreach.hpp>
 
-using namespace std;
-
 bool EnsureWalletIsAvailable(bool avoidException);
 
 std::string static EncodeDumpTime(int64_t nTime) {
@@ -85,7 +83,7 @@ UniValue importprivkey(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 3)
-        throw runtime_error(
+        throw std::runtime_error(
             "importprivkey \"firoprivkey\" ( \"label\" ) ( rescan )\n"
             "\nAdds a private key (as returned by dumpprivkey) to your wallet.\n"
             "\nArguments:\n"
@@ -118,8 +116,8 @@ UniValue importprivkey(const JSONRPCRequest& request)
     }
 
 
-    string strSecret = request.params[0].get_str();
-    string strLabel = "";
+    std::string strSecret = request.params[0].get_str();
+    std::string strLabel = "";
     if (request.params.size() > 1)
         strLabel = request.params[1].get_str();
 
@@ -168,8 +166,8 @@ UniValue importprivkey(const JSONRPCRequest& request)
     return NullUniValue;
 }
 
-void ImportAddress(CWallet *, const CBitcoinAddress& address, const string& strLabel);
-void ImportScript(CWallet * const pwallet, const CScript& script, const string& strLabel, bool isRedeemScript)
+void ImportAddress(CWallet *, const CBitcoinAddress& address, const std::string& strLabel);
+void ImportScript(CWallet * const pwallet, const CScript& script, const std::string& strLabel, bool isRedeemScript)
 {
     if (!isRedeemScript && ::IsMine(*pwallet, script) == ISMINE_SPENDABLE) {
         throw JSONRPCError(RPC_WALLET_ERROR, "The wallet already contains the private key for this address or script");
@@ -194,7 +192,7 @@ void ImportScript(CWallet * const pwallet, const CScript& script, const string& 
     }
 }
 
-void ImportAddress(CWallet * const pwallet, const CBitcoinAddress& address, const string& strLabel)
+void ImportAddress(CWallet * const pwallet, const CBitcoinAddress& address, const std::string& strLabel)
 {
     CScript script = GetScriptForDestination(address.Get());
     ImportScript(pwallet, script, strLabel, false);
@@ -211,7 +209,7 @@ UniValue importaddress(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 4)
-        throw runtime_error(
+        throw std::runtime_error(
             "importaddress \"address\" ( \"label\" rescan p2sh )\n"
             "\nAdds a script (in hex) or address that can be watched as if it were in your wallet but cannot be used to spend.\n"
             "\nArguments:\n"
@@ -233,7 +231,7 @@ UniValue importaddress(const JSONRPCRequest& request)
         );
 
 
-    string strLabel = "";
+    std::string strLabel = "";
     if (request.params.size() > 1)
         strLabel = request.params[1].get_str();
 
@@ -281,7 +279,7 @@ UniValue importprunedfunds(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() != 2)
-        throw runtime_error(
+        throw std::runtime_error(
             "importprunedfunds\n"
             "\nImports funds without rescan. Corresponding address or script must previously be included in wallet. Aimed towards pruned wallets. The end-user is responsible to import additional transactions that subsequently spend the imported outputs or rescan after the point in the blockchain the transaction is included.\n"
             "\nArguments:\n"
@@ -300,8 +298,8 @@ UniValue importprunedfunds(const JSONRPCRequest& request)
     ssMB >> merkleBlock;
 
     //Search partial merkle tree in proof for our transaction and index in valid block
-    vector<uint256> vMatch;
-    vector<unsigned int> vIndex;
+    std::vector<uint256> vMatch;
+    std::vector<unsigned int> vIndex;
     unsigned int txnIndex = 0;
     if (merkleBlock.txn.ExtractMatches(vMatch, vIndex) == merkleBlock.header.hashMerkleRoot) {
 
@@ -310,7 +308,7 @@ UniValue importprunedfunds(const JSONRPCRequest& request)
         if (!mapBlockIndex.count(merkleBlock.header.GetHash()) || !chainActive.Contains(mapBlockIndex[merkleBlock.header.GetHash()]))
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found in chain");
 
-        vector<uint256>::const_iterator it;
+        std::vector<uint256>::const_iterator it;
         if ((it = std::find(vMatch.begin(), vMatch.end(), hashTx))==vMatch.end()) {
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Transaction given doesn't exist in proof");
         }
@@ -342,7 +340,7 @@ UniValue removeprunedfunds(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() != 1)
-        throw runtime_error(
+        throw std::runtime_error(
             "removeprunedfunds \"txid\"\n"
             "\nDeletes the specified transaction from the wallet. Meant for use with pruned wallets and as a companion to importprunedfunds. This will effect wallet balances.\n"
             "\nArguments:\n"
@@ -357,9 +355,9 @@ UniValue removeprunedfunds(const JSONRPCRequest& request)
 
     uint256 hash;
     hash.SetHex(request.params[0].get_str());
-    vector<uint256> vHash;
+    std::vector<uint256> vHash;
     vHash.push_back(hash);
-    vector<uint256> vHashOut;
+    std::vector<uint256> vHashOut;
 
     if (pwallet->ZapSelectTx(vHash, vHashOut) != DB_LOAD_OK) {
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Could not properly delete the transaction.");
@@ -380,7 +378,7 @@ UniValue importpubkey(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 4)
-        throw runtime_error(
+        throw std::runtime_error(
             "importpubkey \"pubkey\" ( \"label\" rescan )\n"
             "\nAdds a public key (in hex) that can be watched as if it were in your wallet but cannot be used to spend.\n"
             "\nArguments:\n"
@@ -398,7 +396,7 @@ UniValue importpubkey(const JSONRPCRequest& request)
         );
 
 
-    string strLabel = "";
+    std::string strLabel = "";
     if (request.params.size() > 1)
         strLabel = request.params[1].get_str();
 
@@ -440,7 +438,7 @@ UniValue importwallet(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() != 1)
-        throw runtime_error(
+        throw std::runtime_error(
             "importwallet \"filename\"\n"
             "\nImports keys from a wallet dump file (see dumpwallet).\n"
             "\nArguments:\n"
@@ -468,7 +466,7 @@ UniValue importwallet(const JSONRPCRequest& request)
     }
 
 
-    ifstream file;
+    std::ifstream file;
     file.open(request.params[0].get_str().c_str(), std::ios::in | std::ios::ate);
     if (!file.is_open())
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot open wallet dump file");
@@ -595,7 +593,7 @@ UniValue dumpprivkey(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() != 1)
-        throw runtime_error(
+        throw std::runtime_error(
             "dumpprivkey \"address\"\n"
             "\nReveals the private key corresponding to 'address'.\n"
             "Then the importprivkey can be used with this output\n"
@@ -613,7 +611,7 @@ UniValue dumpprivkey(const JSONRPCRequest& request)
 
     EnsureWalletIsUnlocked(pwallet);
 
-    string strAddress = request.params[0].get_str();
+    std::string strAddress = request.params[0].get_str();
     CBitcoinAddress address;
     if (!address.SetString(strAddress))
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Firo address");
@@ -631,7 +629,7 @@ UniValue dumpprivkey_firo(const JSONRPCRequest& request)
 {
 #ifndef UNSAFE_DUMPPRIVKEY
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
-        throw runtime_error(
+        throw std::runtime_error(
             "dumpprivkey \"firoaddress\"\n"
             "\nReveals the private key corresponding to 'firoaddress'.\n"
             "Then the importprivkey can be used with this output\n"
@@ -662,7 +660,7 @@ UniValue dumpprivkey_firo(const JSONRPCRequest& request)
             " Reddit: https://www.reddit.com/r/FiroProject/\n"
             "\n"
             ;
-        throw runtime_error(warning);
+        throw std::runtime_error(warning);
     }
 #endif
 
@@ -681,7 +679,7 @@ UniValue dumpwallet(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() != 1)
-        throw runtime_error(
+        throw std::runtime_error(
             "dumpwallet \"filename\"\n"
             "\nDumps all wallet keys in a human-readable format.\n"
             "\nArguments:\n"
@@ -695,7 +693,7 @@ UniValue dumpwallet(const JSONRPCRequest& request)
 
     EnsureWalletIsUnlocked(pwallet);
 
-    ofstream file;
+    std::ofstream file;
     file.open(request.params[0].get_str().c_str());
     if (!file.is_open())
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot open wallet dump file");
@@ -790,7 +788,7 @@ UniValue dumpwallet(const JSONRPCRequest& request)
             if(!masterKeyID.IsNull()){
                 if(pwallet->mapKeyMetadata.find(keyid) != pwallet->mapKeyMetadata.end()){
                     if(pwallet->mapKeyMetadata[keyid].nVersion >= CKeyMetadata::VERSION_WITH_HDDATA){
-                        string hdKeypath = pwallet->mapKeyMetadata[keyid].hdKeypath;
+                        std::string hdKeypath = pwallet->mapKeyMetadata[keyid].hdKeypath;
                         uint160 hdMasterKeyID = pwallet->mapKeyMetadata[keyid].hdMasterKeyID;
                         if(hdKeypath != "")
                             file << strprintf(" hdKeypath=%s", hdKeypath);
@@ -813,7 +811,7 @@ UniValue dumpwallet_firo(const JSONRPCRequest& request)
 {
 #ifndef UNSAFE_DUMPPRIVKEY
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
-        throw runtime_error(
+        throw std::runtime_error(
             "dumpwallet \"filename\"\n"
             "\nDumps all wallet keys in a human-readable format.\n"
             "\nArguments:\n"
@@ -840,7 +838,7 @@ UniValue dumpwallet_firo(const JSONRPCRequest& request)
             " Reddit: https://www.reddit.com/r/FiroProject/\n"
             "\n"
             ;
-        throw runtime_error(warning);
+        throw std::runtime_error(warning);
     }
 #endif
 
@@ -865,16 +863,16 @@ UniValue ProcessImport(CWallet *pwallet, const UniValue& data, const int64_t tim
         }
 
         // Optional fields.
-        const string& strRedeemScript = data.exists("redeemscript") ? data["redeemscript"].get_str() : "";
+        const std::string& strRedeemScript = data.exists("redeemscript") ? data["redeemscript"].get_str() : "";
         const UniValue& pubKeys = data.exists("pubkeys") ? data["pubkeys"].get_array() : UniValue();
         const UniValue& keys = data.exists("keys") ? data["keys"].get_array() : UniValue();
         const bool& internal = data.exists("internal") ? data["internal"].get_bool() : false;
         const bool& watchOnly = data.exists("watchonly") ? data["watchonly"].get_bool() : false;
-        const string& label = data.exists("label") && !internal ? data["label"].get_str() : "";
+        const std::string& label = data.exists("label") && !internal ? data["label"].get_str() : "";
 
         bool isScript = scriptPubKey.getType() == UniValue::VSTR;
         bool isP2SH = strRedeemScript.length() > 0;
-        const string& output = isScript ? scriptPubKey.get_str() : scriptPubKey["address"].get_str();
+        const std::string& output = isScript ? scriptPubKey.get_str() : scriptPubKey["address"].get_str();
 
         // Parse the output.
         CScript script;
@@ -964,7 +962,7 @@ UniValue ProcessImport(CWallet *pwallet, const UniValue& data, const int64_t tim
             // Import private keys.
             if (keys.size()) {
                 for (size_t i = 0; i < keys.size(); i++) {
-                    const string& privkey = keys[i].get_str();
+                    const std::string& privkey = keys[i].get_str();
 
                     CBitcoinSecret vchSecret;
                     bool fGood = vchSecret.SetString(privkey);
@@ -1004,7 +1002,7 @@ UniValue ProcessImport(CWallet *pwallet, const UniValue& data, const int64_t tim
         } else {
             // Import public keys.
             if (pubKeys.size() && keys.size() == 0) {
-                const string& strPubKey = pubKeys[0].get_str();
+                const std::string& strPubKey = pubKeys[0].get_str();
 
                 if (!IsHex(strPubKey)) {
                     throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Pubkey must be a hex string");
@@ -1072,7 +1070,7 @@ UniValue ProcessImport(CWallet *pwallet, const UniValue& data, const int64_t tim
 
             // Import private keys.
             if (keys.size()) {
-                const string& strPrivkey = keys[0].get_str();
+                const std::string& strPrivkey = keys[0].get_str();
 
                 // Checks.
                 CBitcoinSecret vchSecret;
@@ -1191,7 +1189,7 @@ UniValue importmulti(const JSONRPCRequest& mainRequest)
 
     // clang-format off
     if (mainRequest.fHelp || mainRequest.params.size() < 1 || mainRequest.params.size() > 2)
-        throw runtime_error(
+        throw std::runtime_error(
             "importmulti \"requests\" \"options\"\n\n"
             "Import addresses/scripts (with private or public keys, redeem script (P2SH)), rescanning all addresses in one-shot-only (rescan can be disabled via options).\n\n"
             "Arguments:\n"

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -851,7 +851,7 @@ UniValue getprivatebalance(const JSONRPCRequest& request)
     EnsureLelantusWalletIsAvailable();
 
     if (request.fHelp || request.params.size() != 0)
-        throw runtime_error(
+        throw std::runtime_error(
             "getprivatebalance\n"
             "\nReturns  private balance.\n"
             "Private balance is the sum of all confirmed sigma/lelantus mints which are created by the wallet.\n"
@@ -878,7 +878,7 @@ UniValue gettotalbalance(const JSONRPCRequest& request)
     EnsureLelantusWalletIsAvailable();
 
     if (request.fHelp || request.params.size() != 0)
-        throw runtime_error(
+        throw std::runtime_error(
             "gettotalbalance\n"
             "\nReturns total (transparent + private) balance.\n"
             "Transparent balance is the sum of coin amounts received as utxo.\n"

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -843,6 +843,61 @@ UniValue getbalance(const JSONRPCRequest& request)
     return ValueFromAmount(pwallet->GetLegacyBalance(filter, nMinDepth, account));
 }
 
+UniValue getprivatebalance(const JSONRPCRequest& request)
+{
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp)) {
+        return NullUniValue;
+    }
+
+    EnsureLelantusWalletIsAvailable();
+
+    if (request.fHelp || request.params.size() != 0)
+        throw runtime_error(
+            "getprivatebalance\n"
+            "\nReturns  private balance.\n"
+            "Private balance is the sum of all confirmed sigma/lelantus mints which are created by the wallet.\n"
+            "\nResult:\n"
+            "amount              (numeric) The confirmed private balance in " + CURRENCY_UNIT + ".\n"
+            "\nExamples:\n"
+            "\nThe total amount in the wallet\n"
+            + HelpExampleCli("getprivatebalance", "")
+            + HelpExampleRpc("getprivatebalance", "")
+        );
+
+    LOCK2(cs_main, pwallet->cs_wallet);
+
+    return  ValueFromAmount(pwallet->GetPrivateBalance().first);
+}
+
+UniValue gettotalbalance(const JSONRPCRequest& request)
+{
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp)) {
+        return NullUniValue;
+    }
+
+    EnsureLelantusWalletIsAvailable();
+
+    if (request.fHelp || request.params.size() != 0)
+        throw runtime_error(
+            "gettotalbalance\n"
+            "\nReturns total (transparent + private) balance.\n"
+            "Transparent balance is the sum of coin amounts received as utxo.\n"
+            "Private balance is the sum of all confirmed sigma/lelantus mints which are created by the wallet.\n"
+            "\nResult:\n"
+            "amount              (numeric) The total balance in " + CURRENCY_UNIT + " for the wallet.\n"
+            "\nExamples:\n"
+            "\nThe total amount in the wallet\n"
+            + HelpExampleCli("gettotalbalance", "")
+            + HelpExampleRpc("gettotalbalance", "")
+        );
+
+    LOCK2(cs_main, pwallet->cs_wallet);
+
+    return  ValueFromAmount(pwallet->GetBalance() + pwallet->GetPrivateBalance().first);
+}
+
 UniValue getunconfirmedbalance(const JSONRPCRequest &request)
 {
     CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
@@ -4746,6 +4801,8 @@ static const CRPCCommand commands[] =
     { "wallet",             "getaccount",               &getaccount,               true,   {"address"} },
     { "wallet",             "getaddressesbyaccount",    &getaddressesbyaccount,    true,   {"account"} },
     { "wallet",             "getbalance",               &getbalance,               false,  {"account","minconf","include_watchonly"} },
+    { "wallet",             "getprivatebalance",        &getprivatebalance,        false,  {} },
+    { "wallet",             "gettotalbalance",          &gettotalbalance,          false,  {} },
     { "wallet",             "getnewaddress",            &getnewaddress,            true,   {"account"} },
     { "wallet",             "getrawchangeaddress",      &getrawchangeaddress,      true,   {} },
     { "wallet",             "getreceivedbyaccount",     &getreceivedbyaccount,     false,  {"account","minconf"} },

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -36,8 +36,6 @@
 
 #include <univalue.h>
 
-using namespace std;
-
 int64_t nWalletUnlockTime;
 static CCriticalSection cs_nWalletUnlockTime;
 
@@ -86,13 +84,13 @@ void EnsureWalletIsUnlocked(CWallet * const pwallet)
 }
 
 bool ValidMultiMint(CWallet * const pwallet, const UniValue& data){
-    vector<string> keys = data.getKeys();
+    std::vector<std::string> keys = data.getKeys();
     CAmount totalValue = 0;
     int totalInputs = 0;
     int denomination;
     int64_t amount;
-    BOOST_FOREACH(const string& denominationStr, keys){
-        denomination = stoi(denominationStr.c_str());
+    BOOST_FOREACH(const std::string& denominationStr, keys){
+        denomination = std::stoi(denominationStr.c_str());
         amount = data[denominationStr].get_int();
         totalInputs += amount;
         totalValue += denomination * amount * COIN;
@@ -138,13 +136,13 @@ void WalletTxToJSON(const CWalletTx& wtx, UniValue& entry)
     }
     entry.push_back(Pair("bip125-replaceable", rbfStatus));
 
-    BOOST_FOREACH(const PAIRTYPE(string,string)& item, wtx.mapValue)
+    BOOST_FOREACH(const PAIRTYPE(std::string,std::string)& item, wtx.mapValue)
         entry.push_back(Pair(item.first, item.second));
 }
 
-string AccountFromValue(const UniValue& value)
+std::string AccountFromValue(const UniValue& value)
 {
-    string strAccount = value.get_str();
+    std::string strAccount = value.get_str();
     if (strAccount == "*")
         throw JSONRPCError(RPC_WALLET_INVALID_ACCOUNT_NAME, "Invalid account name");
     return strAccount;
@@ -158,7 +156,7 @@ UniValue getnewaddress(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() > 1)
-        throw runtime_error(
+        throw std::runtime_error(
             "getnewaddress ( \"account\" )\n"
             "\nReturns a new Firo address for receiving payments.\n"
             "If 'account' is specified (DEPRECATED), it is added to the address book \n"
@@ -175,7 +173,7 @@ UniValue getnewaddress(const JSONRPCRequest& request)
     LOCK2(cs_main, pwallet->cs_wallet);
 
     // Parse the account first so we don't generate a key if there's an error
-    string strAccount;
+    std::string strAccount;
     if (request.params.size() > 0)
         strAccount = AccountFromValue(request.params[0]);
 
@@ -196,7 +194,7 @@ UniValue getnewaddress(const JSONRPCRequest& request)
 }
 
 
-CBitcoinAddress GetAccountAddress(CWallet * const pwallet, string strAccount, bool bForceNew=false)
+CBitcoinAddress GetAccountAddress(CWallet * const pwallet, std::string strAccount, bool bForceNew=false)
 {
     CPubKey pubKey;
     if (!pwallet->GetAccountPubkey(pubKey, strAccount, bForceNew)) {
@@ -214,7 +212,7 @@ UniValue getaccountaddress(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() != 1)
-        throw runtime_error(
+        throw std::runtime_error(
             "getaccountaddress \"account\"\n"
             "\nDEPRECATED. Returns the current Firo address for receiving payments to this account.\n"
             "\nArguments:\n"
@@ -231,7 +229,7 @@ UniValue getaccountaddress(const JSONRPCRequest& request)
     LOCK2(cs_main, pwallet->cs_wallet);
 
     // Parse the account first so we don't generate a key if there's an error
-    string strAccount = AccountFromValue(request.params[0]);
+    std::string strAccount = AccountFromValue(request.params[0]);
 
     UniValue ret(UniValue::VSTR);
 
@@ -248,7 +246,7 @@ UniValue getrawchangeaddress(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() > 1)
-        throw runtime_error(
+        throw std::runtime_error(
             "getrawchangeaddress\n"
             "\nReturns a new Firo address, for receiving change.\n"
             "This is for use with raw transactions, NOT normal use.\n"
@@ -286,7 +284,7 @@ UniValue setaccount(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
-        throw runtime_error(
+        throw std::runtime_error(
             "setaccount \"firoaddress\" \"account\"\n"
             "\nDEPRECATED. Sets the account associated with the given address.\n"
             "\nArguments:\n"
@@ -303,7 +301,7 @@ UniValue setaccount(const JSONRPCRequest& request)
     if (!address.IsValid())
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Firo address");
 
-    string strAccount;
+    std::string strAccount;
     if (request.params.size() > 1)
         strAccount = AccountFromValue(request.params[1]);
 
@@ -311,7 +309,7 @@ UniValue setaccount(const JSONRPCRequest& request)
     if (IsMine(*pwallet, address.Get())) {
         // Detect when changing the account of an address that is the 'unused current key' of another account:
         if (pwallet->mapAddressBook.count(address.Get())) {
-            string strOldAccount = pwallet->mapAddressBook[address.Get()].name;
+            std::string strOldAccount = pwallet->mapAddressBook[address.Get()].name;
             if (address == GetAccountAddress(pwallet, strOldAccount)) {
                 GetAccountAddress(pwallet, strOldAccount, true);
             }
@@ -333,7 +331,7 @@ UniValue getaccount(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() != 1)
-        throw runtime_error(
+        throw std::runtime_error(
             "getaccount \"firoaddress\"\n"
             "\nDEPRECATED. Returns the account associated with the given address.\n"
             "\nArguments:\n"
@@ -351,8 +349,8 @@ UniValue getaccount(const JSONRPCRequest& request)
     if (!address.IsValid())
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Firo address");
 
-    string strAccount;
-    map<CTxDestination, CAddressBookData>::iterator mi = pwallet->mapAddressBook.find(address.Get());
+    std::string strAccount;
+    std::map<CTxDestination, CAddressBookData>::iterator mi = pwallet->mapAddressBook.find(address.Get());
     if (mi != pwallet->mapAddressBook.end() && !(*mi).second.name.empty()) {
         strAccount = (*mi).second.name;
     }
@@ -362,7 +360,7 @@ UniValue getaccount(const JSONRPCRequest& request)
 UniValue setmininput(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 1)
-        throw runtime_error(
+        throw std::runtime_error(
                 "setmininput <amount>\n"
                         "<amount> is a real and is rounded to the nearest 0.00000001");
 
@@ -384,7 +382,7 @@ UniValue getaddressesbyaccount(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() != 1)
-        throw runtime_error(
+        throw std::runtime_error(
             "getaddressesbyaccount \"account\"\n"
             "\nDEPRECATED. Returns the list of addresses for the given account.\n"
             "\nArguments:\n"
@@ -401,13 +399,13 @@ UniValue getaddressesbyaccount(const JSONRPCRequest& request)
 
     LOCK2(cs_main, pwallet->cs_wallet);
 
-    string strAccount = AccountFromValue(request.params[0]);
+    std::string strAccount = AccountFromValue(request.params[0]);
 
     // Find all addresses that have the given account
     UniValue ret(UniValue::VARR);
     for (const std::pair<CBitcoinAddress, CAddressBookData>& item : pwallet->mapAddressBook) {
         const CBitcoinAddress& address = item.first;
-        const string& strName = item.second.name;
+        const std::string& strName = item.second.name;
         if (strName == strAccount)
             ret.push_back(address.ToString());
     }
@@ -436,7 +434,7 @@ static void SendMoney(CWallet * const pwallet, const CTxDestination &address, CA
     CReserveKey reservekey(pwallet);
     CAmount nFeeRequired;
     std::string strError;
-    vector<CRecipient> vecSend;
+    std::vector<CRecipient> vecSend;
     int nChangePosRet = -1;
     CRecipient recipient = {scriptPubKey, nValue, fSubtractFeeFromAmount};
     vecSend.push_back(recipient);
@@ -460,7 +458,7 @@ UniValue sendtoaddress(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() < 2 || request.params.size() > 5)
-        throw runtime_error(
+        throw std::runtime_error(
             "sendtoaddress \"firoaddress\" amount ( \"comment\" \"comment-to\" subtractfeefromamount )\n"
             "\nSend an amount to a given address.\n"
             + HelpRequiringPassphrase(pwallet) +
@@ -520,7 +518,7 @@ UniValue listaddressgroupings(const JSONRPCRequest& request)
     }
 
     if (request.fHelp)
-        throw runtime_error(
+        throw std::runtime_error(
             "listaddressgroupings\n"
             "\nLists groups of addresses which have had their common ownership\n"
             "made public by common use as inputs or as the resulting change\n"
@@ -545,8 +543,8 @@ UniValue listaddressgroupings(const JSONRPCRequest& request)
     LOCK2(cs_main, pwallet->cs_wallet);
 
     UniValue jsonGroupings(UniValue::VARR);
-    map<CTxDestination, CAmount> balances = pwallet->GetAddressBalances();
-    for (set<CTxDestination> grouping : pwallet->GetAddressGroupings()) {
+    std::map<CTxDestination, CAmount> balances = pwallet->GetAddressBalances();
+    for (std::set<CTxDestination> grouping : pwallet->GetAddressGroupings()) {
         UniValue jsonGrouping(UniValue::VARR);
         BOOST_FOREACH(CTxDestination address, grouping)
         {
@@ -615,7 +613,7 @@ UniValue signmessage(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() != 2)
-        throw runtime_error(
+        throw std::runtime_error(
             "signmessage \"firoaddress\" \"message\"\n"
             "\nSign a message with the private key of an address"
             + HelpRequiringPassphrase(pwallet) + "\n"
@@ -639,8 +637,8 @@ UniValue signmessage(const JSONRPCRequest& request)
 
     EnsureWalletIsUnlocked(pwallet);
 
-    string strAddress = request.params[0].get_str();
-    string strMessage = request.params[1].get_str();
+    std::string strAddress = request.params[0].get_str();
+    std::string strMessage = request.params[1].get_str();
 
     CBitcoinAddress addr(strAddress);
     if (!addr.IsValid())
@@ -659,7 +657,7 @@ UniValue signmessage(const JSONRPCRequest& request)
     ss << strMessageMagic;
     ss << strMessage;
 
-    vector<unsigned char> vchSig;
+    std::vector<unsigned char> vchSig;
     if (!key.SignCompact(ss.GetHash(), vchSig))
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Sign failed");
 
@@ -674,7 +672,7 @@ UniValue getreceivedbyaddress(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
-        throw runtime_error(
+        throw std::runtime_error(
             "getreceivedbyaddress \"firoaddress\" ( minconf )\n"
             "\nReturns the total amount received by the given firoaddress in transactions with at least minconf confirmations.\n"
             "\nArguments:\n"
@@ -734,7 +732,7 @@ UniValue getreceivedbyaccount(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
-        throw runtime_error(
+        throw std::runtime_error(
             "getreceivedbyaccount \"account\" ( minconf )\n"
             "\nDEPRECATED. Returns the total amount received by addresses with <account> in transactions with at least [minconf] confirmations.\n"
             "\nArguments:\n"
@@ -761,8 +759,8 @@ UniValue getreceivedbyaccount(const JSONRPCRequest& request)
         nMinDepth = request.params[1].get_int();
 
     // Get the set of pub keys assigned to account
-    string strAccount = AccountFromValue(request.params[0]);
-    set<CTxDestination> setAddress = pwallet->GetAccountAddresses(strAccount);
+    std::string strAccount = AccountFromValue(request.params[0]);
+    std::set<CTxDestination> setAddress = pwallet->GetAccountAddresses(strAccount);
 
     // Tally
     CAmount nAmount = 0;
@@ -793,7 +791,7 @@ UniValue getbalance(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() > 3)
-        throw runtime_error(
+        throw std::runtime_error(
             "getbalance ( \"account\" minconf include_watchonly )\n"
             "\nIf account is not specified, returns the server's total available balance.\n"
             "If account is specified (DEPRECATED), returns the balance in the account.\n"
@@ -906,7 +904,7 @@ UniValue getunconfirmedbalance(const JSONRPCRequest &request)
     }
 
     if (request.fHelp || request.params.size() > 0)
-        throw runtime_error(
+        throw std::runtime_error(
                 "getunconfirmedbalance\n"
                 "Returns the server's total unconfirmed balance\n");
 
@@ -924,7 +922,7 @@ UniValue movecmd(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() < 3 || request.params.size() > 5)
-        throw runtime_error(
+        throw std::runtime_error(
             "move \"fromaccount\" \"toaccount\" amount ( minconf \"comment\" )\n"
             "\nDEPRECATED. Move a specified amount from one account in your wallet to another.\n"
             "\nArguments:\n"
@@ -946,15 +944,15 @@ UniValue movecmd(const JSONRPCRequest& request)
 
     LOCK2(cs_main, pwallet->cs_wallet);
 
-    string strFrom = AccountFromValue(request.params[0]);
-    string strTo = AccountFromValue(request.params[1]);
+    std::string strFrom = AccountFromValue(request.params[0]);
+    std::string strTo = AccountFromValue(request.params[1]);
     CAmount nAmount = AmountFromValue(request.params[2]);
     if (nAmount <= 0)
         throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount for send");
     if (request.params.size() > 3)
         // unused parameter, used to be nMinDepth, keep type-checking it though
         (void)request.params[3].get_int();
-    string strComment;
+    std::string strComment;
     if (request.params.size() > 4)
         strComment = request.params[4].get_str();
 
@@ -974,7 +972,7 @@ UniValue sendfrom(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() < 3 || request.params.size() > 6)
-        throw runtime_error(
+        throw std::runtime_error(
             "sendfrom \"fromaccount\" \"toaddress\" amount ( minconf \"comment\" \"comment_to\" )\n"
             "\nDEPRECATED (use sendtoaddress). Sent an amount from an account to a bitcoin address."
             + HelpRequiringPassphrase(pwallet) + "\n"
@@ -1004,7 +1002,7 @@ UniValue sendfrom(const JSONRPCRequest& request)
 
     LOCK2(cs_main, pwallet->cs_wallet);
 
-    string strAccount = AccountFromValue(request.params[0]);
+    std::string strAccount = AccountFromValue(request.params[0]);
     CBitcoinAddress address(request.params[1].get_str());
     if (!address.IsValid())
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Firo address");
@@ -1043,7 +1041,7 @@ UniValue sendmany(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() < 2 || request.params.size() > 5)
-        throw runtime_error(
+        throw std::runtime_error(
             "sendmany \"fromaccount\" {\"address\":amount,...} ( minconf \"comment\" [\"address\",...] )\n"
             "\nSend multiple times. Amounts are double-precision floating point numbers."
             + HelpRequiringPassphrase(pwallet) + "\n"
@@ -1084,7 +1082,7 @@ UniValue sendmany(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
     }
 
-    string strAccount = AccountFromValue(request.params[0]);
+    std::string strAccount = AccountFromValue(request.params[0]);
     UniValue sendTo = request.params[1].get_obj();
     int nMinDepth = 1;
     if (request.params.size() > 2)
@@ -1099,19 +1097,19 @@ UniValue sendmany(const JSONRPCRequest& request)
     if (request.params.size() > 4)
         subtractFeeFromAmount = request.params[4].get_array();
 
-    set<CBitcoinAddress> setAddress;
-    vector<CRecipient> vecSend;
+    std::set<CBitcoinAddress> setAddress;
+    std::vector<CRecipient> vecSend;
 
     CAmount totalAmount = 0;
-    vector<string> keys = sendTo.getKeys();
-    BOOST_FOREACH(const string& name_, keys)
+    std::vector<std::string> keys = sendTo.getKeys();
+    BOOST_FOREACH(const std::string& name_, keys)
     {
         CBitcoinAddress address(name_);
         if (!address.IsValid())
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, string("Invalid Firo address: ")+name_);
+            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid Firo address: ")+name_);
 
         if (setAddress.count(address))
-            throw JSONRPCError(RPC_INVALID_PARAMETER, string("Invalid parameter, duplicated address: ")+name_);
+            throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("Invalid parameter, duplicated address: ")+name_);
         setAddress.insert(address);
 
         CScript scriptPubKey = GetScriptForDestination(address.Get());
@@ -1142,7 +1140,7 @@ UniValue sendmany(const JSONRPCRequest& request)
     CReserveKey keyChange(pwallet);
     CAmount nFeeRequired = 0;
     int nChangePosRet = -1;
-    string strFailReason;
+    std::string strFailReason;
     bool fCreated = pwallet->CreateTransaction(vecSend, wtx, keyChange, nFeeRequired, nChangePosRet, strFailReason);
     if (!fCreated)
         throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, strFailReason);
@@ -1167,7 +1165,7 @@ UniValue addmultisigaddress(const JSONRPCRequest& request)
 
     if (request.fHelp || request.params.size() < 2 || request.params.size() > 3)
     {
-        string msg = "addmultisigaddress nrequired [\"key\",...] ( \"account\" )\n"
+        std::string msg = "addmultisigaddress nrequired [\"key\",...] ( \"account\" )\n"
             "\nAdd a nrequired-to-sign multisignature address to the wallet.\n"
             "Each key is a Firo address or hex-encoded public key.\n"
             "If 'account' is specified (DEPRECATED), assign address to that account.\n"
@@ -1190,12 +1188,12 @@ UniValue addmultisigaddress(const JSONRPCRequest& request)
             "\nAs json rpc call\n"
             + HelpExampleRpc("addmultisigaddress", "2, \"[\\\"16sSauSf5pF2UkUwvKGq4qjNRzBZYqgEL5\\\",\\\"171sgjn4YtPu27adkKGrdDwzRTxnRkBfKV\\\"]\"")
         ;
-        throw runtime_error(msg);
+        throw std::runtime_error(msg);
     }
 
     LOCK2(cs_main, pwallet->cs_wallet);
 
-    string strAccount;
+    std::string strAccount;
     if (request.params.size() > 2)
         strAccount = AccountFromValue(request.params[2]);
 
@@ -1265,7 +1263,7 @@ UniValue addwitnessaddress(const JSONRPCRequest& request)
 
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 1)
     {
-        string msg = "addwitnessaddress \"address\"\n"
+        std::string msg = "addwitnessaddress \"address\"\n"
             "\nAdd a witness address for a script (with pubkey or redeemscript known).\n"
             "It returns the witness script.\n"
 
@@ -1276,7 +1274,7 @@ UniValue addwitnessaddress(const JSONRPCRequest& request)
             "\"witnessaddress\",  (string) The value of the new address (P2SH of witness script).\n"
             "}\n"
         ;
-        throw runtime_error(msg);
+        throw std::runtime_error(msg);
     }
 
     {
@@ -1306,7 +1304,7 @@ struct tallyitem
 {
     CAmount nAmount;
     int nConf;
-    vector<uint256> txids;
+    std::vector<uint256> txids;
     bool fIsWatchonly;
     tallyitem()
     {
@@ -1334,7 +1332,7 @@ UniValue ListReceived(CWallet * const pwallet, const UniValue& params, bool fByA
             filter = filter | ISMINE_WATCH_ONLY;
 
     // Tally
-    map<CBitcoinAddress, tallyitem> mapTally;
+    std::map<CBitcoinAddress, tallyitem> mapTally;
     for (const std::pair<uint256, CWalletTx>& pairWtx : pwallet->mapWallet) {
         const CWalletTx& wtx = pairWtx.second;
 
@@ -1357,7 +1355,7 @@ UniValue ListReceived(CWallet * const pwallet, const UniValue& params, bool fByA
 
             tallyitem& item = mapTally[address];
             item.nAmount += txout.nValue;
-            item.nConf = min(item.nConf, nDepth);
+            item.nConf = std::min(item.nConf, nDepth);
             item.txids.push_back(wtx.GetHash());
             if (mine & ISMINE_WATCH_ONLY)
                 item.fIsWatchonly = true;
@@ -1366,11 +1364,11 @@ UniValue ListReceived(CWallet * const pwallet, const UniValue& params, bool fByA
 
     // Reply
     UniValue ret(UniValue::VARR);
-    map<string, tallyitem> mapAccountTally;
+    std::map<std::string, tallyitem> mapAccountTally;
     for (const std::pair<CBitcoinAddress, CAddressBookData>& item : pwallet->mapAddressBook) {
         const CBitcoinAddress& address = item.first;
-        const string& strAccount = item.second.name;
-        map<CBitcoinAddress, tallyitem>::iterator it = mapTally.find(address);
+        const std::string& strAccount = item.second.name;
+        std::map<CBitcoinAddress, tallyitem>::iterator it = mapTally.find(address);
         if (it == mapTally.end() && !fIncludeEmpty)
             continue;
 
@@ -1388,7 +1386,7 @@ UniValue ListReceived(CWallet * const pwallet, const UniValue& params, bool fByA
         {
             tallyitem& _item = mapAccountTally[strAccount];
             _item.nAmount += nAmount;
-            _item.nConf = min(_item.nConf, nConf);
+            _item.nConf = std::min(_item.nConf, nConf);
             _item.fIsWatchonly = fIsWatchonly;
         }
         else
@@ -1417,7 +1415,7 @@ UniValue ListReceived(CWallet * const pwallet, const UniValue& params, bool fByA
 
     if (fByAccounts)
     {
-        for (map<string, tallyitem>::iterator it = mapAccountTally.begin(); it != mapAccountTally.end(); ++it)
+        for (std::map<std::string, tallyitem>::iterator it = mapAccountTally.begin(); it != mapAccountTally.end(); ++it)
         {
             CAmount nAmount = (*it).second.nAmount;
             int nConf = (*it).second.nConf;
@@ -1442,7 +1440,7 @@ UniValue listreceivedbyaddress(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() > 3)
-        throw runtime_error(
+        throw std::runtime_error(
             "listreceivedbyaddress ( minconf include_empty include_watchonly)\n"
             "\nList balances by receiving address.\n"
             "\nArguments:\n"
@@ -1486,7 +1484,7 @@ UniValue listreceivedbyaccount(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() > 3)
-        throw runtime_error(
+        throw std::runtime_error(
             "listreceivedbyaccount ( minconf include_empty include_watchonly)\n"
             "\nDEPRECATED. List balances by account.\n"
             "\nArguments:\n"
@@ -1523,17 +1521,17 @@ static void MaybePushAddress(UniValue & entry, const CTxDestination &dest, CBitc
         entry.push_back(Pair("address", addr.ToString()));
 }
 
-void ListTransactions(CWallet * const pwallet, const CWalletTx& wtx, const string& strAccount, int nMinDepth, bool fLong, UniValue& ret, const isminefilter& filter)
+void ListTransactions(CWallet * const pwallet, const CWalletTx& wtx, const std::string& strAccount, int nMinDepth, bool fLong, UniValue& ret, const isminefilter& filter)
 {
     CAmount nFee;
-    string strSentAccount;
-    list<COutputEntry> listReceived;
-    list<COutputEntry> listSent;
+    std::string strSentAccount;
+    std::list<COutputEntry> listReceived;
+    std::list<COutputEntry> listSent;
     CBitcoinAddress addr;
 
     wtx.GetAmounts(listReceived, listSent, nFee, strSentAccount, filter);
 
-    bool fAllAccounts = (strAccount == string("*"));
+    bool fAllAccounts = (strAccount == std::string("*"));
     bool involvesWatchonly = wtx.IsFromMe(ISMINE_WATCH_ONLY);
 
     // Sent
@@ -1574,7 +1572,7 @@ void ListTransactions(CWallet * const pwallet, const CWalletTx& wtx, const strin
     {
         BOOST_FOREACH(const COutputEntry& r, listReceived)
         {
-            string account;
+            std::string account;
             if (pwallet->mapAddressBook.count(r.destination)) {
                 account = pwallet->mapAddressBook[r.destination].name;
             }
@@ -1631,9 +1629,9 @@ void ListTransactions(CWallet * const pwallet, const CWalletTx& wtx, const strin
     }
 }
 
-void AcentryToJSON(const CAccountingEntry& acentry, const string& strAccount, UniValue& ret)
+void AcentryToJSON(const CAccountingEntry& acentry, const std::string& strAccount, UniValue& ret)
 {
-    bool fAllAccounts = (strAccount == string("*"));
+    bool fAllAccounts = (strAccount == std::string("*"));
 
     if (fAllAccounts || acentry.strAccount == strAccount)
     {
@@ -1656,7 +1654,7 @@ UniValue listtransactions(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() > 4)
-        throw runtime_error(
+        throw std::runtime_error(
             "listtransactions ( \"account\" count skip include_watchonly)\n"
             "\nReturns up to 'count' most recent transactions skipping the first 'from' transactions for account 'account'.\n"
             "\nArguments:\n"
@@ -1717,7 +1715,7 @@ UniValue listtransactions(const JSONRPCRequest& request)
 
     LOCK2(cs_main, pwallet->cs_wallet);
 
-    string strAccount = "*";
+    std::string strAccount = "*";
     if (request.params.size() > 0)
         strAccount = request.params[0].get_str();
     int nCount = 10;
@@ -1759,11 +1757,11 @@ UniValue listtransactions(const JSONRPCRequest& request)
     if ((nFrom + nCount) > (int)ret.size())
         nCount = ret.size() - nFrom;
 
-    vector<UniValue> arrTmp = ret.getValues();
+    std::vector<UniValue> arrTmp = ret.getValues();
 
-    vector<UniValue>::iterator first = arrTmp.begin();
+    std::vector<UniValue>::iterator first = arrTmp.begin();
     std::advance(first, nFrom);
-    vector<UniValue>::iterator last = arrTmp.begin();
+    std::vector<UniValue>::iterator last = arrTmp.begin();
     std::advance(last, nFrom+nCount);
 
     if (last != arrTmp.end()) arrTmp.erase(last, arrTmp.end());
@@ -1786,7 +1784,7 @@ UniValue listaccounts(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() > 2)
-        throw runtime_error(
+        throw std::runtime_error(
             "listaccounts ( minconf include_watchonly)\n"
             "\nDEPRECATED. Returns Object that has account names as keys, account balances as values.\n"
             "\nArguments:\n"
@@ -1818,7 +1816,7 @@ UniValue listaccounts(const JSONRPCRequest& request)
         if(request.params[1].get_bool())
             includeWatchonly = includeWatchonly | ISMINE_WATCH_ONLY;
 
-    map<string, CAmount> mapAccountBalances;
+    std::map<std::string, CAmount> mapAccountBalances;
     for (const std::pair<CTxDestination, CAddressBookData>& entry : pwallet->mapAddressBook) {
         if (IsMine(*pwallet, entry.first) & includeWatchonly) {  // This address belongs to me
             mapAccountBalances[entry.second.name] = 0;
@@ -1828,9 +1826,9 @@ UniValue listaccounts(const JSONRPCRequest& request)
     for (const std::pair<uint256, CWalletTx>& pairWtx : pwallet->mapWallet) {
         const CWalletTx& wtx = pairWtx.second;
         CAmount nFee;
-        string strSentAccount;
-        list<COutputEntry> listReceived;
-        list<COutputEntry> listSent;
+        std::string strSentAccount;
+        std::list<COutputEntry> listReceived;
+        std::list<COutputEntry> listSent;
         int nDepth = wtx.GetDepthInMainChain();
         if (wtx.GetBlocksToMaturity() > 0 || nDepth < 0)
             continue;
@@ -1849,12 +1847,12 @@ UniValue listaccounts(const JSONRPCRequest& request)
         }
     }
 
-    const list<CAccountingEntry> & acentries = pwallet->laccentries;
+    const std::list<CAccountingEntry> & acentries = pwallet->laccentries;
     BOOST_FOREACH(const CAccountingEntry& entry, acentries)
         mapAccountBalances[entry.strAccount] += entry.nCreditDebit;
 
     UniValue ret(UniValue::VOBJ);
-    BOOST_FOREACH(const PAIRTYPE(string, CAmount)& accountBalance, mapAccountBalances) {
+    BOOST_FOREACH(const PAIRTYPE(std::string, CAmount)& accountBalance, mapAccountBalances) {
         ret.push_back(Pair(accountBalance.first, ValueFromAmount(accountBalance.second)));
     }
     return ret;
@@ -1868,7 +1866,7 @@ UniValue listsinceblock(const JSONRPCRequest& request)
     }
 
     if (request.fHelp)
-        throw runtime_error(
+        throw std::runtime_error(
             "listsinceblock ( \"blockhash\" target_confirmations include_watchonly)\n"
             "\nGet all transactions in blocks since block [blockhash], or all transactions if omitted\n"
             "\nArguments:\n"
@@ -1975,7 +1973,7 @@ UniValue gettransaction(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
-        throw runtime_error(
+        throw std::runtime_error(
             "gettransaction \"txid\" ( include_watchonly )\n"
             "\nGet detailed information about in-wallet transaction <txid>\n"
             "\nArguments:\n"
@@ -2053,7 +2051,7 @@ UniValue gettransaction(const JSONRPCRequest& request)
     ListTransactions(pwallet, wtx, "*", 0, false, details, filter);
     entry.push_back(Pair("details", details));
 
-    string strHex = EncodeHexTx(static_cast<CTransaction>(wtx), RPCSerializationFlags());
+    std::string strHex = EncodeHexTx(static_cast<CTransaction>(wtx), RPCSerializationFlags());
     entry.push_back(Pair("hex", strHex));
 
     return entry;
@@ -2067,7 +2065,7 @@ UniValue abandontransaction(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() != 1)
-        throw runtime_error(
+        throw std::runtime_error(
             "abandontransaction \"txid\"\n"
             "\nMark in-wallet transaction <txid> as abandoned\n"
             "This will mark this transaction and all its in-wallet descendants as abandoned which will allow\n"
@@ -2106,7 +2104,7 @@ UniValue backupwallet(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() != 1)
-        throw runtime_error(
+        throw std::runtime_error(
             "backupwallet \"destination\"\n"
             "\nSafely copies current wallet file to destination, which can be a directory or a path with filename.\n"
             "\nArguments:\n"
@@ -2128,7 +2126,7 @@ UniValue backupwallet(const JSONRPCRequest& request)
     //
     // We don't need to worry about pwallet->BackupWallet() due to it already thread safe.
 
-    string strDest = request.params[0].get_str();
+    std::string strDest = request.params[0].get_str();
     if (!pwallet->BackupWallet(strDest)) {
         throw JSONRPCError(RPC_WALLET_ERROR, "Error: Wallet backup failed!");
     }
@@ -2145,7 +2143,7 @@ UniValue keypoolrefill(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() > 1)
-        throw runtime_error(
+        throw std::runtime_error(
             "keypoolrefill ( newsize )\n"
             "\nFills the keypool."
             + HelpRequiringPassphrase(pwallet) + "\n"
@@ -2192,7 +2190,7 @@ UniValue walletpassphrase(const JSONRPCRequest& request)
     }
 
     if (pwallet->IsCrypted() && (request.fHelp || request.params.size() != 2)) {
-        throw runtime_error(
+        throw std::runtime_error(
             "walletpassphrase \"passphrase\" timeout\n"
             "\nStores the wallet decryption key in memory for 'timeout' seconds.\n"
             "This is needed prior to performing transactions related to private keys such as sending firos\n"
@@ -2234,7 +2232,7 @@ UniValue walletpassphrase(const JSONRPCRequest& request)
         }
     }
     else
-        throw runtime_error(
+        throw std::runtime_error(
             "walletpassphrase <passphrase> <timeout>\n"
             "Stores the wallet decryption key in memory for <timeout> seconds.");
 
@@ -2256,7 +2254,7 @@ UniValue walletpassphrasechange(const JSONRPCRequest& request)
     }
 
     if (pwallet->IsCrypted() && (request.fHelp || request.params.size() != 2)) {
-        throw runtime_error(
+        throw std::runtime_error(
             "walletpassphrasechange \"oldpassphrase\" \"newpassphrase\"\n"
             "\nChanges the wallet passphrase from 'oldpassphrase' to 'newpassphrase'.\n"
             "\nArguments:\n"
@@ -2287,7 +2285,7 @@ UniValue walletpassphrasechange(const JSONRPCRequest& request)
     strNewWalletPass = request.params[1].get_str().c_str();
 
     if (strOldWalletPass.length() < 1 || strNewWalletPass.length() < 1)
-        throw runtime_error(
+        throw std::runtime_error(
             "walletpassphrasechange <oldpassphrase> <newpassphrase>\n"
             "Changes the wallet passphrase from <oldpassphrase> to <newpassphrase>.");
 
@@ -2307,7 +2305,7 @@ UniValue walletlock(const JSONRPCRequest& request)
     }
 
     if (pwallet->IsCrypted() && (request.fHelp || request.params.size() != 0)) {
-        throw runtime_error(
+        throw std::runtime_error(
             "walletlock\n"
             "\nRemoves the wallet encryption key from memory, locking the wallet.\n"
             "After calling this method, you will need to call walletpassphrase again\n"
@@ -2347,7 +2345,7 @@ UniValue encryptwallet(const JSONRPCRequest& request)
     }
 
     if (!pwallet->IsCrypted() && (request.fHelp || request.params.size() != 1)) {
-        throw runtime_error(
+        throw std::runtime_error(
             "encryptwallet \"passphrase\"\n"
             "\nEncrypts the wallet with 'passphrase'. This is for first time encryption.\n"
             "After this, any calls that interact with private keys such as sending or signing \n"
@@ -2386,7 +2384,7 @@ UniValue encryptwallet(const JSONRPCRequest& request)
     strWalletPass = request.params[0].get_str().c_str();
 
     if (strWalletPass.length() < 1)
-        throw runtime_error(
+        throw std::runtime_error(
             "encryptwallet <passphrase>\n"
             "Encrypts the wallet with <passphrase>.");
 
@@ -2410,7 +2408,7 @@ UniValue lockunspent(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
-        throw runtime_error(
+        throw std::runtime_error(
             "lockunspent unlock ([{\"txid\":\"txid\",\"vout\":n},...])\n"
             "\nUpdates list of temporarily unspendable outputs.\n"
             "Temporarily lock (unlock=false) or unlock (unlock=true) specified transaction outputs.\n"
@@ -2474,7 +2472,7 @@ UniValue lockunspent(const JSONRPCRequest& request)
                 {"vout", UniValueType(UniValue::VNUM)},
             });
 
-        string txid = find_value(o, "txid").get_str();
+        std::string txid = find_value(o, "txid").get_str();
         if (!IsHex(txid))
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, expected hex txid");
 
@@ -2501,7 +2499,7 @@ UniValue listlockunspent(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() > 0)
-        throw runtime_error(
+        throw std::runtime_error(
             "listlockunspent\n"
             "\nReturns list of temporarily unspendable outputs.\n"
             "See the lockunspent call to lock and unlock transactions for spending.\n"
@@ -2528,7 +2526,7 @@ UniValue listlockunspent(const JSONRPCRequest& request)
 
     LOCK2(cs_main, pwallet->cs_wallet);
 
-    vector<COutPoint> vOutpts;
+    std::vector<COutPoint> vOutpts;
     pwallet->ListLockedCoins(vOutpts);
 
     UniValue ret(UniValue::VARR);
@@ -2552,7 +2550,7 @@ UniValue settxfee(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 1)
-        throw runtime_error(
+        throw std::runtime_error(
             "settxfee amount\n"
             "\nSet the transaction fee per kB. Overwrites the paytxfee parameter.\n"
             "\nArguments:\n"
@@ -2581,7 +2579,7 @@ UniValue getwalletinfo(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() != 0)
-        throw runtime_error(
+        throw std::runtime_error(
             "getwalletinfo\n"
             "Returns an object containing various wallet state info.\n"
             "\nResult:\n"
@@ -2630,7 +2628,7 @@ UniValue resendwallettransactions(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() != 0)
-        throw runtime_error(
+        throw std::runtime_error(
             "resendwallettransactions\n"
             "Immediately re-broadcast unconfirmed wallet transactions to all peers.\n"
             "Intended only for testing; the wallet code periodically re-broadcasts\n"
@@ -2660,7 +2658,7 @@ UniValue listunspent(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() > 4)
-        throw runtime_error(
+        throw std::runtime_error(
             "listunspent ( minconf maxconf  [\"addresses\",...] [include_unsafe] )\n"
             "\nReturns array of unspent transaction outputs\n"
             "with between minconf and maxconf (inclusive) confirmations.\n"
@@ -2712,7 +2710,7 @@ UniValue listunspent(const JSONRPCRequest& request)
         nMaxDepth = request.params[1].get_int();
     }
 
-    set<CBitcoinAddress> setAddress;
+    std::set<CBitcoinAddress> setAddress;
     if (request.params.size() > 2 && !request.params[2].isNull()) {
         RPCTypeCheckArgument(request.params[2], UniValue::VARR);
         UniValue inputs = request.params[2].get_array();
@@ -2720,9 +2718,9 @@ UniValue listunspent(const JSONRPCRequest& request)
             const UniValue& input = inputs[idx];
             CBitcoinAddress address(input.get_str());
             if (!address.IsValid())
-                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, string("Invalid Firo address: ")+input.get_str());
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid Firo address: ")+input.get_str());
             if (setAddress.count(address))
-                throw JSONRPCError(RPC_INVALID_PARAMETER, string("Invalid parameter, duplicated address: ")+input.get_str());
+                throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("Invalid parameter, duplicated address: ")+input.get_str());
            setAddress.insert(address);
         }
     }
@@ -2734,7 +2732,7 @@ UniValue listunspent(const JSONRPCRequest& request)
     }
 
     UniValue results(UniValue::VARR);
-    vector<COutput> vecOutputs;
+    std::vector<COutput> vecOutputs;
     assert(pwallet != NULL);
     LOCK2(cs_main, pwallet->cs_wallet);
     pwallet->AvailableCoins(vecOutputs, !include_unsafe, NULL, true);
@@ -2788,7 +2786,7 @@ UniValue fundrawtransaction(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
-        throw runtime_error(
+        throw std::runtime_error(
                             "fundrawtransaction \"hexstring\" ( options )\n"
                             "\nAdd inputs to a transaction until it has enough in value to meet its out value.\n"
                             "This will not modify existing inputs, and will add at most one change output to the outputs.\n"
@@ -2845,7 +2843,7 @@ UniValue fundrawtransaction(const JSONRPCRequest& request)
     CFeeRate feeRate = CFeeRate(0);
     bool overrideEstimatedFeerate = false;
     UniValue subtractFeeFromOutputs;
-    set<int> setSubtractFeeFromOutputs;
+    std::set<int> setSubtractFeeFromOutputs;
 
     if (request.params.size() > 1) {
       if (request.params[1].type() == UniValue::VBOOL) {
@@ -2924,7 +2922,7 @@ UniValue fundrawtransaction(const JSONRPCRequest& request)
     }
 
     CAmount nFeeOut;
-    string strFailReason;
+    std::string strFailReason;
 
     if (!pwallet->FundTransaction(tx, nFeeOut, overrideEstimatedFeerate, feeRate, changePosition, strFailReason, includeWatching, lockUnspents, setSubtractFeeFromOutputs, reserveChangeKey, changeAddress)) {
         throw JSONRPCError(RPC_INTERNAL_ERROR, strFailReason);
@@ -2945,7 +2943,7 @@ UniValue regeneratemintpool(const JSONRPCRequest& request) {
     }
 
     if (request.fHelp || request.params.size() > 0)
-        throw runtime_error(
+        throw std::runtime_error(
                 "regeneratemintpool\n"
                 "\nIf issues exist with the keys that map to mintpool entries in the DB, this function corrects them.\n"
                 "\nExamples:\n"
@@ -2963,7 +2961,7 @@ UniValue regeneratemintpool(const JSONRPCRequest& request) {
     }
 
     CWalletDB walletdb(pwallet->strWalletFile);
-    vector<std::pair<uint256, MintPoolEntry>> listMintPool = walletdb.ListMintPool();
+    std::vector<std::pair<uint256, MintPoolEntry>> listMintPool = walletdb.ListMintPool();
     std::vector<std::pair<uint256, GroupElement>> serialPubcoinPairs = walletdb.ListSerialPubcoinPairs();
 
     // <hashPubcoin, hashSerial>
@@ -2979,7 +2977,7 @@ UniValue regeneratemintpool(const JSONRPCRequest& request) {
         bool hasSerial = pwallet->zwallet->GetSerialForPubcoin(serialPubcoinPairs, oldHashPubcoin, oldHashSerial);
 
         MintPoolEntry entry = mintPoolPair.second;
-        nIndexes = pwallet->zwallet->RegenerateMintPoolEntry(walletdb, get<0>(entry),get<1>(entry),get<2>(entry));
+        nIndexes = pwallet->zwallet->RegenerateMintPoolEntry(walletdb, std::get<0>(entry),std::get<1>(entry),std::get<2>(entry));
 
         if(nIndexes.first != oldHashPubcoin){
             walletdb.EraseMintPoolPair(oldHashPubcoin);
@@ -3007,7 +3005,7 @@ UniValue listunspentsigmamints(const JSONRPCRequest& request) {
     }
 
     if (request.fHelp || request.params.size() > 2)
-        throw runtime_error(
+        throw std::runtime_error(
                 "listunspentsigmamints [minconf=1] [maxconf=9999999] \n"
                         "Returns array of unspent transaction outputs\n"
                         "with between minconf and maxconf (inclusive) confirmations.\n"
@@ -3031,7 +3029,7 @@ UniValue listunspentsigmamints(const JSONRPCRequest& request) {
         nMaxDepth = request.params[1].get_int();
 
     UniValue results(UniValue::VARR);
-    vector <COutput> vecOutputs;
+    std::vector <COutput> vecOutputs;
     assert(pwallet != NULL);
     pwallet->ListAvailableSigmaMintCoins(vecOutputs, false);
     LogPrintf("vecOutputs.size()=%s\n", vecOutputs.size());
@@ -3070,7 +3068,7 @@ UniValue listunspentlelantusmints(const JSONRPCRequest& request) {
     }
 
     if (request.fHelp || request.params.size() > 2) {
-        throw runtime_error(
+        throw std::runtime_error(
             "listunspentsigmamints [minconf=1] [maxconf=9999999] \n"
             "Returns array of unspent transaction outputs\n"
             "with between minconf and maxconf (inclusive) confirmations.\n"
@@ -3096,7 +3094,7 @@ UniValue listunspentlelantusmints(const JSONRPCRequest& request) {
         nMaxDepth = request.params[1].get_int();
 
     UniValue results(UniValue::VARR);
-    vector <COutput> vecOutputs;
+    std::vector <COutput> vecOutputs;
     assert(pwallet != NULL);
     pwallet->ListAvailableLelantusMintCoins(vecOutputs, false);
     LogPrintf("vecOutputs.size()=%s\n", vecOutputs.size());
@@ -3184,7 +3182,7 @@ UniValue mint(const JSONRPCRequest& request)
         [sigmaParams](const sigma::CoinDenomination& denom) -> sigma::PrivateCoin {
             return sigma::PrivateCoin(sigmaParams, denom);
         });
-    vector<CHDMint> vDMints;
+    std::vector<CHDMint> vDMints;
     auto vecSend = CWallet::CreateSigmaMintRecipients(privCoins, vDMints);
 
     CWalletTx wtx;
@@ -3531,7 +3529,7 @@ UniValue resetsigmamint(const JSONRPCRequest& request) {
     }
 
     if (request.fHelp || request.params.size() != 0)
-        throw runtime_error(
+        throw std::runtime_error(
                 "resetsigmamint"
                 + HelpRequiringPassphrase(pwallet));
 
@@ -3561,7 +3559,7 @@ UniValue resetlelantusmint(const JSONRPCRequest& request) {
     }
 
     if (request.fHelp || request.params.size() != 0)
-        throw runtime_error(
+        throw std::runtime_error(
                 "resetlelantusmint"
                 + HelpRequiringPassphrase(pwallet));
 
@@ -3591,7 +3589,7 @@ UniValue listsigmamints(const JSONRPCRequest& request) {
     }
 
     if (request.fHelp || request.params.size() > 1)
-        throw runtime_error(
+        throw std::runtime_error(
                 "listsigmamints <all>(false/true)\n"
                 "\nArguments:\n"
                 "1. <all> (boolean, optional) false (default) to return own mints. true to return every mints.\n"
@@ -3608,7 +3606,7 @@ UniValue listsigmamints(const JSONRPCRequest& request) {
     // Mint secret data encrypted in wallet
     EnsureWalletIsUnlocked(pwallet);
 
-    list <CSigmaEntry> listPubcoin;
+    std::list <CSigmaEntry> listPubcoin;
     CWalletDB walletdb(pwallet->strWalletFile);
     listPubcoin = pwallet->zwallet->GetTracker().MintsAsSigmaEntries(false, false);
     UniValue results(UniValue::VARR);
@@ -3637,7 +3635,7 @@ UniValue listlelantusmints(const JSONRPCRequest& request) {
     }
 
     if (request.fHelp || request.params.size() > 1)
-        throw runtime_error(
+        throw std::runtime_error(
                 "listlelantusmints <all>(false/true)\n"
                 "\nArguments:\n"
                 "1. <all> (boolean, optional) false (default) to return own listlelantusmints. true to return every listlelantusmints.\n"
@@ -3654,7 +3652,7 @@ UniValue listlelantusmints(const JSONRPCRequest& request) {
     // Mint secret data encrypted in wallet
     EnsureWalletIsUnlocked(pwallet);
 
-    list <CLelantusEntry> listCoin;
+    std::list <CLelantusEntry> listCoin;
     CWalletDB walletdb(pwallet->strWalletFile);
     listCoin = pwallet->zwallet->GetTracker().MintsAsLelantusEntries(false, false);
     UniValue results(UniValue::VARR);
@@ -3689,7 +3687,7 @@ UniValue listsigmapubcoins(const JSONRPCRequest& request) {
             "\nResults are an array of Objects, each of which has:\n"
             "{id, IsUsed, denomination, value, serialNumber, nHeight, randomness}";
     if (request.fHelp || request.params.size() > 1) {
-        throw runtime_error(help_message);
+        throw std::runtime_error(help_message);
     }
 
     EnsureSigmaWalletIsAvailable();
@@ -3699,14 +3697,14 @@ UniValue listsigmapubcoins(const JSONRPCRequest& request) {
     if (request.params.size() > 0) {
         filter_by_denom = true;
         if (!sigma::StringToDenomination(request.params[0].get_str(), denomination)) {
-            throw runtime_error(help_message);
+            throw std::runtime_error(help_message);
         }
     }
 
     // Mint secret data encrypted in wallet
     EnsureWalletIsUnlocked(pwallet);
 
-    list<CSigmaEntry> listPubcoin;
+    std::list<CSigmaEntry> listPubcoin;
     CWalletDB walletdb(pwallet->strWalletFile);
     listPubcoin = pwallet->zwallet->GetTracker().MintsAsSigmaEntries(false, false);
     UniValue results(UniValue::VARR);
@@ -3741,7 +3739,7 @@ UniValue setsigmamintstatus(const JSONRPCRequest& request) {
     }
 
     if (request.fHelp || request.params.size() != 2)
-        throw runtime_error(
+        throw std::runtime_error(
                 "setsigmamintstatus \"coinserial\" <isused>(true/false)\n"
                 "Set mintsigma IsUsed status to True or False\n"
                 "Results are an array of one or no Objects, each of which has:\n"
@@ -3823,7 +3821,7 @@ UniValue setlelantusmintstatus(const JSONRPCRequest& request) {
     }
 
     if (request.fHelp || request.params.size() != 2)
-        throw runtime_error(
+        throw std::runtime_error(
                 "setlelantusmintstatus \"coinserial\" <isused>(true/false)\n"
                 "Set lelantus mint IsUsed status to True or False\n"
                 "Results are an array of one or no Objects, each of which has:\n"
@@ -3900,7 +3898,7 @@ UniValue listsigmaspends(const JSONRPCRequest& request) {
     }
 
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
-        throw runtime_error(
+        throw std::runtime_error(
                 "listsigmaspends\n"
                 "Return up to \"count\" saved sigma spend transactions\n"
                 "\nArguments:\n"
@@ -4015,7 +4013,7 @@ UniValue listlelantusjoinsplits(const JSONRPCRequest& request) {
     }
 
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
-        throw runtime_error(
+        throw std::runtime_error(
                 "listlelantusjoinsplits\n"
                 "Return up to \"count\" saved lelantus joinsplit transactions\n"
                 "\nArguments:\n"
@@ -4104,7 +4102,7 @@ UniValue removetxmempool(const JSONRPCRequest& request) {
     }
 
     if (request.fHelp || request.params.size() != 1)
-        throw runtime_error(
+        throw std::runtime_error(
                 "removetxmempool <txid>\n"
                 + HelpRequiringPassphrase(pwallet));
 
@@ -4137,7 +4135,7 @@ UniValue removetxwallet(const JSONRPCRequest& request) {
     }
 
     if (request.fHelp || request.params.size() != 1)
-        throw runtime_error("removetxwallet <txid>\n" + HelpRequiringPassphrase(pwallet));
+        throw std::runtime_error("removetxwallet <txid>\n" + HelpRequiringPassphrase(pwallet));
 
     uint256 hash;
     hash.SetHex(request.params[0].get_str());
@@ -4170,14 +4168,14 @@ extern UniValue removeprunedfunds(const JSONRPCRequest& request);
 int64_t CalculateMaximumSignedTxSize(CWallet * const pwallet, const CTransaction &tx)
 {
     CMutableTransaction txNew(tx);
-    std::vector<pair<CWalletTx *, unsigned int>> vCoins;
+    std::vector<std::pair<CWalletTx *, unsigned int>> vCoins;
     // Look up the inputs.  We should have already checked that this transaction
     // IsAllFromMe(ISMINE_SPENDABLE), so every input should already be in our
     // wallet, with a valid index into the vout array.
     for (auto& input : tx.vin) {
         const auto mi = pwallet->mapWallet.find(input.prevout.hash);
         assert(mi != pwallet->mapWallet.end() && input.prevout.n < mi->second.tx->vout.size());
-        vCoins.emplace_back(make_pair(&(mi->second), input.prevout.n));
+        vCoins.emplace_back(std::make_pair(&(mi->second), input.prevout.n));
     }
     if (!pwallet->DummySignTx(txNew, vCoins)) {
         // This should never happen, because IsAllFromMe(ISMINE_SPENDABLE)
@@ -4195,7 +4193,7 @@ UniValue bumpfee(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2) {
-        throw runtime_error(
+        throw std::runtime_error(
             "bumpfee \"txid\" ( options ) \n"
             "\nBumps the fee of an opt-in-RBF transaction T, replacing it with a new transaction B.\n"
             "An opt-in RBF transaction with the given txid must be in the wallet.\n"
@@ -4492,7 +4490,7 @@ UniValue listpcodes(const JSONRPCRequest& request)
     }
 
     auto help = []() {
-        throw runtime_error(
+        throw std::runtime_error(
             "listpcodes verbose \n"
             "Lists all existing receiving payment codes with labels. \n"
             "verbose: (bool, optional) - displays all used and next(unused) addresses for each payment code,\n"
@@ -4585,7 +4583,7 @@ UniValue createpcode(const JSONRPCRequest& request)
 
     std::function<void()> help = []()
     {
-        throw runtime_error(
+        throw std::runtime_error(
             "createpcode  \"label\"\n"
             "Creates a new labeled BIP47 payment code. \n"
             "The label should be unique and non-empty. \n"
@@ -4626,7 +4624,7 @@ UniValue setupchannel(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() != 1)
-        throw runtime_error(
+        throw std::runtime_error(
             "setupchannel \"paymentcode\"\n"
             "\nSets up a payment channel for the payment code. Sends a notification transaction to the payment code notification address.\n"
             "It __will__ use Lelantus facilities to send the notification tx. The tx cost is " + std::to_string(1.0 * bip47::NotificationTxValue / COIN ) + " for the JoinSplit tx + fees\n"
@@ -4674,7 +4672,7 @@ UniValue sendtopcode(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() < 2 || request.params.size() > 5)
-        throw runtime_error(
+        throw std::runtime_error(
             "sendtopcode \"paymentcode\" amount ( \"comment\" \"comment-to\" subtractfeefromamount )\n"
             "\nSend an amount to a given payment code.\n"
             + HelpRequiringPassphrase(pwallet) +
@@ -4736,7 +4734,7 @@ UniValue setusednumber(const JSONRPCRequest& request)
     }
 
     if (request.fHelp || request.params.size() < 2 || request.params.size() > 5)
-        throw runtime_error(
+        throw std::runtime_error(
             "setusednumber \"paymentcode\" number\n"
             "\nIncrease the number of used addresses for a payment code.\n"
             + HelpRequiringPassphrase(pwallet) +
@@ -4760,7 +4758,7 @@ UniValue setusednumber(const JSONRPCRequest& request)
     }
 
     if(!pcodeDesc)
-        throw runtime_error("Payment code not found: " + pcode.toString());
+        throw std::runtime_error("Payment code not found: " + pcode.toString());
 
     if(std::get<4>(*pcodeDesc) == bip47::CPaymentCodeSide::Receiver)
             EnsureWalletIsUnlocked(pwallet);

--- a/src/wallet/test/sigma_tests.cpp
+++ b/src/wallet/test/sigma_tests.cpp
@@ -576,9 +576,9 @@ BOOST_AUTO_TEST_CASE(create_spend_with_coins_more_than_1)
     BOOST_CHECK(CheckSpend(tx.tx->vin[1], selected[1]));
 
     BOOST_CHECK(ContainTxOut(tx.tx->vout,
-        make_pair(GetScriptForDestination(randomAddr1.Get()), 5 * COIN ), 1));
+        std::make_pair(GetScriptForDestination(randomAddr1.Get()), 5 * COIN ), 1));
     BOOST_CHECK(ContainTxOut(tx.tx->vout,
-        make_pair(GetScriptForDestination(randomAddr2.Get()), 10 * COIN ), 1));
+        std::make_pair(GetScriptForDestination(randomAddr2.Get()), 10 * COIN ), 1));
 
     CAmount remintsSum = std::accumulate(tx.tx->vout.begin(), tx.tx->vout.end(), 0, [](CAmount c, const CTxOut& v) {
         return c + (v.scriptPubKey.IsSigmaMint() ? v.nValue : 0);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3205,7 +3205,7 @@ bool CWallet::GetCoinsToJoinSplit(
     Consensus::Params consensusParams = Params().GetConsensus();
 
     if (required > consensusParams.nMaxValueLelantusSpendPerTransaction) {
-        throw invalid_argument(_("The required amount exceeds spend limit"));
+        throw std::invalid_argument(_("The required amount exceeds spend limit"));
     }
 
     CAmount availableBalance = CalculateLelantusCoinsBalance(coins.begin(), coins.end());
@@ -6713,7 +6713,7 @@ CWallet* CWallet::CreateWalletFromFile(const std::string walletFile)
     // recover addressbook
     if (fFirstRun)
     {
-        for (map<uint256, CWalletTx>::iterator it = walletInstance->mapWallet.begin(); it != walletInstance->mapWallet.end(); ++it) {
+        for (std::map<uint256, CWalletTx>::iterator it = walletInstance->mapWallet.begin(); it != walletInstance->mapWallet.end(); ++it) {
             for (uint32_t i = 0; i < (*it).second.tx->vout.size(); i++) {
                 const auto& txout = (*it).second.tx->vout[i];
                 if(txout.scriptPubKey.IsMint() || (*it).second.changes.count(i))

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3707,7 +3707,7 @@ bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, const int nConfMin
     vector<pair<CAmount, pair<const CWalletTx*,unsigned int> > > vValue;
     CAmount nTotalLower = 0;
 
-    random_shuffle(vCoins.begin(), vCoins.end(), GetRandInt);
+    Shuffle(vCoins.begin(), vCoins.end(), FastRandomContext());
 
     BOOST_FOREACH(const COutput &output, vCoins)
     {
@@ -4696,7 +4696,7 @@ bool CWallet::CreateLelantusMintTransactions(
             std::vector<std::pair<CAmount, std::vector<COutput>>> valueAndUTXO;
             AvailableCoinsForLMint(valueAndUTXO, coinControl);
 
-            std::random_shuffle(valueAndUTXO.begin(), valueAndUTXO.end(), GetRandInt);
+            Shuffle(valueAndUTXO.begin(), valueAndUTXO.end(), FastRandomContext());
 
             while (!valueAndUTXO.empty()) {
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -58,8 +58,6 @@
 #include "bip47/paymentcode.h"
 #include "bip47/bip47utils.h"
 
-using namespace std;
-
 CWallet* pwalletMain = NULL;
 
 /** Transaction fee set by the user */
@@ -92,8 +90,8 @@ const uint256 CMerkleTx::ABANDON_HASH(uint256S("00000000000000000000000000000000
 
 struct CompareValueOnly
 {
-    bool operator()(const pair<CAmount, pair<const CWalletTx*, unsigned int> >& t1,
-                    const pair<CAmount, pair<const CWalletTx*, unsigned int> >& t2) const
+    bool operator()(const std::pair<CAmount, std::pair<const CWalletTx*, unsigned int> >& t1,
+                    const std::pair<CAmount, std::pair<const CWalletTx*, unsigned int> >& t2) const
     {
         return t1.first < t2.first;
     }
@@ -342,7 +340,7 @@ bool CWallet::AddKeyPubKey(const CKey& secret, const CPubKey &pubkey)
 }
 
 bool CWallet::AddCryptedKey(const CPubKey &vchPubKey,
-                            const vector<unsigned char> &vchCryptedSecret)
+                            const std::vector<unsigned char> &vchCryptedSecret)
 {
     if (!CCryptoKeyStore::AddCryptedKey(vchPubKey, vchCryptedSecret))
         return false;
@@ -560,9 +558,9 @@ bool CWallet::SetMaxVersion(int nVersion)
     return true;
 }
 
-set<uint256> CWallet::GetConflicts(const uint256& txid) const
+std::set<uint256> CWallet::GetConflicts(const uint256& txid) const
 {
-    set<uint256> result;
+    std::set<uint256> result;
     AssertLockHeld(cs_wallet);
 
     std::map<uint256, CWalletTx>::const_iterator it = mapWallet.find(txid);
@@ -654,7 +652,7 @@ bool CWallet::Verify()
     return true;
 }
 
-void CWallet::SyncMetaData(pair<TxSpends::iterator, TxSpends::iterator> range)
+void CWallet::SyncMetaData(std::pair<TxSpends::iterator, TxSpends::iterator> range)
 {
     // We want all the wallet transactions in range to have the same metadata as
     // the oldest (smallest nOrderPos).
@@ -730,7 +728,7 @@ bool CWallet::IsSpent(const uint256 &hash, unsigned int n) const
 
     // Normal output.
     const COutPoint outpoint(hash, n);
-    pair<TxSpends::const_iterator, TxSpends::const_iterator> range;
+    std::pair<TxSpends::const_iterator, TxSpends::const_iterator> range;
     range = mapTxSpends.equal_range(outpoint);
 
     for (TxSpends::const_iterator it = range.first; it != range.second; ++it)
@@ -748,10 +746,10 @@ bool CWallet::IsSpent(const uint256 &hash, unsigned int n) const
 
 void CWallet::AddToSpends(const COutPoint& outpoint, const uint256& wtxid)
 {
-    mapTxSpends.insert(make_pair(outpoint, wtxid));
+    mapTxSpends.insert(std::make_pair(outpoint, wtxid));
     setWalletUTXO.erase(outpoint);
 
-    pair<TxSpends::iterator, TxSpends::iterator> range;
+    std::pair<TxSpends::iterator, TxSpends::iterator> range;
     range = mapTxSpends.equal_range(outpoint);
     SyncMetaData(range);
 }
@@ -878,16 +876,16 @@ DBErrors CWallet::ReorderTransactions()
     // Probably a bad idea to change the output of this
 
     // First: get all CWalletTx and CAccountingEntry into a sorted-by-time multimap.
-    typedef pair<CWalletTx*, CAccountingEntry*> TxPair;
-    typedef multimap<int64_t, TxPair > TxItems;
+    typedef std::pair<CWalletTx*, CAccountingEntry*> TxPair;
+    typedef std::multimap<int64_t, TxPair > TxItems;
     TxItems txByTime;
 
-    for (map<uint256, CWalletTx>::iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
+    for (std::map<uint256, CWalletTx>::iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
     {
         CWalletTx* wtx = &((*it).second);
         txByTime.insert(make_pair(wtx->nTimeReceived, TxPair(wtx, (CAccountingEntry*)0)));
     }
-    list<CAccountingEntry> acentries;
+    std::list<CAccountingEntry> acentries;
     walletdb.ListAccountCreditDebit("", acentries);
     BOOST_FOREACH(CAccountingEntry& entry, acentries)
     {
@@ -1005,7 +1003,7 @@ bool CWallet::GetAccountPubkey(CPubKey &pubKey, std::string strAccount, bool bFo
         else {
             // Check if the current key has been used
             CScript scriptPubKey = GetScriptForDestination(account.vchPubKey.GetID());
-            for (map<uint256, CWalletTx>::iterator it = mapWallet.begin();
+            for (std::map<uint256, CWalletTx>::iterator it = mapWallet.begin();
                  it != mapWallet.end() && account.vchPubKey.IsValid();
                  ++it)
                 BOOST_FOREACH(const CTxOut& txout, (*it).second.tx->vout)
@@ -1089,7 +1087,7 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose)
     uint256 hash = wtxIn.GetHash();
 
     // Inserts only if not already there, returns tx inserted or tx found
-    pair<map<uint256, CWalletTx>::iterator, bool> ret = mapWallet.insert(make_pair(hash, wtxIn));
+    std::pair<std::map<uint256, CWalletTx>::iterator, bool> ret = mapWallet.insert(std::make_pair(hash, wtxIn));
     CWalletTx& wtx = (*ret.first).second;
     wtx.BindWallet(this);
     bool fInsertedNew = ret.second;
@@ -1552,7 +1550,7 @@ isminetype CWallet::IsMine(const CTxIn &txin) const
         return ISMINE_NO;
     }
     else {
-        map<uint256, CWalletTx>::const_iterator mi = mapWallet.find(txin.prevout.hash);
+        std::map<uint256, CWalletTx>::const_iterator mi = mapWallet.find(txin.prevout.hash);
         if (mi != mapWallet.end())
         {
             const CWalletTx& prev = (*mi).second;
@@ -1616,7 +1614,7 @@ CAmount CWallet::GetDebit(const CTxIn &txin, const isminefilter& filter) const
         }
         return amount;
     } else {
-        map<uint256, CWalletTx>::const_iterator mi = mapWallet.find(txin.prevout.hash);
+        std::map<uint256, CWalletTx>::const_iterator mi = mapWallet.find(txin.prevout.hash);
         if (mi != mapWallet.end())
         {
             const CWalletTx& prev = (*mi).second;
@@ -1870,12 +1868,12 @@ bool CWallet::SetHDChain(const CHDChain &chain, bool memonly, bool& upgradeChain
         if (genNewKeyPool)
             NewKeyPool();
         if (!memonly && !CWalletDB(strWalletFile).WriteHDChain(newChain))
-            throw runtime_error(std::string(__func__) + ": writing chain failed");
+            throw std::runtime_error(std::string(__func__) + ": writing chain failed");
         hdChain = newChain;
     }
     else {
         if (!memonly && !CWalletDB(strWalletFile).WriteHDChain(chain))
-            throw runtime_error(std::string(__func__) + ": writing chain failed");
+            throw std::runtime_error(std::string(__func__) + ": writing chain failed");
         hdChain = chain;
     }
 
@@ -1889,7 +1887,7 @@ bool CWallet::IsHDEnabled()
 
 bool CWallet::SetMnemonicContainer(const MnemonicContainer& mnContainer, bool memonly) {
     if (!memonly && !CWalletDB(strWalletFile).WriteMnemonic(mnContainer))
-        throw runtime_error(std::string(__func__) + ": writing chain failed");
+        throw std::runtime_error(std::string(__func__) + ": writing chain failed");
     mnemonicContainer = mnContainer;
     return true;
 }
@@ -1983,7 +1981,7 @@ int CWalletTx::GetRequestCount() const
             // Generated block
             if (!hashUnset())
             {
-                map<uint256, int>::const_iterator mi = pwallet->mapRequestCount.find(hashBlock);
+                std::map<uint256, int>::const_iterator mi = pwallet->mapRequestCount.find(hashBlock);
                 if (mi != pwallet->mapRequestCount.end())
                     nRequests = (*mi).second;
             }
@@ -1991,7 +1989,7 @@ int CWalletTx::GetRequestCount() const
         else
         {
             // Did anyone request this transaction?
-            map<uint256, int>::const_iterator mi = pwallet->mapRequestCount.find(GetHash());
+            std::map<uint256, int>::const_iterator mi = pwallet->mapRequestCount.find(GetHash());
             if (mi != pwallet->mapRequestCount.end())
             {
                 nRequests = (*mi).second;
@@ -1999,7 +1997,7 @@ int CWalletTx::GetRequestCount() const
                 // How about the block it's in?
                 if (nRequests == 0 && !hashUnset())
                 {
-                    map<uint256, int>::const_iterator _mi = pwallet->mapRequestCount.find(hashBlock);
+                    std::map<uint256, int>::const_iterator _mi = pwallet->mapRequestCount.find(hashBlock);
                     if (_mi != pwallet->mapRequestCount.end())
                         nRequests = (*_mi).second;
                     else
@@ -2011,8 +2009,8 @@ int CWalletTx::GetRequestCount() const
     return nRequests;
 }
 
-void CWalletTx::GetAmounts(list<COutputEntry>& listReceived,
-                           list<COutputEntry>& listSent, CAmount& nFee, string& strSentAccount, const isminefilter& filter) const
+void CWalletTx::GetAmounts(std::list<COutputEntry>& listReceived,
+                           std::list<COutputEntry>& listSent, CAmount& nFee, std::string& strSentAccount, const isminefilter& filter) const
 {
     nFee = 0;
     listReceived.clear();
@@ -2215,9 +2213,9 @@ bool CWalletTx::RelayWalletTransaction(CConnman* connman)
     return false;
 }
 
-set<uint256> CWalletTx::GetConflicts() const
+std::set<uint256> CWalletTx::GetConflicts() const
 {
-    set<uint256> result;
+    std::set<uint256> result;
     if (pwallet != NULL)
     {
         uint256 myHash = GetHash();
@@ -2502,14 +2500,14 @@ std::vector<uint256> CWallet::ResendWalletTransactionsBefore(int64_t nTime, CCon
 
     LOCK(cs_wallet);
     // Sort them in chronological order
-    multimap<unsigned int, CWalletTx*> mapSorted;
+    std::multimap<unsigned int, CWalletTx*> mapSorted;
     BOOST_FOREACH(PAIRTYPE(const uint256, CWalletTx)& item, mapWallet)
     {
         CWalletTx& wtx = item.second;
         // Don't rebroadcast if newer than nTime:
         if (wtx.nTimeReceived > nTime)
             continue;
-        mapSorted.insert(make_pair(wtx.nTimeReceived, &wtx));
+        mapSorted.insert(std::make_pair(wtx.nTimeReceived, &wtx));
     }
     BOOST_FOREACH(PAIRTYPE(const unsigned int, CWalletTx*)& item, mapSorted)
     {
@@ -2559,7 +2557,7 @@ CAmount CWallet::GetBalance(bool fExcludeLocked) const
     CAmount nTotal = 0;
     {
         LOCK2(cs_main, cs_wallet);
-        for (map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
+        for (std::map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
         {
             const CWalletTx* pcoin = &(*it).second;
             if (pcoin->IsTrusted())
@@ -2636,7 +2634,7 @@ std::pair<CAmount, CAmount> CWallet::GetPrivateBalance(size_t &confirmed, size_t
 
 std::vector<CRecipient> CWallet::CreateSigmaMintRecipients(
     std::vector<sigma::PrivateCoin>& coins,
-    vector<CHDMint>& vDMints)
+    std::vector<CHDMint>& vDMints)
 {
     EnsureMintWalletAvailable();
 
@@ -2856,7 +2854,7 @@ std::list<CSigmaEntry> CWallet::GetAvailableCoins(const CCoinControl *coinContro
     CWalletDB walletdb(strWalletFile);
     std::list<CSigmaEntry> coins;
     std::vector<CMintMeta> vecMints = zwallet->GetTracker().ListMints(true, true, false);
-    list<CMintMeta> listMints(vecMints.begin(), vecMints.end());
+    std::list<CMintMeta> listMints(vecMints.begin(), vecMints.end());
     for (const CMintMeta& mint : listMints) {
         CSigmaEntry entry;
         GetMint(mint.hashSerial, entry, forEstimation);
@@ -3117,7 +3115,7 @@ bool CWallet::GetCoinsToSpend(
     // Value of the largest coin, I.E. 100 for now.
     CAmount max_coin_value;
     if (!DenominationToInteger(denominations[0], max_coin_value)) {
-        throw runtime_error("Unknown sigma denomination.\n");
+        throw std::runtime_error("Unknown sigma denomination.\n");
     }
 
     int val = roundedRequired + max_coin_value / zeros;
@@ -3285,7 +3283,7 @@ CAmount CWallet::GetUnconfirmedBalance() const {
     CAmount nTotal = 0;
     {
         LOCK2(cs_main, cs_wallet);
-        for (map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it) {
+        for (std::map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it) {
             const CWalletTx *pcoin = &(*it).second;
             if (!pcoin->IsTrusted() && pcoin->GetDepthInMainChain() == 0 &&
                 (pcoin->InMempool() || pcoin->InStempool()))
@@ -3299,7 +3297,7 @@ CAmount CWallet::GetImmatureBalance() const {
     CAmount nTotal = 0;
     {
         LOCK2(cs_main, cs_wallet);
-        for (map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it) {
+        for (std::map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it) {
             const CWalletTx *pcoin = &(*it).second;
             nTotal += pcoin->GetImmatureCredit();
         }
@@ -3311,7 +3309,7 @@ CAmount CWallet::GetWatchOnlyBalance() const {
     CAmount nTotal = 0;
     {
         LOCK2(cs_main, cs_wallet);
-        for (map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it) {
+        for (std::map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it) {
             const CWalletTx *pcoin = &(*it).second;
             if (pcoin->IsTrusted())
                 nTotal += pcoin->GetAvailableWatchOnlyCredit();
@@ -3325,7 +3323,7 @@ CAmount CWallet::GetUnconfirmedWatchOnlyBalance() const {
     CAmount nTotal = 0;
     {
         LOCK2(cs_main, cs_wallet);
-        for (map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it) {
+        for (std::map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it) {
             const CWalletTx *pcoin = &(*it).second;
             if (!pcoin->IsTrusted() && pcoin->GetDepthInMainChain() == 0 &&
                 (pcoin->InMempool() || pcoin->InStempool()))
@@ -3340,7 +3338,7 @@ CAmount CWallet::GetImmatureWatchOnlyBalance() const
     CAmount nTotal = 0;
     {
         LOCK2(cs_main, cs_wallet);
-        for (map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
+        for (std::map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
         {
             const CWalletTx* pcoin = &(*it).second;
             nTotal += pcoin->GetImmatureWatchOnlyCredit();
@@ -3349,7 +3347,7 @@ CAmount CWallet::GetImmatureWatchOnlyBalance() const
     return nTotal;
 }
 
-void CWallet::AvailableCoins(vector <COutput> &vCoins, bool fOnlyConfirmed, const CCoinControl *coinControl, bool fIncludeZeroValue) const
+void CWallet::AvailableCoins(std::vector <COutput> &vCoins, bool fOnlyConfirmed, const CCoinControl *coinControl, bool fIncludeZeroValue) const
 {
     static const int ZNODE_COIN_REQUIRED  = 1000;
     vCoins.clear();
@@ -3357,7 +3355,7 @@ void CWallet::AvailableCoins(vector <COutput> &vCoins, bool fOnlyConfirmed, cons
 
     {
         LOCK2(cs_main, cs_wallet);
-        for (map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
+        for (std::map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
         {
             const uint256& wtxid = it->first;
             const CWalletTx* pcoin = &(*it).second;
@@ -3543,16 +3541,16 @@ bool CWallet::GetVinAndKeysFromOutput(COutput out, CTxIn &txinRet, CPubKey &pubK
 }
 
 //[firo]
-void CWallet::ListAvailableSigmaMintCoins(vector<COutput> &vCoins, bool fOnlyConfirmed) const {
+void CWallet::ListAvailableSigmaMintCoins(std::vector<COutput> &vCoins, bool fOnlyConfirmed) const {
     EnsureMintWalletAvailable();
 
     vCoins.clear();
     LOCK2(cs_main, cs_wallet);
-    list<CSigmaEntry> listOwnCoins;
+    std::list<CSigmaEntry> listOwnCoins;
     CWalletDB walletdb(pwalletMain->strWalletFile);
     listOwnCoins = zwallet->GetTracker().MintsAsSigmaEntries(true, false);
     LogPrintf("listOwnCoins.size()=%s\n", listOwnCoins.size());
-    for (map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it) {
+    for (std::map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it) {
         const CWalletTx *pcoin = &(*it).second;
 //        LogPrintf("pcoin=%s\n", pcoin->GetHash().ToString());
         if (!CheckFinalTx(*pcoin)) {
@@ -3596,16 +3594,16 @@ void CWallet::ListAvailableSigmaMintCoins(vector<COutput> &vCoins, bool fOnlyCon
     }
 }
 
-void CWallet::ListAvailableLelantusMintCoins(vector<COutput> &vCoins, bool fOnlyConfirmed) const {
+void CWallet::ListAvailableLelantusMintCoins(std::vector<COutput> &vCoins, bool fOnlyConfirmed) const {
     EnsureMintWalletAvailable();
 
     vCoins.clear();
     LOCK2(cs_main, cs_wallet);
-    list<CLelantusEntry> listOwnCoins;
+    std::list<CLelantusEntry> listOwnCoins;
     CWalletDB walletdb(pwalletMain->strWalletFile);
     listOwnCoins = zwallet->GetTracker().MintsAsLelantusEntries(true, false);
     LogPrintf("listOwnCoins.size()=%s\n", listOwnCoins.size());
-    for (map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it) {
+    for (std::map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it) {
         const CWalletTx *pcoin = &(*it).second;
 //        LogPrintf("pcoin=%s\n", pcoin->GetHash().ToString());
         if (!CheckFinalTx(*pcoin)) {
@@ -3649,10 +3647,10 @@ void CWallet::ListAvailableLelantusMintCoins(vector<COutput> &vCoins, bool fOnly
     }
 }
 
-static void ApproximateBestSubset(vector<pair<CAmount, pair<const CWalletTx*,unsigned int> > >vValue, const CAmount& nTotalLower, const CAmount& nTargetValue,
-                                  vector<char>& vfBest, CAmount& nBest, int iterations = 1000)
+static void ApproximateBestSubset(std::vector<std::pair<CAmount, std::pair<const CWalletTx*,unsigned int> > >vValue, const CAmount& nTotalLower, const CAmount& nTargetValue,
+                                  std::vector<char>& vfBest, CAmount& nBest, int iterations = 1000)
 {
-    vector<char> vfIncluded;
+    std::vector<char> vfIncluded;
 
     vfBest.assign(vValue.size(), true);
     nBest = nTotalLower;
@@ -3694,17 +3692,17 @@ static void ApproximateBestSubset(vector<pair<CAmount, pair<const CWalletTx*,uns
     }
 }
 
-bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, const int nConfMine, const int nConfTheirs, const uint64_t nMaxAncestors, vector<COutput> vCoins,
-                                 set<pair<const CWalletTx*,unsigned int> >& setCoinsRet, CAmount& nValueRet) const
+bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, const int nConfMine, const int nConfTheirs, const uint64_t nMaxAncestors, std::vector<COutput> vCoins,
+                                 std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, CAmount& nValueRet) const
 {
     setCoinsRet.clear();
     nValueRet = 0;
 
     // List of values less than target
-    pair<CAmount, pair<const CWalletTx*,unsigned int> > coinLowestLarger;
+    std::pair<CAmount, std::pair<const CWalletTx*,unsigned int> > coinLowestLarger;
     coinLowestLarger.first = std::numeric_limits<CAmount>::max();
     coinLowestLarger.second.first = NULL;
-    vector<pair<CAmount, pair<const CWalletTx*,unsigned int> > > vValue;
+    std::vector<std::pair<CAmount, std::pair<const CWalletTx*,unsigned int> > > vValue;
     CAmount nTotalLower = 0;
 
     Shuffle(vCoins.begin(), vCoins.end(), FastRandomContext());
@@ -3725,7 +3723,7 @@ bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, const int nConfMin
         int i = output.i;
         CAmount n = pcoin->tx->vout[i].nValue;
 
-        pair<CAmount,pair<const CWalletTx*,unsigned int> > coin = make_pair(n,make_pair(pcoin, i));
+        std::pair<CAmount,std::pair<const CWalletTx*,unsigned int> > coin = std::make_pair(n,std::make_pair(pcoin, i));
 
         if (n == nTargetValue)
         {
@@ -3766,7 +3764,7 @@ bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, const int nConfMin
     // Solve subset sum by stochastic approximation
     std::sort(vValue.begin(), vValue.end(), CompareValueOnly());
     std::reverse(vValue.begin(), vValue.end());
-    vector<char> vfBest;
+    std::vector<char> vfBest;
     CAmount nBest;
 
     ApproximateBestSubset(vValue, nTotalLower, nTargetValue, vfBest, nBest);
@@ -3799,9 +3797,9 @@ bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, const int nConfMin
     return true;
 }
 
-bool CWallet::SelectCoins(const vector<COutput>& vAvailableCoins, const CAmount& nTargetValue, set<pair<const CWalletTx*,unsigned int> >& setCoinsRet, CAmount& nValueRet, const CCoinControl* coinControl) const
+bool CWallet::SelectCoins(const std::vector<COutput>& vAvailableCoins, const CAmount& nTargetValue, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, CAmount& nValueRet, const CCoinControl* coinControl) const
 {
-    vector<COutput> vCoins(vAvailableCoins);
+    std::vector<COutput> vCoins(vAvailableCoins);
     CoinType nCoinType = coinControl ? coinControl->nCoinType : CoinType::ALL_COINS;
 
     // coin control -> return all selected outputs (we want all selected to go into the transaction for sure)
@@ -3812,13 +3810,13 @@ bool CWallet::SelectCoins(const vector<COutput>& vAvailableCoins, const CAmount&
             if (!out.fSpendable)
                  continue;
             nValueRet += out.tx->tx->vout[out.i].nValue;
-            setCoinsRet.insert(make_pair(out.tx, out.i));
+            setCoinsRet.insert(std::make_pair(out.tx, out.i));
         }
         return (nValueRet >= nTargetValue);
     }
 
     // calculate value from preset inputs and store them
-    set<pair<const CWalletTx*, uint32_t> > setPresetCoins;
+    std::set<std::pair<const CWalletTx*, uint32_t> > setPresetCoins;
     CAmount nValueFromPresetInputs = 0;
 
     std::vector<COutPoint> vPresetInputs;
@@ -3826,7 +3824,7 @@ bool CWallet::SelectCoins(const vector<COutput>& vAvailableCoins, const CAmount&
         coinControl->ListSelected(vPresetInputs);
     BOOST_FOREACH(const COutPoint& outpoint, vPresetInputs)
     {
-        map<uint256, CWalletTx>::const_iterator it = mapWallet.find(outpoint.hash);
+        std::map<uint256, CWalletTx>::const_iterator it = mapWallet.find(outpoint.hash);
         if (it != mapWallet.end())
         {
             const CWalletTx* pcoin = &it->second;
@@ -3834,15 +3832,15 @@ bool CWallet::SelectCoins(const vector<COutput>& vAvailableCoins, const CAmount&
             if (pcoin->tx->vout.size() <= outpoint.n)
                 return false;
             nValueFromPresetInputs += pcoin->tx->vout[outpoint.n].nValue;
-            setPresetCoins.insert(make_pair(pcoin, outpoint.n));
+            setPresetCoins.insert(std::make_pair(pcoin, outpoint.n));
         } else
             return false; // TODO: Allow non-wallet inputs
     }
 
     // remove preset inputs from vCoins
-    for (vector<COutput>::iterator it = vCoins.begin(); it != vCoins.end() && coinControl && coinControl->HasSelected();)
+    for (std::vector<COutput>::iterator it = vCoins.begin(); it != vCoins.end() && coinControl && coinControl->HasSelected();)
     {
-        if (setPresetCoins.count(make_pair(it->tx, it->i)))
+        if (setPresetCoins.count(std::make_pair(it->tx, it->i)))
             it = vCoins.erase(it);
         else
             ++it;
@@ -3871,7 +3869,7 @@ bool CWallet::SelectCoins(const vector<COutput>& vAvailableCoins, const CAmount&
 
 bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, bool overrideEstimatedFeeRate, const CFeeRate& specificFeeRate, int& nChangePosInOut, std::string& strFailReason, bool includeWatching, bool lockUnspents, const std::set<int>& setSubtractFeeFromOutputs, bool keepReserveKey, const CTxDestination& destChange)
 {
-    vector<CRecipient> vecSend;
+    std::vector<CRecipient> vecSend;
 
     // Turn the txout set into a CRecipient vector
     for (size_t idx = 0; idx < tx.vout.size(); idx++)
@@ -4245,7 +4243,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                     // to be addressed so we avoid creating too small an output.
                     if (nFeeRet > nFeeNeeded && nChangePosInOut != -1 && nSubtractFeeFromAmount == 0) {
                         CAmount extraFeePaid = nFeeRet - nFeeNeeded;
-                        vector<CTxOut>::iterator change_position = txNew.vout.begin()+nChangePosInOut;
+                        std::vector<CTxOut>::iterator change_position = txNew.vout.begin()+nChangePosInOut;
                         change_position->nValue += extraFeePaid;
                         nFeeRet -= extraFeePaid;
                     }
@@ -4255,7 +4253,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                 // Try to reduce change to include necessary fee
                 if (nChangePosInOut != -1 && nSubtractFeeFromAmount == 0) {
                     CAmount additionalFeeNeeded = nFeeNeeded - nFeeRet;
-                    vector<CTxOut>::iterator change_position = txNew.vout.begin()+nChangePosInOut;
+                    std::vector<CTxOut>::iterator change_position = txNew.vout.begin()+nChangePosInOut;
                     // Only reduce change if remaining amount is still a large enough output.
                     if (change_position->nValue >= MIN_FINAL_CHANGE + additionalFeeNeeded) {
                         change_position->nValue -= additionalFeeNeeded;
@@ -4381,7 +4379,7 @@ bool CWallet::EraseFromWallet(uint256 hash) {
  * @param coinControl
  * @return
  */
-bool CWallet::CreateMintTransaction(const vector <CRecipient> &vecSend, CWalletTx &wtxNew,
+bool CWallet::CreateMintTransaction(const std::vector <CRecipient> &vecSend, CWalletTx &wtxNew,
                                             CReserveKey &reservekey,
                                             CAmount &nFeeRet, int &nChangePosInOut, std::string &strFailReason,
                                             const CCoinControl *coinControl, bool sign) {
@@ -4451,7 +4449,7 @@ bool CWallet::CreateMintTransaction(const vector <CRecipient> &vecSend, CWalletT
                 }
 
                 // Choose coins to use
-                set<pair<const CWalletTx*,unsigned int> > setCoins;
+                std::set<std::pair<const CWalletTx*,unsigned int> > setCoins;
                 CAmount nValueIn = 0;
                 if (!SelectCoins(vAvailableCoins, nValueToSelect, setCoins, nValueIn, coinControl))
                 {
@@ -4565,7 +4563,7 @@ bool CWallet::CreateMintTransaction(const vector <CRecipient> &vecSend, CWalletT
                             return false;
                         }
 
-                        vector<CTxOut>::iterator position = txNew.vout.begin()+nChangePosInOut;
+                        std::vector<CTxOut>::iterator position = txNew.vout.begin()+nChangePosInOut;
                         txNew.vout.insert(position, newTxOut);
                         wtxNew.changes.insert(static_cast<uint32_t>(nChangePosInOut));
                     }
@@ -4860,7 +4858,7 @@ bool CWallet::CreateLelantusMintTransactions(
                                 return false;
                             }
 
-                            vector<CTxOut>::iterator position = tx.vout.begin() + nChangePosInOut;
+                            std::vector<CTxOut>::iterator position = tx.vout.begin() + nChangePosInOut;
                             tx.vout.insert(position, newTxOut);
                             wtx.changes.insert(static_cast<uint32_t>(nChangePosInOut));
                         }
@@ -5057,7 +5055,7 @@ bool
 CWallet::CreateMintTransaction(CScript pubCoin, int64_t nValue, CWalletTx &wtxNew, CReserveKey &reservekey,
                                        int64_t &nFeeRet, std::string &strFailReason,
                                        const CCoinControl *coinControl) {
-    vector <CRecipient> vecSend;
+    std::vector <CRecipient> vecSend;
     CRecipient recipient = {pubCoin, nValue, false};
     vecSend.push_back(recipient);
     int nChangePosRet = -1;
@@ -5090,12 +5088,12 @@ CWalletTx CWallet::CreateSigmaSpendTransaction(
     return tx;
 }
 
-string CWallet::MintAndStoreSigma(const vector<CRecipient>& vecSend,
-                                       const vector<sigma::PrivateCoin>& privCoins,
-                                       vector<CHDMint> vDMints,
+std::string CWallet::MintAndStoreSigma(const std::vector<CRecipient>& vecSend,
+                                       const std::vector<sigma::PrivateCoin>& privCoins,
+                                       std::vector<CHDMint> vDMints,
                                        CWalletTx &wtxNew, bool fAskFee,
                                        const CCoinControl *coinControl) {
-    string strError;
+    std::string strError;
 
     EnsureMintWalletAvailable();
 
@@ -5171,7 +5169,7 @@ std::string CWallet::MintAndStoreLelantus(const CAmount& value,
                                           bool autoMintAll,
                                           bool fAskFee,
                                           const CCoinControl *coinControl) {
-    string strError;
+    std::string strError;
 
     EnsureMintWalletAvailable();
 
@@ -5301,7 +5299,7 @@ bool CWallet::CommitSigmaTransaction(CWalletTx& wtxNew, std::vector<CSigmaEntry>
         CMintMeta metaCheck;
         zwallet->GetTracker().GetMetaFromPubcoin(hashPubcoin, metaCheck);
         if (!metaCheck.isUsed) {
-            string strError = "Error, mint with pubcoin hash " + hashPubcoin.GetHex() + " did not get marked as used";
+            std::string strError = "Error, mint with pubcoin hash " + hashPubcoin.GetHex() + " did not get marked as used";
             LogPrintf("SpendSigma() : %s\n", strError.c_str());
         }
 
@@ -5496,7 +5494,7 @@ bool CWallet::CommitLelantusTransaction(CWalletTx& wtxNew, std::vector<CLelantus
         CLelantusMintMeta metaCheck;
         zwallet->GetTracker().GetLelantusMetaFromPubcoin(hashPubcoin, metaCheck);
         if (!metaCheck.isUsed) {
-            string strError = "Error, mint with pubcoin hash " + hashPubcoin.GetHex() + " did not get marked as used";
+            std::string strError = "Error, mint with pubcoin hash " + hashPubcoin.GetHex() + " did not get marked as used";
             LogPrintf("SpendLelantus() : %s\n", strError.c_str());
         }
 
@@ -5543,7 +5541,7 @@ bool CWallet::CommitLelantusTransaction(CWalletTx& wtxNew, std::vector<CLelantus
         CMintMeta metaCheck;
         zwallet->GetTracker().GetMetaFromPubcoin(hashPubcoin, metaCheck);
         if (!metaCheck.isUsed) {
-            string strError = "Error, mint with pubcoin hash " + hashPubcoin.GetHex() + " did not get marked as used";
+            std::string strError = "Error, mint with pubcoin hash " + hashPubcoin.GetHex() + " did not get marked as used";
             LogPrintf("SpendZerocoin() : %s\n", strError.c_str());
         }
 
@@ -5743,7 +5741,7 @@ void CWallet::AutoLockMasternodeCollaterals()
     }
 }
 
-DBErrors CWallet::ZapSelectTx(vector<uint256>& vHashIn, vector<uint256>& vHashOut)
+DBErrors CWallet::ZapSelectTx(std::vector<uint256>& vHashIn, std::vector<uint256>& vHashOut)
 {
     if (!fFileBacked)
         return DB_LOAD_OK;
@@ -5817,7 +5815,7 @@ DBErrors CWallet::ZapLelantusMints() {
 }
 
 
-bool CWallet::SetAddressBook(const CTxDestination& address, const string& strName, const string& strPurpose)
+bool CWallet::SetAddressBook(const CTxDestination& address, const std::string& strName, const std::string& strPurpose)
 {
     bool fUpdated = false;
     {
@@ -5846,7 +5844,7 @@ bool CWallet::DelAddressBook(const CTxDestination& address)
         {
             // Delete destdata tuples associated with address
             std::string strAddress = CBitcoinAddress(address).ToString();
-            BOOST_FOREACH(const PAIRTYPE(string, string) &item, mapAddressBook[address].destdata)
+            BOOST_FOREACH(const PAIRTYPE(std::string, std::string) &item, mapAddressBook[address].destdata)
             {
                 CWalletDB(strWalletFile).EraseDestData(strAddress, item.first);
             }
@@ -5904,7 +5902,7 @@ bool CWallet::NewKeyPool()
         if (IsLocked())
             return false;
 
-        int64_t nKeys = max(GetArg("-keypool", DEFAULT_KEYPOOL_SIZE), (int64_t)0);
+        int64_t nKeys = std::max(GetArg("-keypool", DEFAULT_KEYPOOL_SIZE), (int64_t)0);
         for (int i = 0; i < nKeys; i++)
         {
             int64_t nIndex = i+1;
@@ -5931,7 +5929,7 @@ bool CWallet::TopUpKeyPool(unsigned int kpSize)
         if (kpSize > 0)
             nTargetSize = kpSize;
         else
-            nTargetSize = max(GetArg("-keypool", DEFAULT_KEYPOOL_SIZE), (int64_t) 0);
+            nTargetSize = std::max(GetArg("-keypool", DEFAULT_KEYPOOL_SIZE), (int64_t) 0);
 
         while (setKeyPool.size() < (nTargetSize + 1))
         {
@@ -5939,7 +5937,7 @@ bool CWallet::TopUpKeyPool(unsigned int kpSize)
             if (!setKeyPool.empty())
                 nEnd = *(--setKeyPool.end()) + 1;
             if (!walletdb.WritePool(nEnd, CKeyPool(GenerateNewKey())))
-                throw runtime_error(std::string(__func__) + ": writing generated key failed");
+                throw std::runtime_error(std::string(__func__) + ": writing generated key failed");
             setKeyPool.insert(nEnd);
             LogPrintf("keypool added key %d, size=%u\n", nEnd, setKeyPool.size());
         }
@@ -5966,9 +5964,9 @@ void CWallet::ReserveKeyFromKeyPool(int64_t& nIndex, CKeyPool& keypool)
         nIndex = *(setKeyPool.begin());
         setKeyPool.erase(setKeyPool.begin());
         if (!walletdb.ReadPool(nIndex, keypool))
-            throw runtime_error(std::string(__func__) + ": read failed");
+            throw std::runtime_error(std::string(__func__) + ": read failed");
         if (!HaveKey(keypool.vchPubKey.GetID()))
-            throw runtime_error(std::string(__func__) + ": unknown key in key pool");
+            throw std::runtime_error(std::string(__func__) + ": unknown key in key pool");
         assert(keypool.vchPubKey.IsValid());
         LogPrintf("keypool reserve %d\n", nIndex);
     }
@@ -6027,14 +6025,14 @@ int64_t CWallet::GetOldestKeyPoolTime()
     CWalletDB walletdb(strWalletFile);
     int64_t nIndex = *(setKeyPool.begin());
     if (!walletdb.ReadPool(nIndex, keypool))
-        throw runtime_error(std::string(__func__) + ": read oldest key in keypool failed");
+        throw std::runtime_error(std::string(__func__) + ": read oldest key in keypool failed");
     assert(keypool.vchPubKey.IsValid());
     return keypool.nTime;
 }
 
 std::map<CTxDestination, CAmount> CWallet::GetAddressBalances()
 {
-    map<CTxDestination, CAmount> balances;
+    std::map<CTxDestination, CAmount> balances;
 
     {
         LOCK(cs_wallet);
@@ -6072,11 +6070,11 @@ std::map<CTxDestination, CAmount> CWallet::GetAddressBalances()
     return balances;
 }
 
-set< set<CTxDestination> > CWallet::GetAddressGroupings()
+std::set< std::set<CTxDestination> > CWallet::GetAddressGroupings()
 {
     AssertLockHeld(cs_wallet); // mapWallet
-    set< set<CTxDestination> > groupings;
-    set<CTxDestination> grouping;
+    std::set< std::set<CTxDestination> > groupings;
+    std::set<CTxDestination> grouping;
 
     BOOST_FOREACH(PAIRTYPE(uint256, CWalletTx) walletEntry, mapWallet)
     {
@@ -6130,20 +6128,20 @@ set< set<CTxDestination> > CWallet::GetAddressGroupings()
             }
     }
 
-    set< set<CTxDestination>* > uniqueGroupings; // a set of pointers to groups of addresses
-    map< CTxDestination, set<CTxDestination>* > setmap;  // map addresses to the unique group containing it
-    BOOST_FOREACH(set<CTxDestination> _grouping, groupings)
+    std::set< std::set<CTxDestination>* > uniqueGroupings; // a set of pointers to groups of addresses
+    std::map< CTxDestination, std::set<CTxDestination>* > setmap;  // map addresses to the unique group containing it
+    BOOST_FOREACH(std::set<CTxDestination> _grouping, groupings)
     {
         // make a set of all the groups hit by this new group
-        set< set<CTxDestination>* > hits;
-        map< CTxDestination, set<CTxDestination>* >::iterator it;
+        std::set< std::set<CTxDestination>* > hits;
+        std::map< CTxDestination, std::set<CTxDestination>* >::iterator it;
         BOOST_FOREACH(CTxDestination address, _grouping)
             if ((it = setmap.find(address)) != setmap.end())
                 hits.insert((*it).second);
 
         // merge all hit groups into a new single group and delete old groups
-        set<CTxDestination>* merged = new set<CTxDestination>(_grouping);
-        BOOST_FOREACH(set<CTxDestination>* hit, hits)
+        std::set<CTxDestination>* merged = new std::set<CTxDestination>(_grouping);
+        BOOST_FOREACH(std::set<CTxDestination>* hit, hits)
         {
             merged->insert(hit->begin(), hit->end());
             uniqueGroupings.erase(hit);
@@ -6156,8 +6154,8 @@ set< set<CTxDestination> > CWallet::GetAddressGroupings()
             setmap[element] = merged;
     }
 
-    set< set<CTxDestination> > ret;
-    BOOST_FOREACH(set<CTxDestination>* uniqueGrouping, uniqueGroupings)
+    std::set< std::set<CTxDestination> > ret;
+    BOOST_FOREACH(std::set<CTxDestination>* uniqueGrouping, uniqueGroupings)
     {
         ret.insert(*uniqueGrouping);
         delete uniqueGrouping;
@@ -6169,11 +6167,11 @@ set< set<CTxDestination> > CWallet::GetAddressGroupings()
 std::set<CTxDestination> CWallet::GetAccountAddresses(const std::string& strAccount) const
 {
     LOCK(cs_wallet);
-    set<CTxDestination> result;
+    std::set<CTxDestination> result;
     BOOST_FOREACH(const PAIRTYPE(CTxDestination, CAddressBookData)& item, mapAddressBook)
     {
         const CTxDestination& address = item.first;
-        const string& strName = item.second.name;
+        const std::string& strName = item.second.name;
         if (strName == strAccount)
             result.insert(address);
     }
@@ -6213,7 +6211,7 @@ void CReserveKey::ReturnKey()
     vchPubKey = CPubKey();
 }
 
-void CWallet::GetAllReserveKeys(set<CKeyID>& setAddress) const
+void CWallet::GetAllReserveKeys(std::set<CKeyID>& setAddress) const
 {
     setAddress.clear();
 
@@ -6224,11 +6222,11 @@ void CWallet::GetAllReserveKeys(set<CKeyID>& setAddress) const
     {
         CKeyPool keypool;
         if (!walletdb.ReadPool(id, keypool))
-            throw runtime_error(std::string(__func__) + ": read failed");
+            throw std::runtime_error(std::string(__func__) + ": read failed");
         assert(keypool.vchPubKey.IsValid());
         CKeyID keyID = keypool.vchPubKey.GetID();
         if (!HaveKey(keyID))
-            throw runtime_error(std::string(__func__) + ": unknown key in key pool");
+            throw std::runtime_error(std::string(__func__) + ": unknown key in key pool");
         setAddress.insert(keyID);
     }
 }
@@ -6238,7 +6236,7 @@ bool CWallet::UpdatedTransaction(const uint256 &hashTx)
     {
         LOCK(cs_wallet);
         // Only notify UI if this transaction is in this wallet
-        map<uint256, CWalletTx>::const_iterator mi = mapWallet.find(hashTx);
+        std::map<uint256, CWalletTx>::const_iterator mi = mapWallet.find(hashTx);
         if (mi != mapWallet.end()) {
             NotifyTransactionChanged(this, hashTx, CT_UPDATED);
             return true;
@@ -7215,7 +7213,7 @@ void CWallet::HandleBip47Transaction(CWalletTx const & wtx)
     CKey key;
     bip47::CAccountReceiver * accFound = nullptr;
     int nRequired = 0;
-    vector<CTxDestination> addresses;
+    std::vector<CTxDestination> addresses;
     txnouttype typeRet = TX_NONSTANDARD;
     std::vector<CTxIn>::const_iterator ijsplit;
     std::vector<CTxOut>::const_iterator iregout;
@@ -7269,7 +7267,7 @@ notifTxExit:
     } else {
         // Checking if it uses a bip47 address
         for (CTxOut const & out : wtx.tx->vout) {
-            vector<CTxDestination> addresses;
+            std::vector<CTxDestination> addresses;
             txnouttype typeRet = TX_NONSTANDARD;
             int nRequired = 0;
             if (ExtractDestinations(out.scriptPubKey, typeRet, addresses, nRequired)) {
@@ -7440,7 +7438,7 @@ int CMerkleTx::GetBlocksToMaturity() const
 {
     if (!IsCoinBase())
         return 0;
-    return max(0, (COINBASE_MATURITY+1) - GetDepthInMainChain());
+    return std::max(0, (COINBASE_MATURITY+1) - GetDepthInMainChain());
 }
 
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -919,7 +919,7 @@ public:
 
     static std::vector<CRecipient> CreateSigmaMintRecipients(
         std::vector<sigma::PrivateCoin>& coins,
-        vector<CHDMint>& vDMints);
+        std::vector<CHDMint>& vDMints);
 
     static CRecipient CreateLelantusMintRecipient(
         lelantus::PrivateCoin& coin,
@@ -992,8 +992,8 @@ public:
     /**
      * Add Mint and Spend functions
      */
-    void ListAvailableSigmaMintCoins(vector <COutput> &vCoins, bool fOnlyConfirmed) const;
-    void ListAvailableLelantusMintCoins(vector<COutput> &vCoins, bool fOnlyConfirmed) const;
+    void ListAvailableSigmaMintCoins(std::vector <COutput> &vCoins, bool fOnlyConfirmed) const;
+    void ListAvailableLelantusMintCoins(std::vector<COutput> &vCoins, bool fOnlyConfirmed) const;
 
     bool CreateMintTransaction(const std::vector<CRecipient>& vecSend, CWalletTx& wtxNew, CReserveKey& reservekey, CAmount& nFeeRet, int& nChangePosInOut,
                            std::string& strFailReason, const CCoinControl *coinControl = NULL, bool sign = true);
@@ -1028,9 +1028,9 @@ public:
     std::string SendMoneyToDestination(const CTxDestination &address, int64_t nValue, CWalletTx& wtxNew, bool fAskFee=false);
 
     std::string MintAndStoreSigma(
-        const vector<CRecipient>& vecSend,
-        const vector<sigma::PrivateCoin>& privCoins,
-        vector<CHDMint> vDMints,
+        const std::vector<CRecipient>& vecSend,
+        const std::vector<sigma::PrivateCoin>& privCoins,
+        std::vector<CHDMint> vDMints,
         CWalletTx &wtxNew,
         bool fAskFee=false,
         const CCoinControl *coinControl = NULL);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -908,6 +908,8 @@ public:
     void ResendWalletTransactions(int64_t nBestBlockTime, CConnman* connman) override;
     std::vector<uint256> ResendWalletTransactionsBefore(int64_t nTime, CConnman* connman);
     CAmount GetBalance(bool fExcludeLocked = false) const;
+    std::pair<CAmount, CAmount> GetPrivateBalance() const;
+    std::pair<CAmount, CAmount> GetPrivateBalance(size_t &confirmed, size_t &unconfirmed) const;
     CAmount GetUnconfirmedBalance() const;
     CAmount GetImmatureBalance() const;
     CAmount GetWatchOnlyBalance() const;

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -22,8 +22,6 @@
 #include <boost/foreach.hpp>
 #include <boost/thread.hpp>
 
-using namespace std;
-
 static uint64_t nAccountingEntryNumber = 0;
 
 static std::atomic<unsigned int> nWalletDBUpdateCounter;
@@ -32,42 +30,42 @@ static std::atomic<unsigned int> nWalletDBUpdateCounter;
 // CWalletDB
 //
 
-bool CWalletDB::WriteKV(const string& key, const string& value)
+bool CWalletDB::WriteKV(const std::string& key, const std::string& value)
 {
     nWalletDBUpdateCounter++;
-    return Write(make_pair(string("kv"), key), value);
+    return Write(std::make_pair(std::string("kv"), key), value);
 }
 
-bool CWalletDB::EraseKV(const string& key)
+bool CWalletDB::EraseKV(const std::string& key)
 {
     nWalletDBUpdateCounter++;
-    return Erase(make_pair(string("kv"), key));
+    return Erase(std::make_pair(std::string("kv"), key));
 }
 
-bool CWalletDB::WriteName(const string& strAddress, const string& strName)
+bool CWalletDB::WriteName(const std::string& strAddress, const std::string& strName)
 {
     nWalletDBUpdateCounter++;
-    return Write(make_pair(string("name"), strAddress), strName);
+    return Write(std::make_pair(std::string("name"), strAddress), strName);
 }
 
-bool CWalletDB::EraseName(const string& strAddress)
+bool CWalletDB::EraseName(const std::string& strAddress)
 {
     // This should only be used for sending addresses, never for receiving addresses,
     // receiving addresses must always have an address book entry if they're not change return.
     nWalletDBUpdateCounter++;
-    return Erase(make_pair(string("name"), strAddress));
+    return Erase(std::make_pair(std::string("name"), strAddress));
 }
 
-bool CWalletDB::WritePurpose(const string& strAddress, const string& strPurpose)
+bool CWalletDB::WritePurpose(const std::string& strAddress, const std::string& strPurpose)
 {
     nWalletDBUpdateCounter++;
-    return Write(make_pair(string("purpose"), strAddress), strPurpose);
+    return Write(std::make_pair(std::string("purpose"), strAddress), strPurpose);
 }
 
-bool CWalletDB::ErasePurpose(const string& strPurpose)
+bool CWalletDB::ErasePurpose(const std::string& strPurpose)
 {
     nWalletDBUpdateCounter++;
-    return Erase(make_pair(string("purpose"), strPurpose));
+    return Erase(std::make_pair(std::string("purpose"), strPurpose));
 }
 
 bool CWalletDB::WriteTx(const CWalletTx& wtx)
@@ -195,15 +193,15 @@ bool CWalletDB::WriteMinVersion(int nVersion)
     return Write(std::string("minversion"), nVersion);
 }
 
-bool CWalletDB::ReadAccount(const string& strAccount, CAccount& account)
+bool CWalletDB::ReadAccount(const std::string& strAccount, CAccount& account)
 {
     account.SetNull();
-    return Read(make_pair(string("acc"), strAccount), account);
+    return Read(std::make_pair(std::string("acc"), strAccount), account);
 }
 
-bool CWalletDB::WriteAccount(const string& strAccount, const CAccount& account)
+bool CWalletDB::WriteAccount(const std::string& strAccount, const CAccount& account)
 {
-    return Write(make_pair(string("acc"), strAccount), account);
+    return Write(std::make_pair(std::string("acc"), strAccount), account);
 }
 
 bool CWalletDB::WriteAccountingEntry(const uint64_t nAccEntryNum, const CAccountingEntry& acentry)
@@ -216,9 +214,9 @@ bool CWalletDB::WriteAccountingEntry_Backend(const CAccountingEntry& acentry)
     return WriteAccountingEntry(++nAccountingEntryNumber, acentry);
 }
 
-CAmount CWalletDB::GetAccountCreditDebit(const string& strAccount)
+CAmount CWalletDB::GetAccountCreditDebit(const std::string& strAccount)
 {
-    list<CAccountingEntry> entries;
+    std::list<CAccountingEntry> entries;
     ListAccountCreditDebit(strAccount, entries);
 
     CAmount nCreditDebit = 0;
@@ -228,20 +226,20 @@ CAmount CWalletDB::GetAccountCreditDebit(const string& strAccount)
     return nCreditDebit;
 }
 
-void CWalletDB::ListAccountCreditDebit(const string& strAccount, list<CAccountingEntry>& entries)
+void CWalletDB::ListAccountCreditDebit(const std::string& strAccount, std::list<CAccountingEntry>& entries)
 {
     bool fAllAccounts = (strAccount == "*");
 
     Dbc* pcursor = GetCursor();
     if (!pcursor)
-        throw runtime_error(std::string(__func__) + ": cannot create DB cursor");
+        throw std::runtime_error(std::string(__func__) + ": cannot create DB cursor");
     bool setRange = true;
     while (true)
     {
         // Read next record
         CDataStream ssKey(SER_DISK, CLIENT_VERSION);
         if (setRange)
-            ssKey << std::make_pair(std::string("acentry"), std::make_pair((fAllAccounts ? string("") : strAccount), uint64_t(0)));
+            ssKey << std::make_pair(std::string("acentry"), std::make_pair((fAllAccounts ? std::string("") : strAccount), uint64_t(0)));
         CDataStream ssValue(SER_DISK, CLIENT_VERSION);
         int ret = ReadAtCursor(pcursor, ssKey, ssValue, setRange);
         setRange = false;
@@ -250,11 +248,11 @@ void CWalletDB::ListAccountCreditDebit(const string& strAccount, list<CAccountin
         else if (ret != 0)
         {
             pcursor->close();
-            throw runtime_error(std::string(__func__) + ": error scanning DB");
+            throw std::runtime_error(std::string(__func__) + ": error scanning DB");
         }
 
         // Unserialize
-        string strType;
+        std::string strType;
         ssKey >> strType;
         if (strType != "acentry")
             break;
@@ -322,7 +320,7 @@ bool CWalletDB::WriteCalculatedZCBlock(int height) {
 void CWalletDB::ListSigmaPubCoin(std::list <CSigmaEntry> &listPubCoin) {
     Dbc *pcursor = GetCursor();
     if (!pcursor)
-        throw runtime_error("CWalletDB::ListSigmaPubCoin() : cannot create DB cursor");
+        throw std::runtime_error("CWalletDB::ListSigmaPubCoin() : cannot create DB cursor");
     bool setRange = true;
     while (true) {
         // Read next record
@@ -336,10 +334,10 @@ void CWalletDB::ListSigmaPubCoin(std::list <CSigmaEntry> &listPubCoin) {
             break;
         else if (ret != 0) {
             pcursor->close();
-            throw runtime_error("CWalletDB::ListSigmaPubCoin() : error scanning DB");
+            throw std::runtime_error("CWalletDB::ListSigmaPubCoin() : error scanning DB");
         }
         // Unserialize
-        string strType;
+        std::string strType;
         ssKey >> strType;
         if (strType != "sigma_mint")
             break;
@@ -355,7 +353,7 @@ void CWalletDB::ListSigmaPubCoin(std::list <CSigmaEntry> &listPubCoin) {
 void CWalletDB::ListCoinSpendSerial(std::list <CSigmaSpendEntry> &listCoinSpendSerial) {
     Dbc *pcursor = GetCursor();
     if (!pcursor)
-        throw runtime_error("CWalletDB::ListCoinSpendSerial() : cannot create DB cursor");
+        throw std::runtime_error("CWalletDB::ListCoinSpendSerial() : cannot create DB cursor");
     bool setRange = true;
     while (true) {
         // Read next record
@@ -369,11 +367,11 @@ void CWalletDB::ListCoinSpendSerial(std::list <CSigmaSpendEntry> &listCoinSpendS
             break;
         else if (ret != 0) {
             pcursor->close();
-            throw runtime_error("CWalletDB::ListCoinSpendSerial() : error scanning DB");
+            throw std::runtime_error("CWalletDB::ListCoinSpendSerial() : error scanning DB");
         }
 
         // Unserialize
-        string strType;
+        std::string strType;
         ssKey >> strType;
         if (strType != "sigma_spend")
             break;
@@ -390,7 +388,7 @@ void CWalletDB::ListCoinSpendSerial(std::list <CSigmaSpendEntry> &listCoinSpendS
 void CWalletDB::ListLelantusSpendSerial(std::list <CLelantusSpendEntry>& listLelantusSpendSerial) {
     Dbc *pcursor = GetCursor();
     if (!pcursor)
-        throw runtime_error("CWalletDB::ListLelantusSpendSerial() : cannot create DB cursor");
+        throw std::runtime_error("CWalletDB::ListLelantusSpendSerial() : cannot create DB cursor");
     bool setRange = true;
     while (true) {
         // Read next record
@@ -404,11 +402,11 @@ void CWalletDB::ListLelantusSpendSerial(std::list <CLelantusSpendEntry>& listLel
             break;
         else if (ret != 0) {
             pcursor->close();
-            throw runtime_error("CWalletDB::ListLelantusSpendSerial() : error scanning DB");
+            throw std::runtime_error("CWalletDB::ListLelantusSpendSerial() : error scanning DB");
         }
 
         // Unserialize
-        string strType;
+        std::string strType;
         ssKey >> strType;
         if (strType != "lelantus_spend")
             break;
@@ -429,20 +427,20 @@ DBErrors CWalletDB::ReorderTransactions(CWallet* pwallet)
     // Probably a bad idea to change the output of this
 
     // First: get all CWalletTx and CAccountingEntry into a sorted-by-time multimap.
-    typedef pair<CWalletTx*, CAccountingEntry*> TxPair;
-    typedef multimap<int64_t, TxPair > TxItems;
+    typedef std::pair<CWalletTx*, CAccountingEntry*> TxPair;
+    typedef std::multimap<int64_t, TxPair > TxItems;
     TxItems txByTime;
 
-    for (map<uint256, CWalletTx>::iterator it = pwallet->mapWallet.begin(); it != pwallet->mapWallet.end(); ++it)
+    for (std::map<uint256, CWalletTx>::iterator it = pwallet->mapWallet.begin(); it != pwallet->mapWallet.end(); ++it)
     {
         CWalletTx* wtx = &((*it).second);
-        txByTime.insert(make_pair(wtx->nTimeReceived, TxPair(wtx, (CAccountingEntry*)0)));
+        txByTime.insert(std::make_pair(wtx->nTimeReceived, TxPair(wtx, (CAccountingEntry*)0)));
     }
-    list<CAccountingEntry> acentries;
+    std::list<CAccountingEntry> acentries;
     ListAccountCreditDebit("", acentries);
     BOOST_FOREACH(CAccountingEntry& entry, acentries)
     {
-        txByTime.insert(make_pair(entry.nTime, TxPair((CWalletTx*)0, &entry)));
+        txByTime.insert(std::make_pair(entry.nTime, TxPair((CWalletTx*)0, &entry)));
     }
 
     int64_t& nOrderPosNext = pwallet->nOrderPosNext;
@@ -505,7 +503,7 @@ bool CWalletDB::WriteHDMint(const uint256& hashPubcoin, const CHDMint& dMint, bo
         name = "hdmint";
     else
         name = "hdmint_lelantus";
-    return Write(make_pair(name, hashPubcoin), dMint, true);
+    return Write(std::make_pair(name, hashPubcoin), dMint, true);
 }
 
 bool CWalletDB::ReadHDMint(const uint256& hashPubcoin, bool isLelantus, CHDMint& dMint)
@@ -515,7 +513,7 @@ bool CWalletDB::ReadHDMint(const uint256& hashPubcoin, bool isLelantus, CHDMint&
         name = "hdmint";
     else
         name = "hdmint_lelantus";
-    return Read(make_pair(name, hashPubcoin), dMint);
+    return Read(std::make_pair(name, hashPubcoin), dMint);
 }
 
 bool CWalletDB::EraseHDMint(const CHDMint& dMint) {
@@ -529,15 +527,15 @@ bool CWalletDB::HasHDMint(const secp_primitives::GroupElement& pub) {
 }
 
 bool CWalletDB::WritePubcoinHashes(const uint256& fullHash, const uint256& reducedHash) {
-    return Write(make_pair(std::string("pubhash"), fullHash), reducedHash, true);
+    return Write(std::make_pair(std::string("pubhash"), fullHash), reducedHash, true);
 }
 
 bool CWalletDB::ReadPubcoinHashes(const uint256& fullHash, uint256& reducedHash) {
-    return Read(make_pair(std::string("pubhash"), fullHash), reducedHash);
+    return Read(std::make_pair(std::string("pubhash"), fullHash), reducedHash);
 }
 
 bool CWalletDB::ErasePubcoinHashes(const uint256& fullHash) {
-    return Erase(make_pair(std::string("pubhash"), fullHash));
+    return Erase(std::make_pair(std::string("pubhash"), fullHash));
 }
 
 class CWalletScanState {
@@ -550,7 +548,7 @@ public:
     bool fAnyUnordered;
     bool fUpgradeHDChain;
     int nFileVersion;
-    vector<uint256> vWalletUpgrade;
+    std::vector<uint256> vWalletUpgrade;
 
     CWalletScanState() {
         nKeys = nCKeys = nWatchKeys = nKeyMeta = 0;
@@ -563,7 +561,7 @@ public:
 
 bool
 ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
-             CWalletScanState &wss, string& strType, string& strErr)
+             CWalletScanState &wss, std::string& strType, std::string& strErr)
 {
     try {
         // Unserialize
@@ -572,20 +570,20 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
         ssKey >> strType;
         if (strType == "kv")
         {
-            string key, value;
+            std::string key, value;
             ssKey >> key;
             ssValue >> value;
             pwallet->mapCustomKeyValues.insert(std::make_pair(key, value));
         }
         else if (strType == "name")
         {
-            string strAddress;
+            std::string strAddress;
             ssKey >> strAddress;
             ssValue >> pwallet->mapAddressBook[CBitcoinAddress(strAddress).Get()].name;
         }
         else if (strType == "purpose")
         {
-            string strAddress;
+            std::string strAddress;
             ssKey >> strAddress;
             ssValue >> pwallet->mapAddressBook[CBitcoinAddress(strAddress).Get()].purpose;
         }
@@ -626,7 +624,7 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
         }
         else if (strType == "acentry")
         {
-            string strAccount;
+            std::string strAccount;
             ssKey >> strAccount;
             uint64_t nNumber;
             ssKey >> nNumber;
@@ -739,7 +737,7 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
                 strErr = "Error reading wallet database: CPubKey corrupt";
                 return false;
             }
-            vector<unsigned char> vchPrivKey;
+            std::vector<unsigned char> vchPrivKey;
             ssValue >> vchPrivKey;
             wss.nCKeys++;
 
@@ -844,7 +842,7 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
     return true;
 }
 
-static bool IsKeyType(string strType)
+static bool IsKeyType(std::string strType)
 {
     return (strType== "key" || strType == "wkey" ||
             strType == "mkey" || strType == "ckey");
@@ -860,7 +858,7 @@ DBErrors CWalletDB::LoadWallet(CWallet* pwallet)
     LOCK2(cs_main, pwallet->cs_wallet);
     try {
         int nMinVersion = 0;
-        if (Read((string)"minversion", nMinVersion))
+        if (Read((std::string)"minversion", nMinVersion))
         {
             if (nMinVersion > CLIENT_VERSION)
                 return DB_TOO_NEW;
@@ -890,7 +888,7 @@ DBErrors CWalletDB::LoadWallet(CWallet* pwallet)
             }
 
             // Try to be tolerant of single corrupt records:
-            string strType, strErr;
+            std::string strType, strErr;
             if (!ReadKeyValue(pwallet, ssKey, ssValue, wss, strType, strErr))
             {
                 // losing keys is considered a catastrophic error, anything else
@@ -951,7 +949,7 @@ DBErrors CWalletDB::LoadWallet(CWallet* pwallet)
     pwallet->laccentries.clear();
     ListAccountCreditDebit("*", pwallet->laccentries);
     BOOST_FOREACH(CAccountingEntry& entry, pwallet->laccentries) {
-        pwallet->wtxOrdered.insert(make_pair(entry.nOrderPos, CWallet::TxPair((CWalletTx*)0, &entry)));
+        pwallet->wtxOrdered.insert(std::make_pair(entry.nOrderPos, CWallet::TxPair((CWalletTx*)0, &entry)));
     }
 
     // unencrypted wallets upgrading the wallet version get a new keypool here
@@ -961,7 +959,7 @@ DBErrors CWalletDB::LoadWallet(CWallet* pwallet)
     return result;
 }
 
-DBErrors CWalletDB::FindWalletTx(CWallet* pwallet, vector<uint256>& vTxHash, vector<CWalletTx>& vWtx)
+DBErrors CWalletDB::FindWalletTx(CWallet* pwallet, std::vector<uint256>& vTxHash, std::vector<CWalletTx>& vWtx)
 {
     pwallet->vchDefaultKey = CPubKey();
     bool fNoncriticalErrors = false;
@@ -970,7 +968,7 @@ DBErrors CWalletDB::FindWalletTx(CWallet* pwallet, vector<uint256>& vTxHash, vec
     try {
         LOCK(pwallet->cs_wallet);
         int nMinVersion = 0;
-        if (Read((string)"minversion", nMinVersion))
+        if (Read((std::string)"minversion", nMinVersion))
         {
             if (nMinVersion > CLIENT_VERSION)
                 return DB_TOO_NEW;
@@ -999,7 +997,7 @@ DBErrors CWalletDB::FindWalletTx(CWallet* pwallet, vector<uint256>& vTxHash, vec
                 return DB_CORRUPT;
             }
 
-            string strType;
+            std::string strType;
             ssKey >> strType;
             if (strType == "tx") {
                 uint256 hash;
@@ -1027,11 +1025,11 @@ DBErrors CWalletDB::FindWalletTx(CWallet* pwallet, vector<uint256>& vTxHash, vec
     return result;
 }
 
-DBErrors CWalletDB::ZapSelectTx(CWallet* pwallet, vector<uint256>& vTxHashIn, vector<uint256>& vTxHashOut)
+DBErrors CWalletDB::ZapSelectTx(CWallet* pwallet, std::vector<uint256>& vTxHashIn, std::vector<uint256>& vTxHashOut)
 {
     // build list of wallet TXs and hashes
-    vector<uint256> vTxHash;
-    vector<CWalletTx> vWtx;
+    std::vector<uint256> vTxHash;
+    std::vector<CWalletTx> vWtx;
     DBErrors err = FindWalletTx(pwallet, vTxHash, vWtx);
     if (err != DB_LOAD_OK) {
         return err;
@@ -1042,7 +1040,7 @@ DBErrors CWalletDB::ZapSelectTx(CWallet* pwallet, vector<uint256>& vTxHashIn, ve
 
     // erase each matching wallet TX
     bool delerror = false;
-    vector<uint256>::iterator it = vTxHashIn.begin();
+    std::vector<uint256>::iterator it = vTxHashIn.begin();
     BOOST_FOREACH (uint256 hash, vTxHash) {
         while (it < vTxHashIn.end() && (*it) < hash) {
             it++;
@@ -1105,10 +1103,10 @@ DBErrors CWalletDB::ZapLelantusMints(CWallet *pwallet) {
     return DB_LOAD_OK;
 }
 
-DBErrors CWalletDB::ZapWalletTx(CWallet* pwallet, vector<CWalletTx>& vWtx)
+DBErrors CWalletDB::ZapWalletTx(CWallet* pwallet, std::vector<CWalletTx>& vWtx)
 {
     // build list of wallet TXs
-    vector<uint256> vTxHash;
+    std::vector<uint256> vTxHash;
     DBErrors err = FindWalletTx(pwallet, vTxHash, vWtx);
     if (err != DB_LOAD_OK)
         return err;
@@ -1154,7 +1152,7 @@ void ThreadFlushWalletDB()
             {
                 // Don't do this if any databases are in use
                 int nRefCount = 0;
-                map<string, int>::iterator mi = bitdb.mapFileUseCount.begin();
+                std::map<std::string, int>::iterator mi = bitdb.mapFileUseCount.begin();
                 while (mi != bitdb.mapFileUseCount.end())
                 {
                     nRefCount += (*mi).second;
@@ -1165,7 +1163,7 @@ void ThreadFlushWalletDB()
                 {
                     boost::this_thread::interruption_point();
                     const std::string& strFile = pwalletMain->strWalletFile;
-                    map<string, int>::iterator _mi = bitdb.mapFileUseCount.find(strFile);
+                    std::map<std::string, int>::iterator _mi = bitdb.mapFileUseCount.find(strFile);
                     if (_mi != bitdb.mapFileUseCount.end())
                     {
                         LogPrint("db", "Flushing %s\n", strFile);
@@ -1218,8 +1216,8 @@ bool AutoBackupWallet (CWallet* wallet, std::string strWalletFile, std::string& 
             LOCK2(cs_main, wallet->cs_wallet);
             strWalletFile = wallet->strWalletFile;
             fs::path backupFile = backupsDir / (strWalletFile + dateTimeStr);
-//            if(!BackupWallet(*wallet, backupFile.string())) {
-//                strBackupWarning = strprintf(_("Failed to create backup %s!"), backupFile.string());
+//            if(!BackupWallet(*wallet, backupFile.std::string())) {
+//                strBackupWarning = strprintf(_("Failed to create backup %s!"), backupFile.std::string());
 //                LogPrintf("%s\n", strBackupWarning);
 //                nWalletBackups = -1;
 //                return false;
@@ -1360,7 +1358,7 @@ bool CWalletDB::Recover(CDBEnv& dbenv, const std::string& filename, bool fOnlyKe
         {
             CDataStream ssKey(row.first, SER_DISK, CLIENT_VERSION);
             CDataStream ssValue(row.second, SER_DISK, CLIENT_VERSION);
-            string strType, strErr;
+            std::string strType, strErr;
             bool fReadOK;
             {
                 // Required in LoadKeyMetadata():
@@ -1422,37 +1420,37 @@ bool CWalletDB::WriteMnemonic(const MnemonicContainer& mnContainer) {
 
 bool CWalletDB::ReadMintCount(int32_t& nCount)
 {
-    return Read(string("dzc"), nCount);
+    return Read(std::string("dzc"), nCount);
 }
 
 bool CWalletDB::WriteMintCount(const int32_t& nCount)
 {
-    return Write(string("dzc"), nCount);
+    return Write(std::string("dzc"), nCount);
 }
 
 bool CWalletDB::ReadMintSeedCount(int32_t& nCount)
 {
-    return Read(string("dzsc"), nCount);
+    return Read(std::string("dzsc"), nCount);
 }
 
 bool CWalletDB::WriteMintSeedCount(const int32_t& nCount)
 {
-    return Write(string("dzsc"), nCount);
+    return Write(std::string("dzsc"), nCount);
 }
 
 bool CWalletDB::WritePubcoin(const uint256& hashSerial, const GroupElement& pubcoin)
 {
-    return Write(make_pair(string("pubcoin"), hashSerial), pubcoin);
+    return Write(std::make_pair(std::string("pubcoin"), hashSerial), pubcoin);
 }
 
 bool CWalletDB::ReadPubcoin(const uint256& hashSerial, GroupElement& pubcoin)
 {
-    return Read(make_pair(string("pubcoin"), hashSerial), pubcoin);
+    return Read(std::make_pair(std::string("pubcoin"), hashSerial), pubcoin);
 }
 
 bool CWalletDB::ErasePubcoin(const uint256& hashSerial)
 {
-    return Erase(make_pair(string("pubcoin"), hashSerial));
+    return Erase(std::make_pair(std::string("pubcoin"), hashSerial));
 }
 
 std::vector<std::pair<uint256, GroupElement>> CWalletDB::ListSerialPubcoinPairs()
@@ -1460,14 +1458,14 @@ std::vector<std::pair<uint256, GroupElement>> CWalletDB::ListSerialPubcoinPairs(
     std::vector<std::pair<uint256, GroupElement>> listSerialPubcoin;
     Dbc* pcursor = GetCursor();
     if (!pcursor)
-        throw runtime_error(std::string(__func__)+" : cannot create DB cursor");
+        throw std::runtime_error(std::string(__func__)+" : cannot create DB cursor");
     bool setRange = true;
     for (;;)
     {
         // Read next record
         CDataStream ssKey(SER_DISK, CLIENT_VERSION);
         if (setRange)
-            ssKey << make_pair(string("pubcoin"), ArithToUint256(arith_uint256(0)));
+            ssKey << std::make_pair(std::string("pubcoin"), ArithToUint256(arith_uint256(0)));
         CDataStream ssValue(SER_DISK, CLIENT_VERSION);
         int ret = ReadAtCursor(pcursor, ssKey, ssValue, setRange);
         setRange = false;
@@ -1476,11 +1474,11 @@ std::vector<std::pair<uint256, GroupElement>> CWalletDB::ListSerialPubcoinPairs(
         else if (ret != 0)
         {
             pcursor->close();
-            throw runtime_error(std::string(__func__)+" : error scanning DB");
+            throw std::runtime_error(std::string(__func__)+" : error scanning DB");
         }
 
         // Unserialize
-        string strType;
+        std::string strType;
         ssKey >> strType;
         if (strType != "pubcoin")
             break;
@@ -1491,7 +1489,7 @@ std::vector<std::pair<uint256, GroupElement>> CWalletDB::ListSerialPubcoinPairs(
         GroupElement pubcoin;
         ssValue >> pubcoin;
 
-        listSerialPubcoin.push_back(make_pair(hashSerial, pubcoin));
+        listSerialPubcoin.push_back(std::make_pair(hashSerial, pubcoin));
     }
 
     pcursor->close();
@@ -1502,22 +1500,22 @@ std::vector<std::pair<uint256, GroupElement>> CWalletDB::ListSerialPubcoinPairs(
 
 bool CWalletDB::EraseMintPoolPair(const uint256& hashPubcoin)
 {
-    return Erase(make_pair(string("mintpool"), hashPubcoin));
+    return Erase(std::make_pair(std::string("mintpool"), hashPubcoin));
 }
 
 bool CWalletDB::WriteMintPoolPair(const uint256& hashPubcoin, const std::tuple<uint160, CKeyID, int32_t>& hashSeedMintPool)
 {
-    return Write(make_pair(string("mintpool"), hashPubcoin), hashSeedMintPool);
+    return Write(std::make_pair(std::string("mintpool"), hashPubcoin), hashSeedMintPool);
 }
 
 bool CWalletDB::ReadMintPoolPair(const uint256& hashPubcoin, uint160& hashSeedMaster, CKeyID& seedId, int32_t& nCount)
 {
     std::tuple<uint160, CKeyID, int32_t> hashSeedMintPool;
-    if(!Read(make_pair(string("mintpool"), hashPubcoin), hashSeedMintPool))
+    if(!Read(std::make_pair(std::string("mintpool"), hashPubcoin), hashSeedMintPool))
         return false;
-    hashSeedMaster = get<0>(hashSeedMintPool);
-    seedId = get<1>(hashSeedMintPool);
-    nCount = get<2>(hashSeedMintPool);
+    hashSeedMaster = std::get<0>(hashSeedMintPool);
+    seedId = std::get<1>(hashSeedMintPool);
+    nCount = std::get<2>(hashSeedMintPool);
     return true;
 }
 
@@ -1527,14 +1525,14 @@ std::vector<std::pair<uint256, MintPoolEntry>> CWalletDB::ListMintPool()
     std::vector<std::pair<uint256, MintPoolEntry>> listPool;
     Dbc* pcursor = GetCursor();
     if (!pcursor)
-        throw runtime_error(std::string(__func__)+" : cannot create DB cursor");
+        throw std::runtime_error(std::string(__func__)+" : cannot create DB cursor");
     bool setRange = true;
     for (;;)
     {
         // Read next record
         CDataStream ssKey(SER_DISK, CLIENT_VERSION);
         if (setRange)
-            ssKey << make_pair(string("mintpool"), ArithToUint256(arith_uint256(0)));
+            ssKey << std::make_pair(std::string("mintpool"), ArithToUint256(arith_uint256(0)));
         CDataStream ssValue(SER_DISK, CLIENT_VERSION);
         int ret = ReadAtCursor(pcursor, ssKey, ssValue, setRange);
         setRange = false;
@@ -1543,13 +1541,13 @@ std::vector<std::pair<uint256, MintPoolEntry>> CWalletDB::ListMintPool()
         else if (ret != 0)
         {
             pcursor->close();
-            throw runtime_error(std::string(__func__)+" : error scanning DB");
+            throw std::runtime_error(std::string(__func__)+" : error scanning DB");
         }
 
         // Unserialize
 
         try {
-            string strType;
+            std::string strType;
             ssKey >> strType;
             if (strType != "mintpool")
                 break;
@@ -1568,7 +1566,7 @@ std::vector<std::pair<uint256, MintPoolEntry>> CWalletDB::ListMintPool()
 
             MintPoolEntry mintPoolEntry(hashSeedMaster, seedId, nCount);
 
-            listPool.push_back(make_pair(hashPubcoin, mintPoolEntry));
+            listPool.push_back(std::make_pair(hashPubcoin, mintPoolEntry));
         } catch (std::ios_base::failure const &) {
             // There maybe some old entries that don't conform to the latest version. Just skipping those.
         }
@@ -1584,7 +1582,7 @@ std::list<CHDMint> CWalletDB::ListHDMints(bool isLelantus)
     std::list<CHDMint> listMints;
     Dbc* pcursor = GetCursor();
     if (!pcursor)
-        throw runtime_error(std::string(__func__)+" : cannot create DB cursor");
+        throw std::runtime_error(std::string(__func__)+" : cannot create DB cursor");
 
     std::string mintName;
 
@@ -1599,7 +1597,7 @@ std::list<CHDMint> CWalletDB::ListHDMints(bool isLelantus)
         // Read next record
         CDataStream ssKey(SER_DISK, CLIENT_VERSION);
         if (setRange)
-            ssKey << make_pair(mintName, ArithToUint256(arith_uint256(0)));
+            ssKey << std::make_pair(mintName, ArithToUint256(arith_uint256(0)));
         CDataStream ssValue(SER_DISK, CLIENT_VERSION);
         int ret = ReadAtCursor(pcursor, ssKey, ssValue, setRange);
         setRange = false;
@@ -1608,11 +1606,11 @@ std::list<CHDMint> CWalletDB::ListHDMints(bool isLelantus)
         else if (ret != 0)
         {
             pcursor->close();
-            throw runtime_error(std::string(__func__)+" : error scanning DB");
+            throw std::runtime_error(std::string(__func__)+" : error scanning DB");
         }
 
         // Unserialize
-        string strType;
+        std::string strType;
         ssKey >> strType;
         if (strType != mintName)
             break;
@@ -1632,10 +1630,10 @@ std::list<CHDMint> CWalletDB::ListHDMints(bool isLelantus)
 
 bool CWalletDB::ArchiveDeterministicOrphan(const CHDMint& dMint)
 {
-    if (!Write(make_pair(string("dzco"), dMint.GetPubCoinHash()), dMint))
+    if (!Write(std::make_pair(std::string("dzco"), dMint.GetPubCoinHash()), dMint))
         return error("%s: write failed", __func__);
 
-    if (!Erase(make_pair(string("hdmint"), dMint.GetPubCoinHash())))
+    if (!Erase(std::make_pair(std::string("hdmint"), dMint.GetPubCoinHash())))
         return error("%s: failed to erase", __func__);
 
     if (!Erase(std::make_pair(std::string("hdmint_lelantus"), dMint.GetPubCoinHash())))
@@ -1646,13 +1644,13 @@ bool CWalletDB::ArchiveDeterministicOrphan(const CHDMint& dMint)
 
 bool CWalletDB::UnarchiveHDMint(const uint256& hashPubcoin, bool isLelantus, CHDMint& dMint)
 {
-    if (!Read(make_pair(string("dzco"), hashPubcoin), dMint))
+    if (!Read(std::make_pair(std::string("dzco"), hashPubcoin), dMint))
         return error("%s: failed to retrieve deterministic mint from archive", __func__);
 
     if (!WriteHDMint(hashPubcoin, dMint, isLelantus))
         return error("%s: failed to write deterministic mint", __func__);
 
-    if (!Erase(make_pair(string("dzco"), dMint.GetPubCoinHash())))
+    if (!Erase(std::make_pair(std::string("dzco"), dMint.GetPubCoinHash())))
         return error("%s : failed to erase archived deterministic mint", __func__);
 
     return true;
@@ -1660,14 +1658,14 @@ bool CWalletDB::UnarchiveHDMint(const uint256& hashPubcoin, bool isLelantus, CHD
 
 bool CWalletDB::UnarchiveSigmaMint(const uint256& hashPubcoin, CSigmaEntry& sigma)
 {
-    if (!Read(make_pair(string("zco"), hashPubcoin), sigma))
+    if (!Read(std::make_pair(std::string("zco"), hashPubcoin), sigma))
         return error("%s: failed to retrieve sigmamint from archive", __func__);
 
     if (!WriteSigmaEntry(sigma))
         return error("%s: failed to write sigmamint", __func__);
 
     uint256 hash = primitives::GetPubCoinValueHash(sigma.value);
-    if (!Erase(make_pair(string("zco"), hash)))
+    if (!Erase(std::make_pair(std::string("zco"), hash)))
         return error("%s : failed to erase archived sigma mint", __func__);
 
     return true;
@@ -1690,12 +1688,12 @@ unsigned int CWalletDB::GetUpdateCounter()
 
 bool CWalletDB::WriteBip47Account(bip47::CAccountReceiver const & account)
 {
-    return Write(make_pair(string("bip47rcv"), uint32_t(account.getAccountNum())), account, true);
+    return Write(std::make_pair(std::string("bip47rcv"), uint32_t(account.getAccountNum())), account, true);
 }
 
 bool CWalletDB::WriteBip47Account(bip47::CAccountSender const & account)
 {
-    return Write(make_pair(string("bip47snd"), uint32_t(account.getAccountNum())), account, true);
+    return Write(std::make_pair(std::string("bip47snd"), uint32_t(account.getAccountNum())), account, true);
 }
 
 void CWalletDB::LoadBip47Accounts(bip47::CWallet & wallet)

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -65,14 +65,14 @@ enum DBErrors
 };
 
 // {value, isHardened}
-typedef pair<uint32_t,bool> Component;
+typedef std::pair<uint32_t,bool> Component;
 
 /* simple HD chain data model */
 class CHDChain
 {
 public:
     uint32_t nExternalChainCounter; // VERSION_BASIC
-    vector<uint32_t> nExternalChainCounters; // VERSION_WITH_BIP44: vector index corresponds to account value
+    std::vector<uint32_t> nExternalChainCounters; // VERSION_WITH_BIP44: vector index corresponds to account value
     CKeyID masterKeyID; //!< master key hash160
 
     static const int VERSION_BASIC = 1;
@@ -146,11 +146,11 @@ public:
         std::string nChangeStr = nComponents[nComponents.size()-2];
         std::string nChildStr  = nComponents[nComponents.size()-1];
 
-        nChange.second = (nChangeStr.find("'") != string::npos);
+        nChange.second = (nChangeStr.find("'") != std::string::npos);
         boost::erase_all(nChangeStr, "'");
         nChange.first = boost::lexical_cast<uint32_t>(nChangeStr);
 
-        nChild.second = (nChildStr.find("'") != string::npos);
+        nChild.second = (nChildStr.find("'") != std::string::npos);
         boost::erase_all(nChildStr, "'");
         nChild.first = boost::lexical_cast<uint32_t>(nChildStr);
 
@@ -373,7 +373,7 @@ public:
     template<typename K, typename V, typename InsertF>
     void ListElysiumMintsV0(InsertF insertF)
     {
-        ListEntries<K, V, InsertF>(string("exodus_mint"), insertF);
+        ListEntries<K, V, InsertF>(std::string("exodus_mint"), insertF);
     }
 
     // version 1
@@ -445,7 +445,7 @@ public:
     template<typename K, typename V, typename InsertF>
     void ListElysiumMintsV1(InsertF insertF)
     {
-        ListEntries<K, V, InsertF>(string("exodus_mint_v1"), insertF);
+        ListEntries<K, V, InsertF>(std::string("exodus_mint_v1"), insertF);
     }
 
 #endif
@@ -463,7 +463,7 @@ private:
     {
         auto cursor = GetCursor();
         if (!cursor) {
-            throw runtime_error(std::string(__func__) + " : cannot create DB cursor");
+            throw std::runtime_error(std::string(__func__) + " : cannot create DB cursor");
         }
 
         bool setRange = true;


### PR DESCRIPTION
## PR intention
Switch to C++17 standard

## Code changes brief
Deprecated function `std::random_shuffle` is removed in C++17. New function called `Shuffle` is taken from recent bitcoin version.

Removed most of  `use namespace std` lines and added explicit `std::` prefixes to C++ functions/types