### PR TITLE
Fixing UI stuck issues on huge wallets

### DIFF
--- a/src/qt/automintmodel.cpp
+++ b/src/qt/automintmodel.cpp
@@ -13,7 +13,7 @@
 
 IncomingFundNotifier::IncomingFundNotifier(
     CWallet *_wallet, QObject *parent) :
-    QObject(parent), wallet(_wallet), timer(0)
+    QObject(parent), wallet(_wallet), timer(0), lastUpdateTime(0)
 {
     timer = new QTimer(this);
     timer->setSingleShot(true);
@@ -58,9 +58,12 @@ void IncomingFundNotifier::check()
 {
     LOCK(cs);
 
-    if (txs.empty()) {
+    // update only if there are transaction and last update was done more than 2 minutes ago, and in case it is first time
+    if (txs.empty() || (lastUpdateTime!= 0 && (GetSystemTimeInSeconds() - lastUpdateTime <= 120))) {
         return;
     }
+
+    lastUpdateTime = GetSystemTimeInSeconds();
 
     CAmount credit = 0;
     std::vector<uint256> immatures;

--- a/src/qt/automintmodel.h
+++ b/src/qt/automintmodel.h
@@ -62,6 +62,8 @@ private:
 
     std::vector<uint256> txs;
     mutable CCriticalSection cs;
+
+    int64_t lastUpdateTime;
 };
 
 class AutoMintModel : public QObject

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -279,8 +279,9 @@ void TransactionTableModel::updateConfirmations()
     // Invalidate status (number of confirmations) and (possibly) description
     //  for all rows. Qt is smart enough to only actually request the data for the
     //  visible rows.
-    Q_EMIT dataChanged(index(0, Status), index(priv->size()-1, Status));
-    Q_EMIT dataChanged(index(0, ToAddress), index(priv->size()-1, ToAddress));
+    int numRows = std::min(1000, priv->size()-1);
+    Q_EMIT dataChanged(index(0, Status), index(numRows, Status));
+    Q_EMIT dataChanged(index(0, ToAddress), index(numRows, ToAddress));
 }
 
 void TransactionTableModel::updateNumISLocks(int numISLocks)

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -157,41 +157,6 @@ void WalletModel::pollBalanceChanged()
         checkBalanceChanged();
         if(transactionTableModel)
             transactionTableModel->updateConfirmations();
-
-        // check sigma
-        // support only hd
-        if (wallet->zwallet) {
-            checkSigmaAmount(false);
-        }
-    }
-}
-
-void WalletModel::updateSigmaCoins(const QString &pubCoin, const QString &isUsed, int status)
-{
-    if (status == ChangeType::CT_UPDATED) {
-        // some coin have been updated to be used
-        LOCK2(cs_main, wallet->cs_wallet);
-        checkSigmaAmount(true);
-
-    } else if (status == ChangeType::CT_NEW) {
-        // new mint
-        LOCK2(cs_main, wallet->cs_wallet);
-        auto coins = wallet->zwallet->GetTracker().ListMints(true, false, false);
-
-        int block = cachedNumBlocks;
-        for (const auto& coin : coins) {
-            if (!coin.isUsed) {
-                int coinHeight = coin.nHeight;
-                if (coinHeight == -1
-                    || (coinHeight <= block && coinHeight > block - ZC_MINT_CONFIRMATIONS)) {
-                    cachedHavePendingCoin = true;
-                }
-            }
-        }
-
-        if (cachedHavePendingCoin) {
-            checkSigmaAmount(true);
-        }
     }
 }
 
@@ -966,14 +931,6 @@ static void NotifyZerocoinChanged(WalletModel *walletmodel, CWallet *wallet, con
                               Q_ARG(QString, QString::fromStdString(pubCoin)),
                               Q_ARG(QString, QString::fromStdString(isUsed)),
                               Q_ARG(int, status));
-
-    // disable sigma
-    if (wallet->zwallet) {
-        QMetaObject::invokeMethod(walletmodel, "updateSigmaCoins", Qt::QueuedConnection,
-                              Q_ARG(QString, QString::fromStdString(pubCoin)),
-                              Q_ARG(QString, QString::fromStdString(isUsed)),
-                              Q_ARG(int, status));
-    }
 }
 
 static void NotifyTransactionChanged(WalletModel *walletmodel, CWallet *wallet, const uint256 &hash, ChangeType status)

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -373,8 +373,6 @@ public Q_SLOTS:
     void updateWatchOnlyFlag(bool fHaveWatchonly);
     /* Current, immature or unconfirmed balance might have changed - emit 'balanceChanged' if so */
     void pollBalanceChanged();
-    /* Update Amount of sigma change */
-    void updateSigmaCoins(const QString &pubCoin, const QString &isUsed, int status);
     // Handle the changed BIP47 privkeys
     void handleBip47Keys(int receiverAccountNum, void * pBlockIndex);
     // Locks wallet from timer calls


### PR DESCRIPTION
**First comit:** 
In case transaction list is big, each update takes a lot of time, as `filterAcceptsRow` function in transactionfilterproxy.cpp works slow. now we are updating status only of last 1k rows,

**Second commit:**
We remove some sigma related unneeded code from UI, the code was called during each incoming transaction.

**Third commit** 
AutoMint notifier was being called after each incoming fund, this was slowing down the UI during sync, Now it is being called after each 2 minutes but not sooner.