### PR TITLE
Fixed broken spark state

### DIFF
--- a/src/spark/state.cpp
+++ b/src/spark/state.cpp
@@ -262,15 +262,17 @@ bool ConnectBlockSpark(
             )) {
                 return false;
             }
+        }
 
-            if (!fJustCheck) {
+        if (!fJustCheck) {
+            BOOST_FOREACH(auto& lTag, pblock->sparkTxInfo->spentLTags) {
                 pindexNew->spentLTags.insert(lTag);
                 sparkState.AddSpend(lTag.first, lTag.second);
             }
         }
-
-        if (fJustCheck)
+        else {
             return true;
+        }
 
         const auto& params = ::Params().GetConsensus();
         CHash256 hash;

--- a/src/spark/state.cpp
+++ b/src/spark/state.cpp
@@ -1005,12 +1005,10 @@ void CSparkState::AddMintsToStateAndBlockIndex(
 }
 
 void CSparkState::AddSpend(const GroupElement& lTag, int coinGroupId) {
-    if (!mintMetaInfo.count(coinGroupId)) {
-        throw std::invalid_argument("group id doesn't exist");
+    if (mintMetaInfo.count(coinGroupId) > 0) {
+        usedLTags[lTag] = coinGroupId;
+        spendMetaInfo[coinGroupId] += 1;
     }
-
-    usedLTags[lTag] = coinGroupId;
-    spendMetaInfo[coinGroupId] += 1;
 }
 
 void CSparkState::RemoveSpend(const GroupElement& lTag) {

--- a/src/test/spark_state_test.cpp
+++ b/src/test/spark_state_test.cpp
@@ -147,9 +147,6 @@ BOOST_AUTO_TEST_CASE(lTag_adding)
     BOOST_CHECK(!sparkState->IsUsedLTag(lTag2));
     BOOST_CHECK(!sparkState->IsUsedLTagHash(receivedLTag, lTagHash2));
 
-    // add lTags to group that doesn't exist, should fail
-    BOOST_CHECK_THROW(sparkState->AddSpend(GroupElement(), 100), std::invalid_argument);
-
     sparkState->Reset();
     mempool.clear();
 }


### PR DESCRIPTION
## PR intention
There is a bug that leaves spark state inconsistent when there is a failure to connect a block with more than one spark spend due to lTag being used in the blockchain

## Code changes brief
Check for all the lTags to ensure there is no conflict, only then modify the state
