### PR TITLE
To support multiple inputs in Lelantus spend tx in Elysium

### DIFF
--- a/src/elysium/test/build_tx_tests.cpp
+++ b/src/elysium/test/build_tx_tests.cpp
@@ -36,30 +36,6 @@ namespace elysium {
 
 BOOST_FIXTURE_TEST_SUITE(elysium_build_tx_tests, ZerocoinTestingSetup200)
 
-BOOST_AUTO_TEST_CASE(wallettxbuilder_create_normal_b)
-{
-    std::vector<unsigned char> data(nMaxDatacarrierBytes + 1);
-
-    std::string fromAddress = CBitcoinAddress(pubkey.GetID()).ToString();
-
-    uint256 txid;
-    std::string rawHex;
-    BOOST_CHECK_EQUAL(
-        0, // No error
-        elysium::WalletTxBuilder(fromAddress, "", "", 0, data, txid, rawHex, false)
-    );
-
-    CMutableTransaction decTx;
-    BOOST_CHECK(DecodeHexTx(decTx, rawHex));
-
-    BOOST_CHECK(!CTransaction(decTx).IsSigmaSpend());
-
-    BOOST_CHECK_EQUAL(
-        PacketClass::B,
-        DeterminePacketClass(decTx, chainActive.Height())
-    );
-}
-
 BOOST_AUTO_TEST_CASE(wallettxbuilder_create_normal_c)
 {
     std::vector<unsigned char> data(80);

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -27,7 +27,7 @@ public:
     CScriptID(const uint160& in) : uint160(in) {}
 };
 
-static const unsigned int MAX_OP_RETURN_RELAY = 4096;
+static const unsigned int MAX_OP_RETURN_RELAY = 16384;
 extern bool fAcceptDatacarrier;
 extern unsigned nMaxDatacarrierBytes;
 


### PR DESCRIPTION
Increase to support multiple inputs in Lelantus spend tx in Elysium layer, due to with 4k, it will support only one spend input, which impractical to support multiple spend input in a spend tx.