### PR TITLE
Update ci-master.yml

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -8,6 +8,9 @@ on:
     - master
 env:
   SOURCE_ARTIFACT: source
+permissions:
+  contents: read
+
 jobs:
   create-source-distribution:
     name: Create Source Distribution
@@ -40,6 +43,8 @@ jobs:
         name: ${{ env.SOURCE_ARTIFACT }}
         path: ${{ env.ARTIFACT_DIR }}
   build-linux:
+    permissions:
+      contents: none
     name: Build for Linux
     needs: create-source-distribution
     runs-on: ubuntu-18.04
@@ -107,6 +112,8 @@ jobs:
         name: test-logs
         path: ${{ env.TEST_LOG_ARTIFACT_DIR }}
   build-windows:
+    permissions:
+      contents: none
     name: Build for Windows
     needs: create-source-distribution
     runs-on: ubuntu-20.04
@@ -148,6 +155,8 @@ jobs:
         name: windows-binaries
         path: ${{ env.ARTIFACT_DIR }}
   build-mac:
+    permissions:
+      contents: none
     name: Build for macOS
     needs: create-source-distribution
     runs-on: macos-10.15


### PR DESCRIPTION
GitHub asks users to define workflow permissions, see https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/ and https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token for securing GitHub workflows against supply-chain attacks.

The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) also treats not setting token permissions as a high-risk issue. 

The `Token-Permissions` category has a score of 0/10 in Scorecards.

This file was fixed automatically using the open-source tool https://github.com/step-security/secure-workflows. If you like the changes and merge them, please consider starring the repo. 
