### PR TITLE
Offloaded signing

### DIFF
--- a/src/libspark/hash.cpp
+++ b/src/libspark/hash.cpp
@@ -31,6 +31,18 @@ void Hash::include(CDataStream& data) {
 	EVP_DigestUpdate(this->ctx, reinterpret_cast<unsigned char *>(data.data()), data.size());
 }
 
+// Finalize the hash function to a byte array
+std::vector<unsigned char> Hash::finalize() {
+    // Use the full output size of the hash function
+    std::vector<unsigned char> result;
+    result.resize(EVP_MD_size(EVP_sha512()));
+
+    unsigned int TEMP;
+    EVP_DigestFinal_ex(this->ctx, result.data(), &TEMP);
+
+    return result;
+}
+
 // Finalize the hash function to a scalar
 Scalar Hash::finalize_scalar() {
     // Ensure we can properly populate a scalar

--- a/src/libspark/hash.cpp
+++ b/src/libspark/hash.cpp
@@ -7,7 +7,7 @@ using namespace secp_primitives;
 // Set up a labeled hash function
 Hash::Hash(const std::string label) {
 	this->ctx = EVP_MD_CTX_new();
-	EVP_DigestInit_ex(this->ctx, EVP_blake2b512(), NULL);
+	EVP_DigestInit_ex(this->ctx, EVP_sha512(), NULL);
 
 	// Write the protocol and mode information
 	std::vector<unsigned char> protocol(LABEL_PROTOCOL.begin(), LABEL_PROTOCOL.end());
@@ -34,21 +34,21 @@ void Hash::include(CDataStream& data) {
 // Finalize the hash function to a scalar
 Scalar Hash::finalize_scalar() {
     // Ensure we can properly populate a scalar
-    if (EVP_MD_size(EVP_blake2b512()) < SCALAR_ENCODING) {
+    if (EVP_MD_size(EVP_sha512()) < SCALAR_ENCODING) {
         throw std::runtime_error("Bad hash size!");
     }
 
     std::vector<unsigned char> hash;
-    hash.resize(EVP_MD_size(EVP_blake2b512()));
+    hash.resize(EVP_MD_size(EVP_sha512()));
     unsigned char counter = 0;
 
     EVP_MD_CTX* state_counter;
     state_counter = EVP_MD_CTX_new();
-    EVP_DigestInit_ex(state_counter, EVP_blake2b512(), NULL);
+    EVP_DigestInit_ex(state_counter, EVP_sha512(), NULL);
 
     EVP_MD_CTX* state_finalize;
     state_finalize = EVP_MD_CTX_new();
-    EVP_DigestInit_ex(state_finalize, EVP_blake2b512(), NULL);
+    EVP_DigestInit_ex(state_finalize, EVP_sha512(), NULL);
 
     while (1) {
         // Prepare temporary state for counter testing
@@ -83,21 +83,21 @@ GroupElement Hash::finalize_group() {
 	const unsigned char ZERO = 0;
 
     // Ensure we can properly populate a 
-    if (EVP_MD_size(EVP_blake2b512()) < GROUP_ENCODING) {
+    if (EVP_MD_size(EVP_sha512()) < GROUP_ENCODING) {
         throw std::runtime_error("Bad hash size!");
     }
 
     std::vector<unsigned char> hash;
-    hash.resize(EVP_MD_size(EVP_blake2b512()));
+    hash.resize(EVP_MD_size(EVP_sha512()));
     unsigned char counter = 0;
 
     EVP_MD_CTX* state_counter;
     state_counter = EVP_MD_CTX_new();
-    EVP_DigestInit_ex(state_counter, EVP_blake2b512(), NULL);
+    EVP_DigestInit_ex(state_counter, EVP_sha512(), NULL);
 
     EVP_MD_CTX* state_finalize;
     state_finalize = EVP_MD_CTX_new();
-    EVP_DigestInit_ex(state_finalize, EVP_blake2b512(), NULL);
+    EVP_DigestInit_ex(state_finalize, EVP_sha512(), NULL);
 
     while (1) {
         // Prepare temporary state for counter testing

--- a/src/libspark/hash.h
+++ b/src/libspark/hash.h
@@ -12,6 +12,7 @@ public:
 	Hash(const std::string label);
 	~Hash();
 	void include(CDataStream& data);
+	std::vector<unsigned char> finalize();
 	Scalar finalize_scalar();
 	GroupElement finalize_group();
 

--- a/src/libspark/kdf.cpp
+++ b/src/libspark/kdf.cpp
@@ -5,7 +5,7 @@ namespace spark {
 // Set up a labeled KDF
 KDF::KDF(const std::string label, std::size_t derived_key_size) {
 	this->ctx = EVP_MD_CTX_new();
-	EVP_DigestInit_ex(this->ctx, EVP_blake2b512(), NULL);
+	EVP_DigestInit_ex(this->ctx, EVP_sha512(), NULL);
 
 	// Write the protocol and mode information
 	std::vector<unsigned char> protocol(LABEL_PROTOCOL.begin(), LABEL_PROTOCOL.end());
@@ -18,7 +18,7 @@ KDF::KDF(const std::string label, std::size_t derived_key_size) {
 	EVP_DigestUpdate(this->ctx, label_bytes.data(), label_bytes.size());
 
 	// Embed and set the derived key size
-	if (derived_key_size > EVP_MD_size(EVP_blake2b512())) {
+	if (derived_key_size > EVP_MD_size(EVP_sha512())) {
 		throw std::invalid_argument("Requested KDF size is too large");
 	}
 	include_size(derived_key_size);
@@ -39,7 +39,7 @@ void KDF::include(CDataStream& data) {
 // Finalize the KDF with arbitrary size
 std::vector<unsigned char> KDF::finalize() {
 	std::vector<unsigned char> result;
-	result.resize(EVP_MD_size(EVP_blake2b512()));
+	result.resize(EVP_MD_size(EVP_sha512()));
 
 	unsigned int TEMP;
 	EVP_DigestFinal_ex(this->ctx, result.data(), &TEMP);

--- a/src/libspark/spend_transaction.cpp
+++ b/src/libspark/spend_transaction.cpp
@@ -178,9 +178,7 @@ SpendTransaction::SpendTransaction(
 	Scalar mu = hash_bind(
 		hash_bind_inner(
 			this->cover_set_representations,
-			this->S1,
 			this->C1,
-			this->T,
 			this->grootle_proofs,
 			this->balance_proof,
 			this->range_proof
@@ -297,9 +295,7 @@ bool SpendTransaction::verify(
 		Scalar mu = hash_bind(
 			hash_bind_inner(
 				tx.cover_set_representations,
-				tx.S1,
 				tx.C1,
-				tx.T,
 				tx.grootle_proofs,
 				tx.balance_proof,
 				tx.range_proof
@@ -411,9 +407,7 @@ bool SpendTransaction::verify(
 // Its value is then used as part of the binding hash, which a limited signer can verify as part of the signing process
 std::vector<unsigned char> SpendTransaction::hash_bind_inner(
 	const std::unordered_map<uint64_t, std::vector<unsigned char>>& cover_set_representations,
-	const std::vector<GroupElement>& S1,
 	const std::vector<GroupElement>& C1,
-	const std::vector<GroupElement>& T,
 	const std::vector<GrootleProof>& grootle_proofs,
 	const SchnorrProof& balance_proof,
 	const BPPlusProof& range_proof

--- a/src/libspark/spend_transaction.cpp
+++ b/src/libspark/spend_transaction.cpp
@@ -176,15 +176,17 @@ SpendTransaction::SpendTransaction(
 
 	// Compute the binding hash
 	Scalar mu = hash_bind(
+		hash_bind_inner(
+			this->cover_set_representations,
+			this->S1,
+			this->C1,
+			this->T,
+			this->grootle_proofs,
+			this->balance_proof,
+			this->range_proof
+		),
 		this->out_coins,
-		this->f + vout,
-		this->cover_set_representations,
-		this->S1,
-		this->C1,
-		this->T,
-		this->grootle_proofs,
-		this->balance_proof,
-		this->range_proof
+		this->f + vout
 	);
 
 	// Compute the authorizing Chaum proof
@@ -293,15 +295,17 @@ bool SpendTransaction::verify(
 
 		// Compute the binding hash
 		Scalar mu = hash_bind(
+			hash_bind_inner(
+				tx.cover_set_representations,
+				tx.S1,
+				tx.C1,
+				tx.T,
+				tx.grootle_proofs,
+				tx.balance_proof,
+				tx.range_proof
+			),
 			tx.out_coins,
-			tx.f + tx.vout,
-			tx.cover_set_representations,
-			tx.S1,
-			tx.C1,
-			tx.T,
-			tx.grootle_proofs,
-			tx.balance_proof,
-			tx.range_proof
+			tx.f + tx.vout
 		);
 
 		// Verify the authorizing Chaum-Pedersen proof
@@ -402,25 +406,20 @@ bool SpendTransaction::verify(
 	return true;
 }
 
-// Hash-to-scalar function H_bind
-Scalar SpendTransaction::hash_bind(
-    const std::vector<Coin>& out_coins,
-    const uint64_t f_,
+// Hash function H_bind_inner
+// This function pre-hashes auxiliary data that makes things easier for a limited signer who cannot process the data directly
+// Its value is then used as part of the binding hash, which a limited signer can verify as part of the signing process
+std::vector<unsigned char> SpendTransaction::hash_bind_inner(
 	const std::unordered_map<uint64_t, std::vector<unsigned char>>& cover_set_representations,
-    const std::vector<GroupElement>& S1,
-    const std::vector<GroupElement>& C1,
-    const std::vector<GroupElement>& T,
-    const std::vector<GrootleProof>& grootle_proofs,
-    const SchnorrProof& balance_proof,
+	const std::vector<GroupElement>& S1,
+	const std::vector<GroupElement>& C1,
+	const std::vector<GroupElement>& T,
+	const std::vector<GrootleProof>& grootle_proofs,
+	const SchnorrProof& balance_proof,
 	const BPPlusProof& range_proof
 ) {
-    Hash hash(LABEL_HASH_BIND);
-
+    Hash hash(LABEL_HASH_BIND_INNER);
     CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
-
-	// Perform the serialization and hashing
-    stream << out_coins;
-    stream << f_;
 	stream << cover_set_representations;
     stream << S1;
     stream << C1;
@@ -429,6 +428,23 @@ Scalar SpendTransaction::hash_bind(
     stream << balance_proof;
 	stream << range_proof;
     hash.include(stream);
+
+	return hash.finalize();
+}
+
+// Hash-to-scalar function H_bind
+// This function must accept pre-hashed data from `H_bind_inner` intended to correspond to the signing operation
+Scalar SpendTransaction::hash_bind(
+	const std::vector<unsigned char> hash_bind_inner,
+    const std::vector<Coin>& out_coins,
+    const uint64_t f_
+) {
+	Hash hash(LABEL_HASH_BIND);
+    CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
+	stream << hash_bind_inner,
+	stream << out_coins;
+	stream << f_;
+	hash.include(stream);
 
     return hash.finalize_scalar();
 }

--- a/src/libspark/spend_transaction.h
+++ b/src/libspark/spend_transaction.h
@@ -62,9 +62,7 @@ public:
     
     static std::vector<unsigned char> hash_bind_inner(
 		const std::unordered_map<uint64_t, std::vector<unsigned char>>& cover_set_representations,
-        const std::vector<GroupElement>& S1,
         const std::vector<GroupElement>& C1,
-        const std::vector<GroupElement>& T,
         const std::vector<GrootleProof>& grootle_proofs,
         const SchnorrProof& balance_proof,
 		const BPPlusProof& range_proof

--- a/src/libspark/spend_transaction.h
+++ b/src/libspark/spend_transaction.h
@@ -60,9 +60,7 @@ public:
 	static bool verify(const Params* params, const std::vector<SpendTransaction>& transactions, const std::unordered_map<uint64_t, std::vector<Coin>>& cover_sets);
 	static bool verify(const SpendTransaction& transaction, const std::unordered_map<uint64_t, std::vector<Coin>>& cover_sets);
     
-	static Scalar hash_bind(
-        const std::vector<Coin>& out_coins,
-        const uint64_t f_,
+    static std::vector<unsigned char> hash_bind_inner(
 		const std::unordered_map<uint64_t, std::vector<unsigned char>>& cover_set_representations,
         const std::vector<GroupElement>& S1,
         const std::vector<GroupElement>& C1,
@@ -70,6 +68,11 @@ public:
         const std::vector<GrootleProof>& grootle_proofs,
         const SchnorrProof& balance_proof,
 		const BPPlusProof& range_proof
+    );
+	static Scalar hash_bind(
+        const std::vector<unsigned char> hash_bind_inner,
+        const std::vector<Coin>& out_coins,
+        const uint64_t f_
     );
 
     ADD_SERIALIZE_METHODS;

--- a/src/libspark/transcript.cpp
+++ b/src/libspark/transcript.cpp
@@ -14,7 +14,7 @@ const unsigned char FLAG_CHALLENGE = 3;
 Transcript::Transcript(const std::string domain) {
     // Prepare the state
     this->ctx = EVP_MD_CTX_new();
-    EVP_DigestInit_ex(this->ctx, EVP_blake2b512(), NULL);
+    EVP_DigestInit_ex(this->ctx, EVP_sha512(), NULL);
 
     // Write the protocol and mode information
     std::vector<unsigned char> protocol(LABEL_PROTOCOL.begin(), LABEL_PROTOCOL.end());
@@ -98,21 +98,21 @@ void Transcript::add(const std::string label, const std::vector<unsigned char>& 
 // Produce a challenge
 Scalar Transcript::challenge(const std::string label) {
     // Ensure we can properly populate a scalar
-    if (EVP_MD_size(EVP_blake2b512()) < SCALAR_ENCODING) {
+    if (EVP_MD_size(EVP_sha512()) < SCALAR_ENCODING) {
         throw std::runtime_error("Bad hash size!");
     }
 
     std::vector<unsigned char> hash;
-    hash.resize(EVP_MD_size(EVP_blake2b512()));
+    hash.resize(EVP_MD_size(EVP_sha512()));
     unsigned char counter = 0;
 
     EVP_MD_CTX* state_counter;
     state_counter = EVP_MD_CTX_new();
-    EVP_DigestInit_ex(state_counter, EVP_blake2b512(), NULL);
+    EVP_DigestInit_ex(state_counter, EVP_sha512(), NULL);
 
     EVP_MD_CTX* state_finalize;
     state_finalize = EVP_MD_CTX_new();
-    EVP_DigestInit_ex(state_finalize, EVP_blake2b512(), NULL);
+    EVP_DigestInit_ex(state_finalize, EVP_sha512(), NULL);
 
     include_flag(FLAG_CHALLENGE);
     include_label(label);

--- a/src/libspark/util.cpp
+++ b/src/libspark/util.cpp
@@ -56,14 +56,14 @@ GroupElement SparkUtils::hash_generator(const std::string label) {
 	const int GROUP_ENCODING = 34;
 	const unsigned char ZERO = 0;
 
-    // Ensure we can properly populate a 
-    if (EVP_MD_size(EVP_blake2b512()) < GROUP_ENCODING) {
+    // Ensure we can properly populate a group element encoding
+    if (EVP_MD_size(EVP_sha512()) < GROUP_ENCODING) {
         throw std::runtime_error("Bad hash size!");
     }
 
     EVP_MD_CTX* ctx;
     ctx = EVP_MD_CTX_new();
-    EVP_DigestInit_ex(ctx, EVP_blake2b512(), NULL);
+    EVP_DigestInit_ex(ctx, EVP_sha512(), NULL);
 
     // Write the protocol and mode
     std::vector<unsigned char> protocol(LABEL_PROTOCOL.begin(), LABEL_PROTOCOL.end());
@@ -75,16 +75,16 @@ GroupElement SparkUtils::hash_generator(const std::string label) {
     EVP_DigestUpdate(ctx, bytes.data(), bytes.size());
 
     std::vector<unsigned char> hash;
-    hash.resize(EVP_MD_size(EVP_blake2b512()));
+    hash.resize(EVP_MD_size(EVP_sha512()));
     unsigned char counter = 0;
 
     EVP_MD_CTX* state_counter;
     state_counter = EVP_MD_CTX_new();
-    EVP_DigestInit_ex(state_counter, EVP_blake2b512(), NULL);
+    EVP_DigestInit_ex(state_counter, EVP_sha512(), NULL);
 
     EVP_MD_CTX* state_finalize;
     state_finalize = EVP_MD_CTX_new();
-    EVP_DigestInit_ex(state_finalize, EVP_blake2b512(), NULL);
+    EVP_DigestInit_ex(state_finalize, EVP_sha512(), NULL);
 
     // Finalize the hash
     while (1) {

--- a/src/libspark/util.h
+++ b/src/libspark/util.h
@@ -48,6 +48,7 @@ const std::string LABEL_HASH_SER = "SER";
 const std::string LABEL_HASH_VAL = "VAL";
 const std::string LABEL_HASH_SER1 = "SER1";
 const std::string LABEL_HASH_VAL1 = "VAL1";
+const std::string LABEL_HASH_BIND_INNER = "BIND_INNER";
 const std::string LABEL_HASH_BIND = "BIND";
 const std::string LABEL_F4GRUMBLE_G = "SPARK_F4GRUMBLE_G";
 const std::string LABEL_F4GRUMBLE_H = "SPARK_F4GRUMBLE_H";


### PR DESCRIPTION
## PR intention
This PR makes some careful changes intended to make it easier to support offloaded signing, where a computationally-limited signer device wants to work with a (possibly malicious) helper device to authorize a transaction.

## Code changes brief
All cryptographic hash functions in Spark that previously used `Blake2b512` now use `SHA512` for broader library support. The binding hash included with Chaum-Pedersen authorizing proofs now pre-hashes auxiliary data, and then adds in generated coin data. This is intended to allow the signing device to confirm that generated coins have been produced by the helper honestly.