### PR TITLE
Fixed compilation issues on newer macOS versions

### DIFF
--- a/depends/packages/tor.mk
+++ b/depends/packages/tor.mk
@@ -55,7 +55,8 @@ endef
 
 define $(package)_preprocess_cmds
   cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub . && \
-  patch -p1 < $($(package)_patch_dir)/configure.patch
+  patch -p1 < $($(package)_patch_dir)/configure.patch && \
+  sed -i.old 's/^PROGRAMS =.*/PROGRAMS =/' Makefile.in
 endef
 
 define $(package)_config_cmds


### PR DESCRIPTION
## PR intention
Fix compilation issues on macOS 12.6

## Code changes brief
`tor` binaries can't be compiled, so the patch was made to ensure only libraries are built