### PR TITLE
Fix for txindex/addressindex

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5308,7 +5308,8 @@ bool CVerifyDB::VerifyDB(const CChainParams& chainparams, CCoinsView *coinsview,
         }
         // check level 3: check for inconsistencies during memory-only disconnect of tip blocks
         if (nCheckLevel >= 3 && pindex == pindexState && (coins.DynamicMemoryUsage() + pcoinsTip->DynamicMemoryUsage()) <= nCoinCacheUsage) {
-            DisconnectResult res = DisconnectBlock(block, state, pindex, coins);
+            bool  pfClean = false;
+            DisconnectResult res = DisconnectBlock(block, state, pindex, coins, &pfClean);
             if (res == DISCONNECT_FAILED) {
                 return error("VerifyDB(): *** irrecoverable inconsistency in block data at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
             }


### PR DESCRIPTION
## PR intention
Fix wrong result of `getaddressbalance` RPC call

## Code changes brief
During startup last three blocks are typically disconnected to test the data integrity. This is mock disconnection meaning there are no real changes made to the blockchain state. But the addressindex code was incorrectly removing information about transactions in pseudo-disconnected blocks from the database. This is fixed by this PR.
