### PR TITLE
Fix Windows CI on Github Actions

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -141,7 +141,7 @@ jobs:
       working-directory: ${{ env.SOURCE_ARTIFACT }}
     - name: Build Firo
       run: |
-        ./configure --disable-jni --enable-elysium --prefix=$(realpath depends/x86_64-w64-mingw32)
+        ./configure --without-libs --disable-jni --enable-elysium --prefix=$(realpath depends/x86_64-w64-mingw32)
         make -j$(nproc)
       working-directory: ${{ env.SOURCE_ARTIFACT }}
     - name: Prepare Files for Artifact


### PR DESCRIPTION
Disable building libconsensus for Windows in CI