### PR TITLE
Make Firo run natively on M1 macs

### DIFF
--- a/depends/packages/gmp.mk
+++ b/depends/packages/gmp.mk
@@ -1,12 +1,13 @@
 package=gmp
-$(package)_version=6.1.2
+$(package)_version=6.2.1
 $(package)_download_path=https://gmplib.org/download/gmp
 $(package)_file_name=gmp-$($(package)_version).tar.bz2
-$(package)_sha256_hash=5275bb04f4863a13516b2f39392ac5e272f5e1bb8057b18aec1c9b79d73d8fb2
+$(package)_sha256_hash=eae9326beb4158c386e39a356818031bd28f3124cf915f8c5b1dc4c7a36b4d7c
 
 define $(package)_set_vars
 $(package)_config_opts+=--enable-cxx --enable-fat --with-pic --disable-shared
 $(package)_cflags_armv7l_linux+=-march=armv7-a
+$(package)_config_opts_arm_darwin+=--build=$(subst arm,aarch64,$(BUILD)) --host=$(subst arm,aarch64,$(HOST))
 endef
 
 define $(package)_config_cmds

--- a/depends/packages/openssl.mk
+++ b/depends/packages/openssl.mk
@@ -62,7 +62,7 @@ define $(package)_build_cmds
 endef
 
 define $(package)_stage_cmds
-  $(MAKE) DESTDIR=$($(package)_staging_dir) -j1 install_sw
+  $(MAKE) DESTDIR=$($(package)_staging_dir) -j1 install_dev
 endef
 
 define $(package)_postprocess_cmds

--- a/depends/packages/openssl.mk
+++ b/depends/packages/openssl.mk
@@ -1,8 +1,8 @@
 package=openssl
-$(package)_version=1.0.1k
+$(package)_version=1.1.1m
 $(package)_download_path=https://www.openssl.org/source
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=8f9faeaebad088e772f4ef5e38252d472be4d878c6b3a2718c10a4fcebe7a41c
+$(package)_sha256_hash=f89199be8b23ca45fc7cb9f1d8d3ee67312318286ad030f5316aca6462db6c96
 
 define $(package)_set_vars
 $(package)_config_env=AR="$($(package)_ar)" RANLIB="$($(package)_ranlib)" CC="$($(package)_cc)"
@@ -15,28 +15,20 @@ $(package)_config_opts+=no-dso
 $(package)_config_opts+=no-dtls1
 $(package)_config_opts+=no-ec_nistp_64_gcc_128
 $(package)_config_opts+=no-gost
-$(package)_config_opts+=no-gmp
 $(package)_config_opts+=no-heartbeats
 $(package)_config_opts+=no-idea
-$(package)_config_opts+=no-jpake
-$(package)_config_opts+=no-krb5
-$(package)_config_opts+=no-libunbound
 $(package)_config_opts+=no-md2
 $(package)_config_opts+=no-mdc2
 $(package)_config_opts+=no-rc4
 $(package)_config_opts+=no-rc5
 $(package)_config_opts+=no-rdrand
 $(package)_config_opts+=no-rfc3779
-$(package)_config_opts+=no-rsax
 $(package)_config_opts+=no-sctp
 $(package)_config_opts+=no-seed
-$(package)_config_opts+=no-sha0
 $(package)_config_opts+=no-shared
 $(package)_config_opts+=no-ssl-trace
 $(package)_config_opts+=no-ssl2
 $(package)_config_opts+=no-ssl3
-$(package)_config_opts+=no-static_engine
-$(package)_config_opts+=no-store
 $(package)_config_opts+=no-unit-test
 $(package)_config_opts+=no-weak-ssl-ciphers
 $(package)_config_opts+=no-whirlpool
@@ -54,11 +46,11 @@ $(package)_config_opts_powerpc_linux=linux-generic32
 $(package)_config_opts_x86_64_darwin=darwin64-x86_64-cc
 $(package)_config_opts_x86_64_mingw32=mingw64
 $(package)_config_opts_i686_mingw32=mingw
+$(package)_config_opts_arm_darwin=darwin64-arm64-cc
 endef
 
 define $(package)_preprocess_cmds
-  sed -i.old "/define DATE/d" util/mkbuildinf.pl && \
-  sed -i.old "s|engines apps test|engines|" Makefile.org
+  sed -i.old "s/built on: \$date//" util/mkbuildinf.pl
 endef
 
 define $(package)_config_cmds
