### PR TITLE
Ban nodes with version lower than 0.14.9.0

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -52,7 +52,7 @@ static const int SHORT_IDS_BLOCKS_VERSION = 90013;
 static const int INVALID_CB_NO_BAN_VERSION = 90013;
 
 //! minimum version of official client to connect to
-static const int MIN_FIRO_CLIENT_VERSION = 130808; // 0.13.8.8
+static const int MIN_FIRO_CLIENT_VERSION = 140900; // 0.14.9.0
 
 //! introduction of DIP3/deterministic masternodes
 static const int DMN_PROTO_VERSION = 90030;


### PR DESCRIPTION
## PR intention
Ban versions of Firo client below 0.14.9.0. 

Occasionally nodes on mainnet will connect to an older stuck version. If this older version is the first in the peer list, it takes a significant amount of time for it to disconnect and normal sync to continue.

On testnet, peers as low as version 0.14.1, 0.14.6 and 0.14.8 has been observed. As the number of testnet nodes are lower than mainnet, this problem is amplified.

## Code changes brief
As per #742. Increase minimum version to 140900 as this is the minimum version required to run on the network currently.
