### PR TITLE
Fix for window width increasing on Mac

### DIFF
--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -437,7 +437,7 @@ void TransactionView::updateHeaderSizes(int logicalIndex, int oldSize, int newSi
         {TransactionTableModel::Amount, amountWidget}
     };
 
-    if(logicalIndex < TransactionTableModel::ToAddress)
+    if(logicalIndex <= TransactionTableModel::ToAddress)
         return;
 
     for(std::pair<int, QWidget*> const & p : headerWidgets) {


### PR DESCRIPTION
## PR intention
This PR fixes an issue where the firo-qt app window was expanding infinitely on a Mac. 