@@ -70,7 +62,7 @@ define $(package)_build_cmds
 endef
 
 define $(package)_stage_cmds
-  $(MAKE) INSTALL_PREFIX=$($(package)_staging_dir) -j1 install_sw
+  $(MAKE) DESTDIR=$($(package)_staging_dir) -j1 install_sw
 endef
 
 define $(package)_postprocess_cmds

--- a/depends/packages/openssl.mk
+++ b/depends/packages/openssl.mk
@@ -62,7 +62,7 @@ define $(package)_build_cmds
 endef
 
 define $(package)_stage_cmds
-  $(MAKE) DESTDIR=$($(package)_staging_dir) -j1 install_dev
+  $(MAKE) DESTDIR=$($(package)_staging_dir) -j1 install_dev install_engines
 endef
 
 define $(package)_postprocess_cmds

--- a/src/bls-signatures/Makefile
+++ b/src/bls-signatures/Makefile
@@ -1,7 +1,7 @@
 
-all: build/libchiabls.la
+all: build/libchiabls.la build/.libs/libchiabls.a
 
-build/libchiabls.la:
+build/libchiabls.la build/.libs/libchiabls.a:
 	$(AM_V_at)$(MAKE) -C ./build/
 
 .PHONY distdir: 

--- a/src/bls-signatures/Makefile
+++ b/src/bls-signatures/Makefile
@@ -1,7 +1,7 @@
 
-all: build/libchiabls.la build/.libs/libchiabls.a
+all: build/libchiabls.la
 
-build/libchiabls.la build/.libs/libchiabls.a:
+build/libchiabls.la:
 	$(AM_V_at)$(MAKE) -C ./build/
 
 .PHONY distdir: 

--- a/src/bls-signatures/contrib/relic/bench/bench_bn.c
+++ b/src/bls-signatures/contrib/relic/bench/bench_bn.c
@@ -51,7 +51,7 @@ static void memory(void) {
 		bn_new(a[i]);
 		bn_clean(a[i]);
 	}
-	BENCH_FEW("bn_init", bn_init(a[i], RLC_BN_DIGS), 1);
+	BENCH_FEW("bn_make", bn_make(a[i], RLC_BN_DIGS), 1);
 	for (int i = 0; i < BENCH; i++) {
 		bn_free(a[i]);
 	}

--- a/src/bls-signatures/contrib/relic/include/relic_bn.h
+++ b/src/bls-signatures/contrib/relic/include/relic_bn.h
@@ -148,11 +148,11 @@ typedef bn_st *bn_t;
 	if ((A) == NULL) {														\
 		RLC_THROW(ERR_NO_MEMORY);											\
 	}																		\
-	bn_init(A, RLC_BN_SIZE);												\
+	bn_make(A, RLC_BN_SIZE);												\
 
 #elif ALLOC == AUTO
 #define bn_new(A)															\
-	bn_init(A, RLC_BN_SIZE);												\
+	bn_make(A, RLC_BN_SIZE);												\
 
 #endif
 
@@ -172,11 +172,11 @@ typedef bn_st *bn_t;
 	if (A == NULL) {														\
 		RLC_THROW(ERR_NO_MEMORY);											\
 	}																		\
-	bn_init(A, D);															\
+	bn_make(A, D);															\
 
 #elif ALLOC == AUTO
 #define bn_new_size(A, D)													\
-	bn_init(A, D);															\
+	bn_make(A, D);															\
 
 #endif
 
@@ -374,7 +374,7 @@ typedef bn_st *bn_t;
  * @throw ERR_PRECISION		- if the required precision cannot be represented
  * 							by the library.
  */
-void bn_init(bn_t a, int digits);
+void bn_make(bn_t a, int digits);
 
 /**
  * Cleans a multiple precision integer.

--- a/src/bls-signatures/contrib/relic/include/relic_label.h
+++ b/src/bls-signatures/contrib/relic/include/relic_label.h
@@ -174,7 +174,7 @@
 #define bn_st     	RLC_PREFIX(bn_st)
 #define bn_t      	RLC_PREFIX(bn_t)
 
-#undef bn_init
+#undef bn_make
 #undef bn_clean
 #undef bn_grow
 #undef bn_trim
@@ -277,7 +277,7 @@
 #undef bn_rec_jsf
 #undef bn_rec_glv
 
-#define bn_init 	RLC_PREFIX(bn_init)
+#define bn_make 	RLC_PREFIX(bn_make)
 #define bn_clean 	RLC_PREFIX(bn_clean)
 #define bn_grow 	RLC_PREFIX(bn_grow)
 #define bn_trim 	RLC_PREFIX(bn_trim)

--- a/src/bls-signatures/contrib/relic/src/bn/relic_bn_mem.c
+++ b/src/bls-signatures/contrib/relic/src/bn/relic_bn_mem.c
@@ -41,7 +41,7 @@
 /* Public definitions                                                         */
 /*============================================================================*/
 
