### PR TITLE
Add the -checkblockindexpow flag, reducing startup time by 70%.

### DIFF
--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -350,6 +350,7 @@ bool CBlockTreeDB::ReadFlag(const std::string &name, bool &fValue) {
 
 bool CBlockTreeDB::LoadBlockIndexGuts(boost::function<CBlockIndex*(const uint256&)> insertBlockIndex)
 {
+    bool checkPow = GetBoolArg("-checkblockindexpow", false);
     const auto &consensusParams = Params().GetConsensus();
     std::unique_ptr<CDBIterator> pcursor(NewIterator());
 
@@ -400,7 +401,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts(boost::function<CBlockIndex*(const uint256
 
                 pindexNew->activeDisablingSporks = diskindex.activeDisablingSporks;
 
-                if (!CheckProofOfWork(pindexNew->GetBlockPoWHash(), pindexNew->nBits, consensusParams))
+                if (checkPow && !CheckProofOfWork(pindexNew->GetBlockPoWHash(), pindexNew->nBits, consensusParams))
                     return error("LoadBlockIndex(): CheckProofOfWork failed: %s", pindexNew->ToString());
 
                 pcursor->Next();


### PR DESCRIPTION
Stop checking PoW of already blocks that we've already persisted (and therefore have already checked the PoW of). Add a flag -checkblockindexpow if we really want to do this anyway.

This cuts startup time by around 70%.