### PR TITLE
Zero value mints

### DIFF
--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -105,7 +105,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
             parts.append(sub);
         } else {
             for (const CTxOut& txout : wtx.tx->vout) {
-                if (wtx.IsChange(txout)) {
+                if (wtx.IsChange(txout) || txout.scriptPubKey.IsLelantusJMint()) {
                     continue;
                 }
                 isminetype mine = wallet->IsMine(txout);

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -175,6 +175,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "setlelantusmintstatus", 1 },
     { "listmintzerocoins", 0 },
     { "listsigmamints", 0 },
+    { "listlelantusmints", 0 },
     { "listpubcoins", 0 },
     { "listsigmapubcoins", 0 },
     { "listspendzerocoins", 0 },

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3677,7 +3677,7 @@ UniValue listlelantusmints(const JSONRPCRequest& request) {
         throw std::runtime_error(
                 "listlelantusmints <all>(false/true)\n"
                 "\nArguments:\n"
-                "1. <all> (boolean, optional) false (default) to return own listlelantusmints. true to return every listlelantusmints.\n"
+                "1. <all> (boolean, optional) false (default) to return real listlelantusmints. true to return every listlelantusmints.\n"
                 "\nResults are an array of Objects, each of which has:\n"
                 "{id, IsUsed, amount, value, serialNumber, nHeight, randomness}");
 
@@ -3697,7 +3697,7 @@ UniValue listlelantusmints(const JSONRPCRequest& request) {
     UniValue results(UniValue::VARR);
 
     BOOST_FOREACH(const CLelantusEntry &lelantusItem, listCoin) {
-        if (fAllStatus || lelantusItem.IsUsed || (lelantusItem.randomness != uint64_t(0) && lelantusItem.serialNumber != uint64_t(0))) {
+        if ((fAllStatus || lelantusItem.amount != uint64_t(0))  && (lelantusItem.IsUsed || (lelantusItem.randomness != uint64_t(0) && lelantusItem.serialNumber != uint64_t(0)))) {
             UniValue entry(UniValue::VOBJ);
             entry.push_back(Pair("id", lelantusItem.id));
             entry.push_back(Pair("isUsed", lelantusItem.IsUsed));

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3697,7 +3697,7 @@ UniValue listlelantusmints(const JSONRPCRequest& request) {
     UniValue results(UniValue::VARR);
 
     BOOST_FOREACH(const CLelantusEntry &lelantusItem, listCoin) {
-        if ((fAllStatus || lelantusItem.amount != uint64_t(0))  && (lelantusItem.IsUsed || (lelantusItem.randomness != uint64_t(0) && lelantusItem.serialNumber != uint64_t(0)))) {
+        if ((fAllStatus || lelantusItem.amount != uint64_t(0)) && (lelantusItem.IsUsed || (lelantusItem.randomness != uint64_t(0) && lelantusItem.serialNumber != uint64_t(0)))) {
             UniValue entry(UniValue::VOBJ);
             entry.push_back(Pair("id", lelantusItem.id));
             entry.push_back(Pair("isUsed", lelantusItem.IsUsed));


### PR DESCRIPTION
Fixes #1164 

**Code changes** 
- 0 value mints are being created in joinsplit transaction, when there is no change, listlelantusmints rpc now skips such mints, until you pass true during rpc call, to show all mints. 
- In some cases jmints were being shown in transaction list after restoration, as wallet did not recognize such mints as changes, now it skips the output in case it is jmint.