-void bn_init(bn_t a, int digits) {
+void bn_make(bn_t a, int digits) {
 	if (digits < 0) {
 		RLC_THROW(ERR_NO_VALID);
 	}

--- a/src/bls-signatures/contrib/relic/src/eb/relic_eb_curve.c
+++ b/src/bls-signatures/contrib/relic/src/eb/relic_eb_curve.c
@@ -73,8 +73,8 @@ void eb_curve_init(void) {
 	fb_zero(ctx->eb_g.x);
 	fb_zero(ctx->eb_g.y);
 	fb_zero(ctx->eb_g.z);
-	bn_init(&(ctx->eb_r), RLC_FB_DIGS);
-	bn_init(&(ctx->eb_h), RLC_FB_DIGS);
+	bn_make(&(ctx->eb_r), RLC_FB_DIGS);
+	bn_make(&(ctx->eb_h), RLC_FB_DIGS);
 }
 
 void eb_curve_clean(void) {

--- a/src/bls-signatures/contrib/relic/src/ed/relic_ed_curve.c
+++ b/src/bls-signatures/contrib/relic/src/ed/relic_ed_curve.c
@@ -40,8 +40,8 @@ void ed_curve_init(void) {
 	}
 #endif
 	ed_set_infty(&ctx->ed_g);
-	bn_init(&ctx->ed_r, RLC_FP_DIGS);
-	bn_init(&ctx->ed_h, RLC_FP_DIGS);
+	bn_make(&ctx->ed_r, RLC_FP_DIGS);
+	bn_make(&ctx->ed_h, RLC_FP_DIGS);
 }
 
 void ed_curve_clean(void) {

--- a/src/bls-signatures/contrib/relic/src/ep/relic_ep_curve.c
+++ b/src/bls-signatures/contrib/relic/src/ep/relic_ep_curve.c
@@ -209,12 +209,12 @@ void ep_curve_init(void) {
 	}
 #endif
 	ep_set_infty(&ctx->ep_g);
-	bn_init(&ctx->ep_r, RLC_FP_DIGS);
-	bn_init(&ctx->ep_h, RLC_FP_DIGS);
+	bn_make(&ctx->ep_r, RLC_FP_DIGS);
+	bn_make(&ctx->ep_h, RLC_FP_DIGS);
 #if defined(EP_ENDOM) && (EP_MUL == LWNAF || EP_FIX == COMBS || EP_FIX == LWNAF || !defined(STRIP))
 	for (int i = 0; i < 3; i++) {
-		bn_init(&(ctx->ep_v1[i]), RLC_FP_DIGS);
-		bn_init(&(ctx->ep_v2[i]), RLC_FP_DIGS);
+		bn_make(&(ctx->ep_v1[i]), RLC_FP_DIGS);
+		bn_make(&(ctx->ep_v2[i]), RLC_FP_DIGS);
 	}
 #endif
 }

--- a/src/bls-signatures/contrib/relic/src/epx/relic_ep2_curve.c
+++ b/src/bls-signatures/contrib/relic/src/epx/relic_ep2_curve.c
@@ -535,8 +535,8 @@ void ep2_curve_init(void) {
 #endif
 #endif
 	ep2_set_infty(ctx->ep2_g);
-	bn_init(&(ctx->ep2_r), RLC_FP_DIGS);
-	bn_init(&(ctx->ep2_h), RLC_FP_DIGS);
+	bn_make(&(ctx->ep2_r), RLC_FP_DIGS);
+	bn_make(&(ctx->ep2_h), RLC_FP_DIGS);
 
 #ifdef EP_CTMAP
 	iso2_t iso = ep2_curve_get_iso();

--- a/src/bls-signatures/contrib/relic/src/fp/relic_fp_prime.c
+++ b/src/bls-signatures/contrib/relic/src/fp/relic_fp_prime.c
@@ -146,15 +146,15 @@ static void fp_prime_set(const bn_t p) {
 void fp_prime_init(void) {
 	ctx_t *ctx = core_get();
 	ctx->fp_id = 0;
-	bn_init(&(ctx->prime), RLC_FP_DIGS);
-	bn_init(&(ctx->par), RLC_FP_DIGS);
+	bn_make(&(ctx->prime), RLC_FP_DIGS);
+	bn_make(&(ctx->par), RLC_FP_DIGS);
 #if FP_RDC == QUICK || !defined(STRIP)
 	ctx->sps_len = 0;
 	memset(ctx->sps, 0, sizeof(ctx->sps));
 #endif
 #if FP_RDC == MONTY || !defined(STRIP)
-	bn_init(&(ctx->conv), RLC_FP_DIGS);
-	bn_init(&(ctx->one), RLC_FP_DIGS);
+	bn_make(&(ctx->conv), RLC_FP_DIGS);
+	bn_make(&(ctx->one), RLC_FP_DIGS);
 #endif
 }
 

--- a/src/bls-signatures/contrib/relic/src/low/easy/relic_fp_inv_low.c
+++ b/src/bls-signatures/contrib/relic/src/low/easy/relic_fp_inv_low.c
@@ -43,7 +43,7 @@
 void fp_invm_low(dig_t *c, const dig_t *a) {
 	bn_st e;
 
-	bn_init(&e, RLC_FP_DIGS);
+	bn_make(&e, RLC_FP_DIGS);
 
 	e.used = RLC_FP_DIGS;
 	dv_copy(e.dp, fp_prime_get(), RLC_FP_DIGS);

--- a/src/bls-signatures/src/privatekey.cpp
+++ b/src/bls-signatures/src/privatekey.cpp
@@ -258,7 +258,7 @@ void PrivateKey::AllocateKeyData()
 {
     assert(!keydata);
     keydata = Util::SecAlloc<bn_st>(1);
-    bn_init(keydata, RLC_BN_SIZE);
+    keydata->alloc = RLC_BN_SIZE;
     bn_zero(keydata);
 }
 

--- a/src/tor/configure.ac
+++ b/src/tor/configure.ac
@@ -966,7 +966,7 @@ AC_ARG_WITH(ssl-dir,
   ])
 
 AC_MSG_NOTICE([Now, we'll look for OpenSSL >= 1.0.1])
-TOR_SEARCH_LIBRARY(openssl, $tryssldir, [-lssl -lcrypto $TOR_LIB_GDI $TOR_LIB_WS32],
+TOR_SEARCH_LIBRARY(openssl, $tryssldir, [-lssl -lcrypto $TOR_LIB_WS32 $TOR_LIB_CRYPT32 $TOR_LIB_BCRYPT -pthread],
     [#include <openssl/ssl.h>
      char *getenv(const char *);],
     [struct ssl_cipher_st;
@@ -987,10 +987,10 @@ if test "$enable_static_openssl" = "yes"; then
    if test "$tor_cv_library_openssl_dir" = "(system)"; then
      AC_MSG_ERROR("You must specify an explicit --with-openssl-dir=x option when using --enable-static-openssl")
    else
-     TOR_OPENSSL_LIBS="$TOR_LIBDIR_openssl/libssl.a $TOR_LIBDIR_openssl/libcrypto.a"
+     TOR_OPENSSL_LIBS="$TOR_LIBDIR_openssl/libssl.a $TOR_LIBDIR_openssl/libcrypto.a $TOR_LIB_WS32 $TOR_LIB_CRYPT32 $TOR_LIB_BCRYPT -pthread"
    fi
 else
-     TOR_OPENSSL_LIBS="-lssl -lcrypto"
+     TOR_OPENSSL_LIBS="-lssl -lcrypto $TOR_LIB_WS32 $TOR_LIB_CRYPT32 $TOR_LIB_BCRYPT -pthread"
 fi
 AC_SUBST(TOR_OPENSSL_LIBS)
 


### PR DESCRIPTION
## PR intention
Run Firo natively on Apple Silicon Macs

## Code changes brief
Different tweaks for depends. Renamed `bn_init` to `bn_make` in relics library to avoid conflict with OpenSSL
