### PR TITLE
Enable masternodes to run on non-default port.

### DIFF
--- a/src/evo/providertx.cpp
+++ b/src/evo/providertx.cpp
@@ -27,15 +27,6 @@ static bool CheckService(const uint256& proTxHash, const ProTx& proTx, CValidati
         return state.DoS(10, false, REJECT_INVALID, "bad-protx-addr");
     }
 
-    int mainnetDefaultPort = Params(CBaseChainParams::MAIN).GetDefaultPort();
-    if (Params().NetworkIDString() == CBaseChainParams::MAIN) {
-        if (proTx.addr.GetPort() != mainnetDefaultPort) {
-            return state.DoS(10, false, REJECT_INVALID, "bad-protx-addr-port");
-        }
-    } else if (proTx.addr.GetPort() == mainnetDefaultPort) {
-        return state.DoS(10, false, REJECT_INVALID, "bad-protx-addr-port");
-    }
-
     if (!proTx.addr.IsIPv4()) {
         return state.DoS(10, false, REJECT_INVALID, "bad-protx-addr");
     }


### PR DESCRIPTION
This reverts commit 8d54a4e33b069a9f3f95c4967742a158fe01318d. Related issue #1170.

## PR intention
Enable master node to be registered and run on non-default port (mainnet or not). Address and port is stored in registration transaction and correctly used to connect to the master node. This just enables transactions with non-default port to be registered.

