### PR TITLE
Add size and type checks to coin deserialization

### DIFF
--- a/src/libspark/aead.h
+++ b/src/libspark/aead.h
@@ -25,7 +25,7 @@ struct AEADEncryptedData {
 
 		// Key commitment must be the correct size, which also includes an encoded size
 		READWRITE(key_commitment);
-		if (key_commitment.size() != 1 + AEAD_COMMIT_SIZE) {
+		if (key_commitment.size() != AEAD_COMMIT_SIZE) {
 			std::cout << "Bad keycom size " << key_commitment.size() << std::endl;
 			throw std::invalid_argument("Cannot deserialize AEAD data due to bad key commitment size");
 		}

--- a/src/libspark/aead.h
+++ b/src/libspark/aead.h
@@ -15,8 +15,20 @@ struct AEADEncryptedData {
 	template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action) {
         READWRITE(ciphertext);
+
+		// Tag must be the correct size
 		READWRITE(tag);
+		if (tag.size() != AEAD_TAG_SIZE) {
+			std::cout << "Bad tag size " << tag.size() << std::endl;
+			throw std::invalid_argument("Cannot deserialize AEAD data due to bad tag");
+		}
+
+		// Key commitment must be the correct size, which also includes an encoded size
 		READWRITE(key_commitment);
+		if (key_commitment.size() != 1 + AEAD_COMMIT_SIZE) {
+			std::cout << "Bad keycom size " << key_commitment.size() << std::endl;
+			throw std::invalid_argument("Cannot deserialize AEAD data due to bad key commitment size");
+		}
     }
 };
 

--- a/src/libspark/mint_transaction.cpp
+++ b/src/libspark/mint_transaction.cpp
@@ -42,10 +42,10 @@ MintTransaction::MintTransaction(
             value_statement.emplace_back(this->coins[j].C + this->params->get_G().inverse()*Scalar(this->coins[j].v));
             value_witness.emplace_back(SparkUtils::hash_val(k));
         } else {
-            Coin coin;
+            Coin coin(params);
             coin.type = 0;
             coin.r_.ciphertext.resize(82); // max possible size
-            coin.r_.key_commitment.resize(64);
+            coin.r_.key_commitment.resize(32);
             coin.r_.tag.resize(16);
             coin.v = 0;
             this->coins.emplace_back(coin);

--- a/src/libspark/test/aead_test.cpp
+++ b/src/libspark/test/aead_test.cpp
@@ -13,20 +13,28 @@ BOOST_AUTO_TEST_CASE(complete)
     GroupElement prekey;
     prekey.randomize();
 
-    // Serialize
+    // Serialize message
     int message = 12345;
-    CDataStream ser(SER_NETWORK, PROTOCOL_VERSION);
-    ser << message;
+    CDataStream ser_message(SER_NETWORK, PROTOCOL_VERSION);
+    ser_message << message;
 
     // Encrypt
-    AEADEncryptedData data = AEAD::encrypt(prekey, "Associated data", ser);
+    AEADEncryptedData data = AEAD::encrypt(prekey, "Associated data", ser_message);
+
+    // Serialize encrypted data
+    CDataStream ser_data(SER_NETWORK, PROTOCOL_VERSION);
+    ser_data << data;
+
+    // Deserialize encrypted data
+    AEADEncryptedData data_deser;
+    ser_data >> data_deser;
 
     // Decrypt
-    ser = AEAD::decrypt_and_verify(prekey, "Associated data", data);
+    ser_message = AEAD::decrypt_and_verify(prekey, "Associated data", data_deser);
 
     // Deserialize
     int message_;
-    ser >> message_;
+    ser_message >> message_;
 
     BOOST_CHECK_EQUAL(message_, message);
 }

--- a/src/libspark/util.cpp
+++ b/src/libspark/util.cpp
@@ -36,6 +36,9 @@ uint64_t SparkUtils::diversifier_decrypt(const std::vector<unsigned char>& key, 
     if (key.size() != AES256_KEYSIZE) {
         throw std::invalid_argument("Bad diversifier decryption key size");
     }
+    if (d.size() != AES_BLOCKSIZE) {
+        throw std::invalid_argument("Bad diversifier ciphertext size");
+    }
 
     std::vector<unsigned char> iv;
     iv.resize(AES_BLOCKSIZE);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -630,7 +630,9 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
         {
             if (txout.scriptPubKey.IsSparkMint() || txout.scriptPubKey.IsSparkSMint()) {
                 try {
-                    spark::Coin txCoin;
+                    const spark::Params* params = spark::Params::get_default();
+
+                    spark::Coin txCoin(params);
                     spark::ParseSparkMintCoin(txout.scriptPubKey, txCoin);
                     sparkState.RemoveMintFromMempool(txCoin);
                 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3360,7 +3360,9 @@ void static RemoveConflictingPrivacyTransactionsFromMempool(const CBlock &block)
 
             if (txout.scriptPubKey.IsSparkMint() || txout.scriptPubKey.IsSparkSMint()) {
                 try {
-                    spark::Coin txCoin;
+                    const spark::Params* params = spark::Params::get_default();
+
+                    spark::Coin txCoin(params);
                     spark::ParseSparkMintCoin(txout.scriptPubKey, txCoin);
                     sparkState->RemoveMintFromMempool(txCoin);
                 } catch (std::invalid_argument&) {


### PR DESCRIPTION
PR intention
Adds size and type checks during coin deserialization that fail on known bad data.

Closes https://github.com/firoorg/firo/issues/1373.

Code changes brief
Certain aspects of coin data must be checked during deserialization. These include the validity of the coin type (mint or spend) and the size of encrypted recipient data. This PR adds these checks directly into deserializers, and will throw errors on bad data.