### PR TITLE
Speed up AEAD on wrong prekey

### DIFF
--- a/src/libspark/aead.cpp
+++ b/src/libspark/aead.cpp
@@ -48,14 +48,14 @@ AEADEncryptedData AEAD::encrypt(const GroupElement& prekey, const std::string ad
 // NOTE: This uses a fixed zero nonce, which is safe when used in Spark as directed
 // It is NOT safe in general to do this!
 CDataStream AEAD::decrypt_and_verify(const GroupElement& prekey, const std::string additional_data, AEADEncryptedData& data) {
-	// Derive the key and commitment
-	std::vector<unsigned char> key = SparkUtils::kdf_aead(prekey);
-	std::vector<unsigned char> key_commitment = SparkUtils::commit_aead(prekey);
-
 	// Assert that the key commitment is valid
+	std::vector<unsigned char> key_commitment = SparkUtils::commit_aead(prekey);
 	if (key_commitment != data.key_commitment) {
 		throw std::runtime_error("Bad AEAD key commitment");
 	}
+
+	// Derive the key
+	std::vector<unsigned char> key = SparkUtils::kdf_aead(prekey);
 
 	// Set up the result
 	CDataStream result(SER_NETWORK, PROTOCOL_VERSION);


### PR DESCRIPTION
## PR intention
Speeds up AEAD authenticated decryption failure when the wrong prekey is used, which can speed up scanning operations.

## Code changes brief
Currently, AEAD authenticated decryption derives both the key and key commitment before checking if the key commitment is correct. This is wasteful; when scanning outputs, the vast majority will produce the wrong key commitment, so the key is never used.

This PR allows authenticated decryption to fail before deriving the key. This cuts the overall operation time by half.

Note that both the current and proposed designs are _not_ constant-time operations! This means that an adversary with access to a timing side channel can use this information to determine which outputs a user controls.
