### PR TITLE
Fixing lock icon view in coincontrol

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -274,7 +274,7 @@ void CoinControlDialog::lockCoin()
     COutPoint outpt(uint256S(contextMenuItem->text(COLUMN_TXHASH).toStdString()), contextMenuItem->text(COLUMN_VOUT_INDEX).toUInt());
     model->lockCoin(outpt);
     contextMenuItem->setDisabled(true);
-    contextMenuItem->setIcon(COLUMN_CHECKBOX, platformStyle->SingleColorIcon(":/icons/lock_closed"));
+    contextMenuItem->setIcon(COLUMN_CHECKBOX, platformStyle->LockIcon(":/icons/lock_closed"));
     updateLabelLocked();
 }
 
@@ -778,7 +778,7 @@ void CoinControlDialog::updateView()
                 COutPoint outpt(txhash, out.i);
                 coinControl->UnSelect(outpt); // just to be sure
                 itemOutput->setDisabled(true);
-                itemOutput->setIcon(COLUMN_CHECKBOX, platformStyle->SingleColorIcon(":/icons/lock_closed"));
+                itemOutput->setIcon(COLUMN_CHECKBOX, platformStyle->LockIcon(":/icons/lock_closed"));
             }
 
             // set checkbox

--- a/src/qt/platformstyle.cpp
+++ b/src/qt/platformstyle.cpp
@@ -46,6 +46,19 @@ void MakeSingleColorImage(QImage& img, const QColor& colorbase)
     }
 }
 
+void MakeLockColorImage(QImage& img, const QColor& colorbase)
+{
+    img = img.convertToFormat(QImage::Format_ARGB32);
+    for (int x = img.width(); x--; )
+    {
+        for (int y = img.height(); y--; )
+        {
+            const QRgb rgb = img.pixel(x, y);
+            img.setPixel(x, y, qRgba(colorbase.red(), colorbase.green(), colorbase.blue(), qAlpha(rgb)));
+        }
+    }
+}
+
 QIcon ColorizeIcon(const QIcon& ico, const QColor& colorbase)
 {
     QIcon new_ico;
@@ -59,6 +72,7 @@ QIcon ColorizeIcon(const QIcon& ico, const QColor& colorbase)
     return new_ico;
 }
 
+
 QImage ColorizeImage(const QString& filename, const QColor& colorbase)
 {
     QImage img(filename);
@@ -66,9 +80,21 @@ QImage ColorizeImage(const QString& filename, const QColor& colorbase)
     return img;
 }
 
+QImage ColorizeLockImage(const QString& filename, const QColor& colorbase)
+{
+    QImage img(filename);
+    MakeLockColorImage(img, colorbase);
+    return img;
+}
+
 QIcon ColorizeIcon(const QString& filename, const QColor& colorbase)
 {
     return QIcon(QPixmap::fromImage(ColorizeImage(filename, colorbase)));
+}
+
+QIcon ColorizeLockIcon(const QString& filename, const QColor& colorbase)
+{
+    return QIcon(QPixmap::fromImage(ColorizeLockImage(filename, colorbase)));
 }
 
 }
@@ -118,6 +144,13 @@ QIcon PlatformStyle::SingleColorIcon(const QIcon& icon) const
     if (!colorizeIcons)
         return icon;
     return ColorizeIcon(icon, SingleColor());
+}
+
+QIcon PlatformStyle::LockIcon(const QString& filename) const
+{
+    if (!colorizeIcons)
+        return QIcon(filename);
+    return ColorizeLockIcon(filename, SingleColor());
 }
 
 QIcon PlatformStyle::TextColorIcon(const QString& filename) const

--- a/src/qt/platformstyle.h
+++ b/src/qt/platformstyle.h
@@ -39,6 +39,9 @@ public:
     /** Colorize an icon (given object) with the text color */
     QIcon TextColorIcon(const QIcon& icon) const;
 
+    /** Coincontrol lock icon */
+    QIcon LockIcon(const QString& filename) const;
+
 private:
     PlatformStyle(const QString &name, bool imagesOnButtons, bool colorizeIcons, bool useExtraSpacing);
 


### PR DESCRIPTION
**What fixes the PR**
Padlock icon is invisible when the tx is locked and selected.
![image](https://user-images.githubusercontent.com/45027856/149530910-27b5a2fe-92dc-4b79-ab4b-9e200a784dc9.png)
