### PR TITLE
Some labels were grayed out in macOS dark mode

### DIFF
--- a/src/qt/res/css/firo.css
+++ b/src/qt/res/css/firo.css
@@ -282,6 +282,7 @@ QCalendarWidget QAbstractItemView:disabled {
 /* QCheckBox */
 
 QCheckBox {
+    color: #110202;
     background-color: #f4f4f4;
     min-height: 25px;
     margin-right: 10px;


### PR DESCRIPTION
## PR intention
Some labels were grayed out in macOS dark mode. Now they are standard black.