### PR TITLE
Allow upgrade to 0.14.9.3 without reindex

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -538,7 +538,7 @@ public:
         if (!(s.GetType() & SER_GETHASH) && nHeight >= params.nEvoSporkStartBlock) {
             if (nHeight < params.nEvoSporkStopBlock &&
                 // Workaround for late rollout of version 0.14.9.3 in which nEvoSporkStopBlock was extended
-                // If a record on disk for block is less than 140903 and nHeight is greater than previous value
+                // If version of a record for block is less than 140903 and nHeight is greater than previous value
                 // of nEvoSporkStopBlock we don't read activeDisablingSpork from index database
                 !(params.nEvoSporkStopBlockExtensionVersion != 0 &&
                     nVersion < params.nEvoSporkStopBlockExtensionVersion &&

--- a/src/chain.h
+++ b/src/chain.h
@@ -535,9 +535,18 @@ public:
                 READWRITE(anonymitySetHash);
         }
 
-        if (!(s.GetType() & SER_GETHASH) && nHeight >= params.nEvoSporkStartBlock && nHeight < params.nEvoSporkStopBlock)
-            READWRITE(activeDisablingSporks);
+        if (!(s.GetType() & SER_GETHASH) && nHeight >= params.nEvoSporkStartBlock) {
+            if (nHeight < params.nEvoSporkStopBlock &&
+                // Workaround for late rollout of version 0.14.9.3 in which nEvoSporkStopBlock was extended
+                // If a record on disk for block is less than 140903 and nHeight is greater than previous value
+                // of nEvoSporkStopBlock we don't read activeDisablingSpork from index database
+                !(params.nEvoSporkStopBlockExtensionVersion != 0 &&
+                    nVersion < params.nEvoSporkStopBlockExtensionVersion &&
+                    nHeight >= params.nEvoSporkStopBlockPrevious &&
+                    nHeight < params.nEvoSporkStopBlockPrevious + params.nEvoSporkStopBlockExtensionGracefulPeriod))
 
+                READWRITE(activeDisablingSporks);
+        }
         nDiskBlockVersion = nVersion;
     }
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -413,7 +413,7 @@ public:
         consensus.nEvoSporkStopBlock = ZC_LELANTUS_STARTING_BLOCK + 2*24*12*365;  // two years after lelantus
         consensus.nEvoSporkStopBlockExtensionVersion = 140903;
         consensus.nEvoSporkStopBlockPrevious = ZC_LELANTUS_STARTING_BLOCK + 1*24*12*365; // one year after lelantus
-        consensus.nEvoSporkStopBlockExtensionGracefulPeriod = 24*12*7; // one week
+        consensus.nEvoSporkStopBlockExtensionGracefulPeriod = 24*12*14; // two weeks
 
         // reorg
         consensus.nMaxReorgDepth = 5;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -411,6 +411,9 @@ public:
         consensus.evoSporkKeyID = "a78fERshquPsTv2TuKMSsxTeKom56uBwLP";
         consensus.nEvoSporkStartBlock = ZC_LELANTUS_STARTING_BLOCK;
         consensus.nEvoSporkStopBlock = ZC_LELANTUS_STARTING_BLOCK + 2*24*12*365;  // two years after lelantus
+        consensus.nEvoSporkStopBlockExtensionVersion = 140903;
+        consensus.nEvoSporkStopBlockPrevious = ZC_LELANTUS_STARTING_BLOCK + 1*24*12*365; // one year after lelantus
+        consensus.nEvoSporkStopBlockExtensionGracefulPeriod = 24*12*7; // one week
 
         // reorg
         consensus.nMaxReorgDepth = 5;
@@ -681,6 +684,7 @@ public:
         consensus.evoSporkKeyID = "TWSEa1UsZzDHywDG6CZFDNdeJU6LzhbbBL";
         consensus.nEvoSporkStartBlock = 22000;
         consensus.nEvoSporkStopBlock = 40000;
+        consensus.nEvoSporkStopBlockExtensionVersion = 0;
 
         // reorg
         consensus.nMaxReorgDepth = 4;
@@ -898,6 +902,7 @@ public:
         consensus.evoSporkKeyID = "TdxR3tfoHiQUkowcfjEGiMBfk6GXFdajUA";
         consensus.nEvoSporkStartBlock = 1;
         consensus.nEvoSporkStopBlock = 40000;
+        consensus.nEvoSporkStopBlockExtensionVersion = 0;
 
         // reorg
         consensus.nMaxReorgDepth = 4;
@@ -1116,6 +1121,7 @@ public:
         consensus.evoSporkKeyID = "TSpmHGzQT4KJrubWa4N2CRmpA7wKMMWDg4";  // private key is cW2YM2xaeCaebfpKguBahUAgEzLXgSserWRuD29kSyKHq1TTgwRQ
         consensus.nEvoSporkStartBlock = 1000;
         consensus.nEvoSporkStopBlock = 1500;
+        consensus.nEvoSporkStopBlockExtensionVersion = 0;
 
         // reorg
         consensus.nMaxReorgDepth = 4;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -245,6 +245,16 @@ struct Params {
     // The block number to stop using evo sporks
     int nEvoSporkStopBlock;
 
+    // Workaround for a late rollout of version 0.14.9.3
+    // If non-zero allow special behavior for reading index when block index version < nEvoSporkStopBlockExtensionVersion
+    int nEvoSporkStopBlockExtensionVersion;
+
+    // Previous value of stop block
+    int nEvoSporkStopBlockPrevious;
+
+    // Graceful period (number of blocks) to allow this workaround
+    int nEvoSporkStopBlockExtensionGracefulPeriod;
+
     // Key to sign spork txs
     std::string evoSporkKeyID;
 


### PR DESCRIPTION
## PR intention
Version 0.14.9.3 extended spork functionality by one year but if the upgrade to 0.14.9.3 happened after previously set spork expiration date passed reindex is needed. This PR allows two weeks for upgrade without reindex.

## Code changes brief
New `Consensus::Params` variables introduced to facilitate workaround. If a record for a block in index database was made by old client old set of rules are applied to index record serialization.
