### PR TITLE
Store test logs after Jenkins run

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,8 +32,10 @@ pipeline {
         }
         stage('Test') {
             steps {
-                dir('dist') {
-                    sh 'make check'
+                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE'){
+                    dir('dist') {
+                        sh 'make check'
+                    }
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,7 +44,7 @@ pipeline {
                 }
             }
         }
-        stage('Archive artifcats') {
+        stage('Archive artifacts') {
             steps {
                 archiveArtifacts artifacts: 'dist/src/test-suite.log',
                 allowEmptyArchive: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,18 +39,18 @@ pipeline {
                 }
             }
         }
+        stage('Archive unit tests logs') {
+            steps {
+                archiveArtifacts artifacts: 'dist/src/test-suite.log',
+                allowEmptyArchive: true
+                }
+        }
         stage('RPC Tests') {
             steps {
                 dir('dist') {
                     sh 'qa/pull-tester/rpc-tests.py -extended'
                 }
             }
-        }
-        stage('Archive artifacts') {
-            steps {
-                archiveArtifacts artifacts: 'dist/src/test-suite.log',
-                allowEmptyArchive: true
-                }
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,5 +44,11 @@ pipeline {
                 }
             }
         }
+        stage('Archive artifcats') {
+            steps {
+                archiveArtifacts artifacts: 'dist/src/test-suite.log',
+                allowEmptyArchive: true
+                }
+        }
     }
 }


### PR DESCRIPTION
Currently Jenkins does not store the output of `make check` (`src/test-suite.log`).

This PR tells Jenkins to retain the unit test results. RPC test results are already stored and displayed.
