### PR TITLE
Fix sendmany JSON error

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -82,7 +82,6 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "sendmany", 1, "amounts" },
     { "sendmany", 2, "minconf" },
     { "sendmany", 4, "subtractfeefrom" },
-    { "sendmany", 3, "addlockconf" },
     { "addmultisigaddress", 0, "nrequired" },
     { "addmultisigaddress", 1, "keys" },
     { "createmultisig", 0, "nrequired" },


### PR DESCRIPTION
## PR intention
Fix JSON parsing error when invoking `sendmany` RPC call

## Code changes brief
Removed unneeded requirement for fourth argument of this call to be JSON object
