### PR TITLE
Fix Various Instances of Undefined Behaviour

### DIFF
--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -42,7 +42,7 @@ class CBLSWrapper
     friend class CBLSPublicKey;
     friend class CBLSSignature;
 
-    bool fLegacy;
+    bool fLegacy{fLegacyDefault};
 
 protected:
     ImplType impl;

--- a/src/llmq/quorums_blockprocessor.cpp
+++ b/src/llmq/quorums_blockprocessor.cpp
@@ -321,7 +321,8 @@ bool CQuorumBlockProcessor::GetCommitmentsFromBlock(const CBlock& block, const C
                 return state.DoS(100, false, REJECT_INVALID, "bad-qc-dup");
             }
 
-            ret.emplace((Consensus::LLMQType)qc.commitment.llmqType, std::move(qc.commitment));
+            auto llmqTypeTemp = (Consensus::LLMQType)qc.commitment.llmqType;
+            ret.emplace(llmqTypeTemp, std::move(qc.commitment));
         }
     }
 

--- a/src/llmq/quorums_dkgsessionhandler.cpp
+++ b/src/llmq/quorums_dkgsessionhandler.cpp
@@ -238,7 +238,8 @@ void CDKGSessionHandler::SleepBeforePhase(QuorumPhase curPhase,
         phaseTime = 0;
     }
 
-    int64_t sleepTime = (int64_t)(phaseTime * curSession->GetMyMemberIndex());
+    int64_t sleepTime = 0;
+    if (curSession->GetMyMemberIndex() != UINT64_MAX) sleepTime = (int64_t)(phaseTime * curSession->GetMyMemberIndex());
     int64_t endTime = GetTimeMillis() + sleepTime;
     while (GetTimeMillis() < endTime) {
         if (stopRequested || ShutdownRequested()) {


### PR DESCRIPTION
## PR intention
This fixes several instances of UB.

## Code changes brief
- `CQuorumBlockProcessor::GetCommitmentsFromBlock` - std::move() was used incorrectly, leading to a use after free issue.
- bls - An uninitialised boolean value is read.
- `CDKGSessionHandler::SleepBeforePhase` - An invalid implicit cast from `UINT64_MAX` to `double` is performed in some cases.