### PR TITLE
Change firod default settings to allow mining blocks of up to 2MB.

### DIFF
--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -15,7 +15,7 @@
 class CCoinsViewCache;
 
 /** Default for -blockmaxsize, which controls the maximum size of block the mining code will create **/
-static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 500000;
+static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 2000000;
 /** Default for -blockprioritysize, maximum space for zero/low-fee transactions **/
 static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 50000; // 50KB;
 /** Default for -blockmaxweight, which controls the range of block weights the mining code will create **/


### PR DESCRIPTION
## PR intention
Change firod default settings to allow mining blocks of up to 2MB.

## Code changes brief
`DEFAULT_BLOCK_MAX_SIZE` was set to 500KB; this value should be 2MB in order to allow `getblocktemplate` to return blocks with up to 2MB worth of transactions. This does not affect consensus rules, but only miner configuration.