### PR TITLE
Fix undefined behaviour in CHDChain.

### DIFF
--- a/src/hdmint/wallet.cpp
+++ b/src/hdmint/wallet.cpp
@@ -797,7 +797,7 @@ bool CHDMintWallet::CreateMintSeed(CWalletDB& walletdb, uint512& mintSeed, const
 
     if(seedId.IsNull()){
         CPubKey pubKey;
-        int32_t chainIndex = pwalletMain->GetHDChain().nExternalChainCounters[BIP44_MINT_INDEX];
+        int32_t chainIndex = pwalletMain->GetHDChain().nExternalChainCounters.at(BIP44_MINT_INDEX);
         if(nCount==chainIndex){
             // If chainIndex is the same as n (ie. we are generating next available key), generate a new key.
             pubKey = pwalletMain->GenerateNewKey(BIP44_MINT_INDEX, fWriteChain);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -266,12 +266,12 @@ CPubKey CWallet::GenerateNewKey(uint32_t nChange, bool fWriteChain)
         // derive child key at next index, skip keys already known to the wallet
         do
         {
-            externalChainChildKey.Derive(childKey, hdChain.nExternalChainCounters[nChange]);
-            metadata.hdKeypath = "m/44'/" + std::to_string(nIndex) + "'/0'/" + std::to_string(nChange) + "/" + std::to_string(hdChain.nExternalChainCounters[nChange]);
+            externalChainChildKey.Derive(childKey, hdChain.nExternalChainCounters.at(nChange));
+            metadata.hdKeypath = "m/44'/" + std::to_string(nIndex) + "'/0'/" + std::to_string(nChange) + "/" + std::to_string(hdChain.nExternalChainCounters.at(nChange));
             metadata.hdMasterKeyID = hdChain.masterKeyID;
-            metadata.nChild = Component(hdChain.nExternalChainCounters[nChange], false);
+            metadata.nChild = Component(hdChain.nExternalChainCounters.at(nChange), false);
             // increment childkey index
-            hdChain.nExternalChainCounters[nChange]++;
+            hdChain.nExternalChainCounters.at(nChange)++;
         } while (HaveKey(childKey.key.GetPubKey().GetID()));
         secret = childKey.key;
 

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -71,18 +71,23 @@ typedef std::pair<uint32_t,bool> Component;
 class CHDChain
 {
 public:
-    uint32_t nExternalChainCounter; // VERSION_BASIC
-    std::vector<uint32_t> nExternalChainCounters; // VERSION_WITH_BIP44: vector index corresponds to account value
-    CKeyID masterKeyID; //!< master key hash160
 
     static const int VERSION_BASIC = 1;
     static const int VERSION_WITH_BIP44 = 10;
     static const int VERSION_WITH_BIP39 = 11;
     static const int CURRENT_VERSION = VERSION_WITH_BIP39;
     static const int N_CHANGES = 5; // standard = 0/1, mint = 2, elysium = 3, elysiumv1 = 4
-    int nVersion;
+    int nVersion = CHDChain::CURRENT_VERSION;
 
-    CHDChain() { SetNull(); }
+    uint32_t nExternalChainCounter = 0; // VERSION_BASIC
+    // VERSION_WITH_BIP44: vector index corresponds to account value
+    std::vector<uint32_t> nExternalChainCounters;
+    CKeyID masterKeyID; //!< master key hash160
+
+    CHDChain() {
+        nExternalChainCounters.assign(N_CHANGES, 0);
+    }
+
     ADD_SERIALIZE_METHODS;
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action)
@@ -93,7 +98,8 @@ public:
         READWRITE(masterKeyID);
         if (this->nVersion >= VERSION_WITH_BIP44) {
             READWRITE(nExternalChainCounters);
-            nExternalChainCounters.resize(N_CHANGES);
+            if (nExternalChainCounters.size() < N_CHANGES)
+                nExternalChainCounters.resize(N_CHANGES, 0);
         }
     }
 
@@ -102,9 +108,7 @@ public:
         nVersion = CHDChain::CURRENT_VERSION;
         masterKeyID.SetNull();
         nExternalChainCounter = 0;
-        for(int index=0;index<N_CHANGES;index++){
-            nExternalChainCounters.push_back(0);
-        }
+        nExternalChainCounters.assign(N_CHANGES, 0);
     }
 };
 


### PR DESCRIPTION
## PR intention
Fix instances of UB in CHDChain.

## Code changes brief
- Give safe defaults for variables.
- Prevent `nExternalChainCounters` from being initialised with uninitialised values when it is deserialised.