### PR TITLE
Dockerfile update; Add amd64/arm64 support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -118,3 +118,6 @@ doc/doxygen
 
 libfiroconsensus.pc
 contrib/devtools/split-debug.sh
+
+!depends
+!depends/**/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,15 +7,9 @@ RUN apt-get update && apt-get install -y \
     bsdmainutils \
     curl \
     g++ \
-    libboost-all-dev \
-    libevent-dev \
-    libssl-dev \
     libtool \
-    libzmq3-dev \
     make \
-    openjdk-11-jdk \
     pkg-config \
-    zlib1g-dev \
     patch 
 
 # Build Firo

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ COPY --from=build-image /tmp/ldd /tmp/ldd
 
 # restore ldd files in correct paths
 RUN cp --verbose -RT /tmp/ldd / && \
+    rm -rf /tmp/ldd && \
     ldd /usr/bin/firod
 
 # Create user to run daemon

--- a/depends/ldd_copy.sh
+++ b/depends/ldd_copy.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# https://github.com/Nerdmind/Snippets/blob/master/Bash/ldd-copy-dependencies.sh
+
+#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%#
+# Copy Shared Library Dependencies           [Thomas Lange <code@nerdmind.de>] #
+#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%#
+#                                                                              #
+# This script copies all shared library dependencies from a binary source file #
+# to a desired target directory. The directory structure of the libraries will #
+# be mapped relative to the target directory. The binary file itself will also #
+# be copied to the target directory.                                           #
+#                                                                              #
+# OPTION [-b]: Full path to the binary whose dependencies shall be copied.     #
+# OPTION [-t]: Full path to the target directory for the dependencies.         #
+#                                                                              #
+#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%#
+
+#===============================================================================
+# Parsing command-line arguments with the getopts shell builtin
+#===============================================================================
+while getopts :b:t: option
+do
+	case $option in
+		b) ARGUMENT_BINARY="$OPTARG" ;;
+		t) ARGUMENT_TARGET="$OPTARG" ;;
+	esac
+done
+
+#===============================================================================
+# Checking if all required command-line arguments are provided
+#===============================================================================
+[ -z "${ARGUMENT_BINARY}" ] && echo "$0: Missing argument: [-b binary]" >&2
+[ -z "${ARGUMENT_TARGET}" ] && echo "$0: Missing argument: [-t target]" >&2
+
+#===============================================================================
+# Abort execution if required command-line argument is missing
+#===============================================================================
+[ -z "${ARGUMENT_BINARY}" ] || [ -z "${ARGUMENT_TARGET}" ] && exit 1
+
+#===============================================================================
+# Checking if binary or target path does not exists and abort
+#===============================================================================
+[ ! -f "${ARGUMENT_BINARY}" ] && echo "$0: Binary path does not exists." >&2 && exit 1
+[ ! -d "${ARGUMENT_TARGET}" ] && echo "$0: Target path does not exists." >&2 && exit 1
+
+#===============================================================================
+# Copy binary file with its parent directories to the target directory
+#===============================================================================
+# We want to copy only libraries
+# cp --verbose --parents "${ARGUMENT_BINARY}" "${ARGUMENT_TARGET}"
+
+#===============================================================================
+# Copy each library with its parent directories to the target directory
+#===============================================================================
+for library in $(ldd "${ARGUMENT_BINARY}" | cut -d '>' -f 2 | awk '{print $1}')
+do
+	[ -f "${library}" ] && cp --verbose --parents "${library}" "${ARGUMENT_TARGET}"
+done


### PR DESCRIPTION
## PR intention
Fix docker builds from Dockerfile provided in the repository. Adds support for multiarch builds.

## Code changes brief
Updates old Dockerfile with newest debian base image. Builds for x86 (x86_64) and arm64 (aarch64) architecture.

Build using buildx (takes 2h+ for non-native version)
```
docker buildx build \
	--tag username/firo:latest \
	--platform linux/amd64,linux/arm64 \
	--push \
	.
```

Build on separate machines and merge it with manifest (takes around 20minutes with native build)
```
# build and push on amd64 machine
docker build --tag username/firo:latest-amd64 .
docker push username/firo:latest-amd64

# build and push on arm64 machine
docker build --tag username/firo:latest-arm64 .
docker push username/firo:latest-arm64

# merge it to multiarch image
docker manifest create username/firo:latest \
	--amend username/firo:latest-amd64 \
	--amend username/firo:latest-arm64
docker manifest push username/firo:latest
```

You can check multiarch builds here https://hub.docker.com/r/mksdev/firo/tags
`mksdev/firo:master` - this PR master branch 
`mksdev/firo:latest` `mksdev/firo:v0.14.12.0` - v0.14.12.0 commit  https://github.com/firoorg/firo/commit/b8abba9ee8b85bbbab6d34b283da3935096e7747

```
docker run --rm -it mksdev/firo:master
```

##  Still needs to be checked
For `firoorg/firod:latest` the version is printed as `Firo version v0.14.12.0-gb8abba9ee`, but this build reports as `Firo version v0.14.12.0-unk`. 

Using `./configure` with `--without-gui --enable-tests`. Maybe there are different options used for official builds.






