### PR TITLE
Explain new simpler process for building (depends) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,51 +79,70 @@ docker start firod
 Linux Build Instructions and Notes
 ==================================
 
-Dependencies
+Firo contains build scripts for its dependencies to ensure all component versions are compatible. For additional options
+such as cross compilation, read the [depends instructions](depends/README.md)
+
+Alternatively, you can build dependencies manually. See the full [unix build instructions](doc/build-unix.md).
+
+Development Dependencies (compiler and build tools)
 ----------------------
-1.  Update packages
 
-        sudo apt-get update
+- Debian/Ubuntu/Mint:
 
-2.  Install required packages
+    ```
+    sudo apt-get update
+    sudo apt-get install git curl python build-essential libtool automake pkg-config cmake
+    # Also needed for GUI wallet only:
+    sudo apt-get install qttools5-dev qttools5-dev-tools libxcb-xkb-dev bison
+    ```
 
-        sudo apt-get install build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils libboost-all-dev libgmp-dev cmake
+- Redhat/Fedora:
 
-3.  Install Berkeley DB 4.8
+    ```
+    sudo dnf update
+    sudo dnf install bzip2 perl-lib perl-FindBin gcc-c++ libtool make autoconf automake cmake patch which
+    # Also needed for GUI wallet only:
+    sudo dnf install qt5-qttools-devel qt5-qtbase-devel xz bison
+    sudo ln /usr/bin/bison /usr/bin/yacc
+    ```
+- Arch:
 
-        sudo apt-get install software-properties-common
-        sudo add-apt-repository ppa:bitcoin/bitcoin
-        sudo apt-get update
-        sudo apt-get install libdb4.8-dev libdb4.8++-dev
+    ```
+    sudo pacman -Sy
+    sudo pacman -S git base-devel python cmake
+    ```
 
-4.  Install QT 5
-
-        sudo apt-get install libminiupnpc-dev libzmq3-dev
-        sudo apt-get install libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools libprotobuf-dev protobuf-compiler libqrencode-dev
-
-Alternatively, you can use a [depends build](depends/README.md) to handle dependencies.
-
-Build
+Build Firo
 ----------------------
-1.  Clone the source:
+
+1.  Download the source:
 
         git clone https://github.com/firoorg/firo
+        cd firo
 
-2.  Build Firo-core:
+2.  Build dependencies and firo:
 
-    Configure and build the headless Firo binaries as well as the GUI (if Qt is found).
+    Headless (command-line only for servers etc.):
 
-    You can disable the GUI build by passing `--without-gui` to configure.
-        
+        cd depends
+        NO_QT=true make -j`nproc`
+        cd ..
         ./autogen.sh
-        ./configure
-        make
+        ./configure --prefix=`pwd`/depends/`depends/config.guess` --without-gui
+        make -j`nproc`
 
-    Note that the use of a [depends build](depends/README.md) necessitates passing the `--prefix` option to `./configure`.
+    Or with GUI wallet as well:
 
-3.  It is recommended to build and run the unit tests:
+        cd depends
+        make -j`nproc`
+        cd ..
+        ./autogen.sh
+        ./configure --prefix=`pwd`/depends/`depends/config.guess`
+        make -j`nproc`
 
-        ./configure --enable-tests
+3.  *(optional)* It is recommended to build and run the unit tests:
+
+        ./configure --prefix=`pwd`/depends/`depends/config.guess` --enable-tests
         make check
 
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -1,8 +1,16 @@
 UNIX BUILD NOTES
 ====================
-Some notes on how to build Firo Core in Unix.
 
-(for OpenBSD specific instructions, see [build-openbsd.md](build-openbsd.md))
+Quick Install
+---------------------
+
+The instructions below describe how to manually build Firo with system level or
+manually compiled dependencies. It is only recommended for experienced users.
+
+For most users it is easier to use the simple install instructions in the
+[quick install instructions](../README.md) in the top level README.
+
+For OpenBSD specific instructions, see [build-openbsd.md](build-openbsd.md)
 
 Note
 ---------------------


### PR DESCRIPTION
Explain simple usage of the self hosted dependency building (depends) and promote this over manually building dependencies, which doesn't really work now anyway due to some versioning issues on most platforms.

Since the primary build instructions are now in the top level README.md there is a note added to build-unix.md to point anybody looking there back to the top.

## PR intention
There were a few issues with the documentation that can be easily fixed:
- The top level README linked to the depends build instructions but still primarily encouraged users to build manually. But the manual build instructions no longer work as described on newer systems. The depends system should be the primary promoted method, with the manual methods as a fallback instead of the other way around.
- The build-unix.md docs which is where most people look did not refer to the depends build process at all.
- Headless builds using depends needs some extra explanation otherwise it can break on some missing QT dependencies.
- For using the depends build, a bunch of extra system libraries were still recommended that are provided by the depends system anyway.

## Code changes brief
- The change points people looking at the normal build-unix.md to the top level, where the instructions have been moved to.
- Explains how to install just the required system dependencies for compiling, including for some additional distributions.
- Explains how to properly build for headless or GUI.
