### PR TITLE
Fixes for exchange address implementation

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -664,7 +664,7 @@ public:
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector < unsigned char > (1, 65);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector < unsigned char > (1, 178);
-        base58Prefixes[EXCHANGE_PUBKEY_ADDRESS] = {0x01, 0xb9, 0xbb};   // EXT prefix for the address
+        base58Prefixes[EXCHANGE_PUBKEY_ADDRESS] = {0x01, 0xb9, 0xb1};   // EXT prefix for the address
         base58Prefixes[SECRET_KEY] = std::vector < unsigned char > (1, 185);
         base58Prefixes[EXT_PUBLIC_KEY] = boost::assign::list_of(0x04)(0x35)(0x87)(0xCF).convert_to_container < std::vector < unsigned char > > ();
         base58Prefixes[EXT_SECRET_KEY] = boost::assign::list_of(0x04)(0x35)(0x83)(0x94).convert_to_container < std::vector < unsigned char > > ();

--- a/src/spark/sparkwallet.cpp
+++ b/src/spark/sparkwallet.cpp
@@ -1231,7 +1231,7 @@ CWalletTx CSparkWallet::CreateSparkSpendTransaction(
         auto& recipient = recipients[i];
 
         if (recipient.scriptPubKey.IsPayToExchangeAddress()) {
-            throw std::runtime_error("Cannot create private transaction with exchange address as a destination");
+            throw std::runtime_error("Exchange addresses cannot receive private funds. Please transfer your funds to a transparent address first before sending to an Exchange address");
         }
 
         if (!MoneyRange(recipient.nAmount)) {

--- a/src/wallet/lelantusjoinsplitbuilder.cpp
+++ b/src/wallet/lelantusjoinsplitbuilder.cpp
@@ -60,7 +60,7 @@ CWalletTx LelantusJoinSplitBuilder::Build(
         auto& recipient = recipients[i];
 
         if (recipient.scriptPubKey.IsPayToExchangeAddress()) {
-            throw std::runtime_error("Cannot create private transaction with exchange address as a destination");
+            throw std::runtime_error("Exchange addresses cannot receive private funds. Please transfer your funds to a transparent address first before sending to an Exchange address");
         }
 
         if (!MoneyRange(recipient.nAmount)) {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -260,6 +260,8 @@ UniValue getnewexchangeaddress(const JSONRPCRequest& request)
     CBitcoinAddress newAddress;
     newAddress.SetExchange(keyID);
 
+    pwallet->SetAddressBook(newAddress.Get(), "", "receive");
+
     return newAddress.ToString();
 }
 


### PR DESCRIPTION
## PR intention
This PR solves the following issues:
- outputs of transactions sending funds to exchange addresses are treated as change
- `listtransactions` doesn't output exchange address txes
- `gettransaction` can't parse exchange address
- coin control dialog shows exchange addresses in incorrect group
- incorrect prefix for testnet's exchange address

## Code changes brief
`getnewexchangeaddress` now properly adds generated address to the wallet's address book