### PR TITLE
Update Github Actions to latest MacOS and Ubuntu

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   create-source-distribution:
     name: Create Source Distribution
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     env:
       ARTIFACT_DIR: source
     steps:
@@ -42,7 +42,7 @@ jobs:
   build-linux:
     name: Build for Linux
     needs: create-source-distribution
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     env:
       ARTIFACT_DIR: linux-binaries
       TEST_LOG_ARTIFACT_DIR: test-logs
@@ -150,7 +150,7 @@ jobs:
   build-mac:
     name: Build for macOS
     needs: create-source-distribution
-    runs-on: macos-12
+    runs-on: macos-latest
     env:
       ARTIFACT_DIR: mac-binaries
     steps:

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -150,7 +150,7 @@ jobs:
   build-mac:
     name: Build for macOS
     needs: create-source-distribution
-    runs-on: macos-10.15
+    runs-on: macos-12
     env:
       ARTIFACT_DIR: mac-binaries
     steps:


### PR DESCRIPTION
Github Actions is depreciating macOS 10.15 and Ubuntu 18.04. This PR updates the current workflow to use the latest macOS and Ubuntu.

https://github.com/actions/virtual-environments/issues/5583
https://github.com/actions/runner-images/issues/6002