### PR TITLE
Add size and type checks to coin deserialization

### DIFF
--- a/src/libspark/aead.h
+++ b/src/libspark/aead.h
@@ -25,7 +25,7 @@ struct AEADEncryptedData {
 
 		// Key commitment must be the correct size, which also includes an encoded size
 		READWRITE(key_commitment);
-		if (key_commitment.size() != 1 + AEAD_COMMIT_SIZE) {
+		if (key_commitment.size() != AEAD_COMMIT_SIZE) {
 			std::cout << "Bad keycom size " << key_commitment.size() << std::endl;
 			throw std::invalid_argument("Cannot deserialize AEAD data due to bad key commitment size");
 		}

--- a/src/libspark/aead.h
+++ b/src/libspark/aead.h
@@ -15,8 +15,20 @@ struct AEADEncryptedData {
 	template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action) {
         READWRITE(ciphertext);
+
+		// Tag must be the correct size
 		READWRITE(tag);
+		if (tag.size() != AEAD_TAG_SIZE) {
+			std::cout << "Bad tag size " << tag.size() << std::endl;
+			throw std::invalid_argument("Cannot deserialize AEAD data due to bad tag");
+		}
+
+		// Key commitment must be the correct size, which also includes an encoded size
 		READWRITE(key_commitment);
+		if (key_commitment.size() != 1 + AEAD_COMMIT_SIZE) {
+			std::cout << "Bad keycom size " << key_commitment.size() << std::endl;
+			throw std::invalid_argument("Cannot deserialize AEAD data due to bad key commitment size");
+		}
     }
 };
 

--- a/src/libspark/test/aead_test.cpp
+++ b/src/libspark/test/aead_test.cpp
@@ -13,20 +13,28 @@ BOOST_AUTO_TEST_CASE(complete)
     GroupElement prekey;
     prekey.randomize();
 
-    // Serialize
+    // Serialize message
     int message = 12345;
-    CDataStream ser(SER_NETWORK, PROTOCOL_VERSION);
-    ser << message;
+    CDataStream ser_message(SER_NETWORK, PROTOCOL_VERSION);
+    ser_message << message;
 
     // Encrypt
-    AEADEncryptedData data = AEAD::encrypt(prekey, "Associated data", ser);
+    AEADEncryptedData data = AEAD::encrypt(prekey, "Associated data", ser_message);
+
+    // Serialize encrypted data
+    CDataStream ser_data(SER_NETWORK, PROTOCOL_VERSION);
+    ser_data << data;
+
+    // Deserialize encrypted data
+    AEADEncryptedData data_deser;
+    ser_data >> data_deser;
 
     // Decrypt
-    ser = AEAD::decrypt_and_verify(prekey, "Associated data", data);
+    ser_message = AEAD::decrypt_and_verify(prekey, "Associated data", data_deser);
 
     // Deserialize
     int message_;
-    ser >> message_;
+    ser_message >> message_;
 
     BOOST_CHECK_EQUAL(message_, message);
 }

--- a/src/libspark/util.cpp
+++ b/src/libspark/util.cpp
@@ -36,6 +36,9 @@ uint64_t SparkUtils::diversifier_decrypt(const std::vector<unsigned char>& key, 
     if (key.size() != AES256_KEYSIZE) {
         throw std::invalid_argument("Bad diversifier decryption key size");
     }
+    if (d.size() != AES_BLOCKSIZE) {
+        throw std::invalid_argument("Bad diversifier ciphertext size");
+    }
 
     std::vector<unsigned char> iv;
     iv.resize(AES_BLOCKSIZE);


### PR DESCRIPTION
## PR intention
Adds size and type checks during coin deserialization that fail on known bad data.

Closes #1373.

## Code changes brief
Certain aspects of coin data must be checked during deserialization. These include the validity of the coin type (mint or spend) and the size of encrypted recipient data. This PR adds these checks directly into deserializers, and will throw errors on bad data.