### PR TITLE
Fix possible state corruption when connecting blocks with lelantus/sigma

### DIFF
--- a/src/sigma.cpp
+++ b/src/sigma.cpp
@@ -643,15 +643,17 @@ bool ConnectBlockSigma(
                     )) {
                 return false;
             }
+        }
 
-            if (!fJustCheck) {
+        if (!fJustCheck) {
+            BOOST_FOREACH(auto& serial, pblock->sigmaTxInfo->spentSerials) {
                 pindexNew->sigmaSpentSerials.insert(serial);
                 sigmaState.AddSpend(serial.first, serial.second.denomination, serial.second.coinGroupId);
             }
         }
-
-        if (fJustCheck)
+        else {
             return true;
+        }
 
         sigmaState.AddMintsToStateAndBlockIndex(pindexNew, pblock);
     }


### PR DESCRIPTION
## PR intention
Fix state corruption

## Code changes brief
When returning of `ConnectBlockSigma` and `ConnectBlockLelantus` make sure not to leave state in undefined state
