### PR TITLE
Update version in README_windows.txt

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1,4 +1,4 @@
-Firo Core 0.14.8.x
+Firo Core 0.14.9.x
 =====================
 
 Setup

--- a/doc/README_windows.txt
+++ b/doc/README_windows.txt
@@ -1,4 +1,4 @@
-Firo Core 0.14.8.x
+Firo Core 0.14.9.x
 =====================
 
 Intro
@@ -11,7 +11,7 @@ with each other, with the help of a P2P network to check for double-spending.
 
 Setup
 -----
-Unpack the files into a directory and run bitcoin-qt.exe.
+Unpack the files into a directory and run firo-qt.exe.
 
 Firo Core is the original Firo client and it builds the backbone of the network.
 However, it downloads and stores the entire history of Firo transactions;


### PR DESCRIPTION
Windows binaries built with guix fetches `doc/README_windows.txt` and bundles it into the zipped file. The file contains an outdated version number which this PR updates. The Linux zipped binary pulls the `README.md` from main instead.

There are other bitcoin-related information present that can be dealt with at a later date.

Reporting credit to @ajaydono 