### PR TITLE
Fixed for ./configure tor library detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -455,8 +455,6 @@ case $host in
      ;;
 esac
 
-AC_CHECK_LIB([tor], [tor_main], [AC_MSG_NOTICE([Tor found])], [AC_MSG_ERROR([Can't find Tor library])], [-lssl -lcrypto -levent -lz -pthread])
-
 if test x$use_pkgconfig = xyes; then
   m4_ifndef([PKG_PROG_PKG_CONFIG], [AC_MSG_ERROR(PKG_PROG_PKG_CONFIG macro not found. Please install pkg-config and re-run autogen.sh.)])
   m4_ifdef([PKG_PROG_PKG_CONFIG], [
@@ -981,6 +979,11 @@ dnl Check for libcap
 
 AC_CHECK_HEADERS([sys/capability.h])
 AC_SEARCH_LIBS(cap_get_proc, [cap])
+
+dnl ============================================================
+dnl Check for libtor
+
+AC_CHECK_LIB([tor], [tor_main], [AC_MSG_NOTICE([Tor found])], [AC_MSG_ERROR([Can't find Tor library])], [-lssl -lcrypto -levent -lz -pthread])
 
 ac_configure_args="${ac_configure_args} --disable-shared"
 


### PR DESCRIPTION
## Code changes brief
Sometimes `libtor` depends on `libcap`. Changes are made to ensure configure searches for the latter and then tries to do test compilation for `tor` with `-lcap` added to command line if the system has it.