### PR TITLE
Reduced number of compiler warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -280,6 +280,7 @@ if test "x$CXXFLAGS_overridden" = "xno"; then
   AX_CHECK_COMPILE_FLAG([-Wself-assign],[CXXFLAGS="$CXXFLAGS -Wno-self-assign"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wunused-local-typedef],[CXXFLAGS="$CXXFLAGS -Wno-unused-local-typedef"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wdeprecated-register],[CXXFLAGS="$CXXFLAGS -Wno-deprecated-register"],,[[$CXXFLAG_WERROR]])
+  AX_CHECK_COMPILE_FLAG([-Wdeprecated-copy],[CXXFLAGS="$CXXFLAGS -Wno-deprecated-copy"],,[[$CXXFLAG_WERROR]])
 fi
 CPPFLAGS="$CPPFLAGS -DHAVE_BUILD_INFO -D__STDC_FORMAT_MACROS"
 

--- a/src/amount.h
+++ b/src/amount.h
@@ -44,7 +44,6 @@ public:
     explicit CFeeRate(const CAmount& _nSatoshisPerK): nSatoshisPerK(_nSatoshisPerK) { }
     /** Constructor for a fee rate in satoshis per kB. The size in bytes must not exceed (2^63 - 1)*/
     CFeeRate(const CAmount& nFeePaid, size_t nBytes);
-    CFeeRate(const CFeeRate& other) { nSatoshisPerK = other.nSatoshisPerK; }
     /**
      * Return the fee in satoshis for the given size in bytes.
      */

--- a/src/bls-signatures/contrib/relic/include/relic_util.h
+++ b/src/bls-signatures/contrib/relic/include/relic_util.h
@@ -50,7 +50,9 @@
  * @param[in] B		- the second number.
  * @returns			- the smaller number.
  */
+#ifndef MIN
 #define MIN(A, B)			((A) < (B) ? (A) : (B))
+#endif
 
 /**
  * Returns the maximum between two numbers.
@@ -59,7 +61,9 @@
  * @param[in] B		- the second number.
  * @returns			- the bigger number.
  */
+#ifndef MAX
 #define MAX(A, B)			((A) > (B) ? (A) : (B))
+#endif
 
 /**
  * Splits a bit count in a digit count and an updated bit count.

--- a/src/bls-signatures/src/publickey.hpp
+++ b/src/bls-signatures/src/publickey.hpp
@@ -66,6 +66,8 @@ class PublicKey {
     // Don't allow public construction, force static methods
     PublicKey();
 
+    PublicKey& operator=(const PublicKey &) = default;
+
  private:
     // Exponentiate public key with n
     PublicKey Exp(const bn_t n) const;

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -67,7 +67,7 @@ public:
     }
 
     CBLSWrapper(const CBLSWrapper& ref) = default;
-    CBLSWrapper& operator=(const CBLSWrapper& ref) = default;
+    constexpr CBLSWrapper& operator=(const CBLSWrapper& ref) = default;
     CBLSWrapper(CBLSWrapper&& ref)
     {
         std::swap(impl, ref.impl);
@@ -213,6 +213,8 @@ public:
         GetBuf(buf);
         return HexStr(buf.begin(), buf.end());
     }
+
+    virtual ~CBLSWrapper() = default;
 };
 
 class CBLSId : public CBLSWrapper<uint256, BLS_CURVE_ID_SIZE, CBLSId>

--- a/src/elysium/sigmawallet.cpp
+++ b/src/elysium/sigmawallet.cpp
@@ -46,7 +46,7 @@ bool SigmaWallet::MintPoolEntry::operator!=(MintPoolEntry const &another) const
 }
 
 SigmaWallet::SigmaWallet(Database *database)
-    : walletFile(pwalletMain->strWalletFile), database(database)
+    : database(database), walletFile(pwalletMain->strWalletFile)
 {
 }
 

--- a/src/hdmint/wallet.cpp
+++ b/src/hdmint/wallet.cpp
@@ -27,7 +27,7 @@
  * @param strWalletFile wallet file string
  * @return CHDMintWallet object
  */
-CHDMintWallet::CHDMintWallet(const std::string& strWalletFile, bool resetCount) : tracker(strWalletFile), strWalletFile(strWalletFile)
+CHDMintWallet::CHDMintWallet(const std::string& strWalletFile, bool resetCount) : strWalletFile(strWalletFile), tracker(strWalletFile)
 {
     this->mintPool = CMintPool();
 

--- a/src/lelantus.cpp
+++ b/src/lelantus.cpp
@@ -1184,9 +1184,10 @@ void CLelantusState::Containers::CheckSurgeCondition() {
 CLelantusState::CLelantusState(
     size_t maxCoinInGroup,
     size_t startGroupSize)
-    :containers(surgeCondition),
+    :
     maxCoinInGroup(maxCoinInGroup),
-    startGroupSize(startGroupSize)
+    startGroupSize(startGroupSize),
+    containers(surgeCondition)
 {
     Reset();
 }

--- a/src/liblelantus/joinsplit.cpp
+++ b/src/liblelantus/joinsplit.cpp
@@ -19,8 +19,8 @@ JoinSplit::JoinSplit(const Params *p,
              unsigned int nVersion)
         :
         params (p),
-        fee (fee),
-        version (nVersion) {
+        version (nVersion),
+        fee (fee) {
 
     serialNumbers.reserve(Cin.size());
     for(size_t i = 0; i < Cin.size(); i++) {

--- a/src/qt/automintnotification.cpp
+++ b/src/qt/automintnotification.cpp
@@ -7,8 +7,8 @@
 
 AutomintNotification::AutomintNotification(QWidget *parent) :
     QDialog(parent),
-    lelantusModel(nullptr),
-    ui(new Ui::AutomintNotification)
+    ui(new Ui::AutomintNotification),
+    lelantusModel(nullptr)
 {
     ui->setupUi(this);
     ui->buttonBox->button(QDialogButtonBox::Ok)->setText(tr("Anonymize"));

--- a/src/qt/lelantuscoincontroldialog.cpp
+++ b/src/qt/lelantuscoincontroldialog.cpp
@@ -259,10 +259,10 @@ LelantusCoinControlDialog::LelantusCoinControlDialog(
     const PlatformStyle *_platformStyle,
     QWidget *parent) :
     QDialog(parent),
+    storage(_storage),
     ui(new Ui::CoinControlDialog),
     model(0),
-    platformStyle(_platformStyle),
-    storage(_storage)
+    platformStyle(_platformStyle)
 {
     ui->setupUi(this);
 

--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -21,12 +21,12 @@
 
 MasternodeList::MasternodeList(const PlatformStyle* platformStyle, QWidget* parent) :
     QWidget(parent),
+    nTimeFilterUpdatedDIP3(0),
+    nTimeUpdatedDIP3(0),
+    fFilterUpdatedDIP3(true),
     ui(new Ui::MasternodeList),
     clientModel(0),
     walletModel(0),
-    fFilterUpdatedDIP3(true),
-    nTimeFilterUpdatedDIP3(0),
-    nTimeUpdatedDIP3(0),
     mnListChanged(true)
 {
     ui->setupUi(this);


### PR DESCRIPTION
## PR intention
Reduction of compiler warning numbers

## Code changes brief
Deprecated copy warning was the most frequent one. One of reasons lied in BLS (manually fixed in code). Another reason resided in Qt headers, added `-Wno-deprecated-copy` flag to fix it (fix taken from bitcoin)
