### PR TITLE
Check for single-block encrypted diversifier

### DIFF
--- a/src/libspark/util.cpp
+++ b/src/libspark/util.cpp
@@ -36,6 +36,9 @@ uint64_t SparkUtils::diversifier_decrypt(const std::vector<unsigned char>& key, 
     if (key.size() != AES256_KEYSIZE) {
         throw std::invalid_argument("Bad diversifier decryption key size");
     }
+    if (d.size() != AES_BLOCKSIZE) {
+        throw std::invalid_argument("Bad diversifier ciphertext size");
+    }
 
     std::vector<unsigned char> iv;
     iv.resize(AES_BLOCKSIZE);


### PR DESCRIPTION
## PR intention
Checks that encrypted diversifiers occupy only a single AES block.

## Code changes brief
Encrypted diversifiers should only ever occupy a single block. This PR adds a low-level check for this during decryption, and throws an error if needed.