### PR TITLE
Update linking tag

### DIFF
--- a/src/libspark/chaum.cpp
+++ b/src/libspark/chaum.cpp
@@ -3,8 +3,8 @@
 
 namespace spark {
 
-Chaum::Chaum(const GroupElement& F_, const GroupElement& G_, const GroupElement& H_, const GroupElement& U_):
-    F(F_), G(G_), H(H_), U(U_) {
+Chaum::Chaum(const GroupElement& F_, const GroupElement& G_, const GroupElement& H_):
+    F(F_), G(G_), H(H_) {
 }
 
 Scalar Chaum::challenge(
@@ -18,7 +18,6 @@ Scalar Chaum::challenge(
     transcript.add("F", F);
     transcript.add("G", G);
     transcript.add("H", H);
-    transcript.add("U", U);
     transcript.add("mu", mu);
     transcript.add("S", S);
     transcript.add("T", T);
@@ -43,7 +42,7 @@ void Chaum::prove(
         throw std::invalid_argument("Bad Chaum statement!");
     }
     for (std::size_t i = 0; i < n; i++) {
-        if (!(F*x[i] + G*y[i] + H*z[i] == S[i] && T[i]*x[i] + G*y[i] == U)) {
+        if (!(F*x[i] + G*y[i] + H*z[i] == S[i] && (T[i]*x[i] + G*y[i]).isInfinity())) {
             throw std::invalid_argument("Bad Chaum statement!");
         }
     }
@@ -133,15 +132,6 @@ bool Chaum::verify(
     // H
     scalars.emplace_back(proof.t3.negate());
     points.emplace_back(H);
-
-    // U
-    Scalar U_scalar;
-    for (std::size_t i = 0; i < n; i++) {
-        U_scalar += c_powers[i];
-    }
-    U_scalar *= w;
-    scalars.emplace_back(U_scalar);
-    points.emplace_back(U);
 
     // A1
     scalars.emplace_back(Scalar((uint64_t) 1));

--- a/src/libspark/chaum.h
+++ b/src/libspark/chaum.h
@@ -8,7 +8,7 @@ namespace spark {
 
 class Chaum {
 public:
-    Chaum(const GroupElement& F, const GroupElement& G, const GroupElement& H, const GroupElement& U);
+    Chaum(const GroupElement& F, const GroupElement& G, const GroupElement& H);
 
     void prove(
         const Scalar& mu,
@@ -37,7 +37,6 @@ private:
     const GroupElement& F;
     const GroupElement& G;
     const GroupElement& H;
-    const GroupElement& U;
 };
 
 }

--- a/src/libspark/coin.cpp
+++ b/src/libspark/coin.cpp
@@ -110,7 +110,7 @@ bool Coin::validate(
 RecoveredCoinData Coin::recover(const FullViewKey& full_view_key, const IdentifiedCoinData& data) {
 	RecoveredCoinData recovered_data;
 	recovered_data.s = SparkUtils::hash_ser(data.k, this->serial_context) + SparkUtils::hash_Q2(full_view_key.get_s1(), data.i) + full_view_key.get_s2();
-	recovered_data.T = (this->params->get_U() + full_view_key.get_D().inverse())*recovered_data.s.inverse();
+	recovered_data.T = full_view_key.get_D()*recovered_data.s.inverse().negate();
 
 	return recovered_data;
 }

--- a/src/libspark/params.cpp
+++ b/src/libspark/params.cpp
@@ -58,7 +58,6 @@ Params::Params(
     this->F = SparkUtils::hash_generator(LABEL_GENERATOR_F);
     this->G.set_base_g();
     this->H = SparkUtils::hash_generator(LABEL_GENERATOR_H);
-    this->U = SparkUtils::hash_generator(LABEL_GENERATOR_U);
 
     // Coin parameters
     this->memo_bytes = memo_bytes;
@@ -96,10 +95,6 @@ const GroupElement& Params::get_G() const {
 
 const GroupElement& Params::get_H() const {
     return this->H;
-}
-
-const GroupElement& Params::get_U() const {
-    return this->U;
 }
 
 const std::size_t Params::get_memo_bytes() const {

--- a/src/libspark/params.h
+++ b/src/libspark/params.h
@@ -18,7 +18,6 @@ public:
     const GroupElement& get_F() const;
     const GroupElement& get_G() const;
     const GroupElement& get_H() const;
-    const GroupElement& get_U() const;
 
     const std::size_t get_memo_bytes() const;
 
@@ -47,7 +46,6 @@ private:
     GroupElement F;
     GroupElement G;
     GroupElement H;
-    GroupElement U;
 
     // Coin parameters
     std::size_t memo_bytes;

--- a/src/libspark/spend_transaction.cpp
+++ b/src/libspark/spend_transaction.cpp
@@ -191,8 +191,7 @@ SpendTransaction::SpendTransaction(
 	Chaum chaum(
 		this->params->get_F(),
 		this->params->get_G(),
-		this->params->get_H(),
-		this->params->get_U()
+		this->params->get_H()
 	);
 	chaum.prove(
 		mu,
@@ -308,8 +307,7 @@ bool SpendTransaction::verify(
 		Chaum chaum(
 			tx.params->get_F(),
 			tx.params->get_G(),
-			tx.params->get_H(),
-			tx.params->get_U()
+			tx.params->get_H()
 		);
 		if (!chaum.verify(mu, tx.S1, tx.T, tx.chaum_proof)) {
 			return false;

--- a/src/libspark/test/chaum_test.cpp
+++ b/src/libspark/test/chaum_test.cpp
@@ -11,11 +11,10 @@ BOOST_FIXTURE_TEST_SUITE(spark_chaum_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(serialization)
 {
-    GroupElement F, G, H, U;
+    GroupElement F, G, H;
     F.randomize();
     G.randomize();
     H.randomize();
-    U.randomize();
 
     const std::size_t n = 3;
 
@@ -34,12 +33,12 @@ BOOST_AUTO_TEST_CASE(serialization)
         z[i].randomize();
 
         S[i] = F*x[i] + G*y[i] + H*z[i];
-        T[i] = (U + G*y[i].negate())*x[i].inverse();
+        T[i] = G*y[i].negate()*x[i].inverse();
     }
 
     ChaumProof proof;
 
-    Chaum chaum(F, G, H, U);
+    Chaum chaum(F, G, H);
     chaum.prove(mu, x, y, z, S, T, proof);
 
     CDataStream serialized(SER_NETWORK, PROTOCOL_VERSION);
@@ -59,11 +58,10 @@ BOOST_AUTO_TEST_CASE(serialization)
 
 BOOST_AUTO_TEST_CASE(completeness)
 {
-    GroupElement F, G, H, U;
+    GroupElement F, G, H;
     F.randomize();
     G.randomize();
     H.randomize();
-    U.randomize();
 
     const std::size_t n = 3;
 
@@ -82,12 +80,12 @@ BOOST_AUTO_TEST_CASE(completeness)
         z[i].randomize();
 
         S[i] = F*x[i] + G*y[i] + H*z[i];
-        T[i] = (U + G*y[i].negate())*x[i].inverse();
+        T[i] = G*y[i].negate()*x[i].inverse();
     }
 
     ChaumProof proof;
 
-    Chaum chaum(F, G, H, U);
+    Chaum chaum(F, G, H);
     chaum.prove(mu, x, y, z, S, T, proof);
 
     BOOST_CHECK(chaum.verify(mu, S, T, proof));
@@ -95,11 +93,10 @@ BOOST_AUTO_TEST_CASE(completeness)
 
 BOOST_AUTO_TEST_CASE(bad_proofs)
 {
-    GroupElement F, G, H, U;
+    GroupElement F, G, H;
     F.randomize();
     G.randomize();
     H.randomize();
-    U.randomize();
 
     const std::size_t n = 3;
 
@@ -118,12 +115,12 @@ BOOST_AUTO_TEST_CASE(bad_proofs)
         z[i].randomize();
 
         S[i] = F*x[i] + G*y[i] + H*z[i];
-        T[i] = (U + G*y[i].negate())*x[i].inverse();
+        T[i] = G*y[i].negate()*x[i].inverse();
     }
 
     ChaumProof proof;
 
-    Chaum chaum(F, G, H, U);
+    Chaum chaum(F, G, H);
     chaum.prove(mu, x, y, z, S, T, proof);
 
     // Bad mu

--- a/src/libspark/test/coin_test.cpp
+++ b/src/libspark/test/coin_test.cpp
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE(mint_identify_recover)
         params->get_F()*(SparkUtils::hash_ser(k, coin.serial_context) + SparkUtils::hash_Q2(incoming_view_key.get_s1(), i) + full_view_key.get_s2()) + full_view_key.get_D(),
         params->get_F()*r_data.s + full_view_key.get_D()
     );
-    BOOST_CHECK_EQUAL(r_data.T*r_data.s + full_view_key.get_D(), params->get_U());
+    BOOST_CHECK((r_data.T*r_data.s + full_view_key.get_D()).isInfinity());
 }
 
 BOOST_AUTO_TEST_CASE(spend_identify_recover)
@@ -114,7 +114,7 @@ BOOST_AUTO_TEST_CASE(spend_identify_recover)
         params->get_F()*(SparkUtils::hash_ser(k, coin.serial_context) + SparkUtils::hash_Q2(incoming_view_key.get_s1(), i) + full_view_key.get_s2()) + full_view_key.get_D(),
         params->get_F()*r_data.s + full_view_key.get_D()
     );
-    BOOST_CHECK_EQUAL(r_data.T*r_data.s + full_view_key.get_D(), params->get_U());
+    BOOST_CHECK((r_data.T*r_data.s + full_view_key.get_D()).isInfinity());
 }
 BOOST_AUTO_TEST_SUITE_END()
 


### PR DESCRIPTION
Updates linking tags in preparation for a possible one-of-many proof upgrade. Makes corresponding changes to authorizing proofs.

Because this PR changes how linking tags and authorizing proofs are computed, it is a **breaking change** against [this commit](https://github.com/firoorg/firo/tree/89024560ba73b05796d08b930233e4011a727be5), which is apparently the current devnet and testnet commit.