### PR TITLE
Unpad memos

### DIFF
--- a/src/libspark/params.cpp
+++ b/src/libspark/params.cpp
@@ -17,7 +17,7 @@ Params const* Params::get_default() {
             return instance.get();
         }
 
-        std::size_t memo_bytes = 32;
+        std::size_t memo_bytes = 31; // 32 bytes after length prepending!
         std::size_t max_M_range = 16;
         std::size_t n_grootle = 8;
         std::size_t m_grootle = 5;
@@ -37,7 +37,7 @@ Params const* Params::get_test() {
             return instance.get();
         }
 
-        std::size_t memo_bytes = 32;
+        std::size_t memo_bytes = 31; // 32 bytes after length prepending!
         std::size_t max_M_range = 16;
         std::size_t n_grootle = 2;
         std::size_t m_grootle = 4;

--- a/src/libspark/params.h
+++ b/src/libspark/params.h
@@ -50,7 +50,7 @@ private:
     GroupElement U;
 
     // Coin parameters
-    std::size_t memo_bytes;
+    std::size_t memo_bytes; // This MUST NOT exceed 256, since the length is encoded to 8 bits
 
     // Range proof parameters
     std::size_t max_M_range;

--- a/src/libspark/test/coin_test.cpp
+++ b/src/libspark/test/coin_test.cpp
@@ -28,7 +28,8 @@ BOOST_AUTO_TEST_CASE(mint_identify_recover)
     
     const uint64_t i = 12345;
     const uint64_t v = 86;
-    const std::string memo = "Spam and eggs";
+    const std::string memo = "Spam and eggs are a tasty dish!"; // maximum length
+    BOOST_CHECK_EQUAL(memo.size(), params->get_memo_bytes());
 
     // Generate keys
     SpendKey spend_key(params);
@@ -57,8 +58,8 @@ BOOST_AUTO_TEST_CASE(mint_identify_recover)
     BOOST_CHECK_EQUAL_COLLECTIONS(i_data.d.begin(), i_data.d.end(), address.get_d().begin(), address.get_d().end());
     BOOST_CHECK_EQUAL(i_data.v, v);
     BOOST_CHECK_EQUAL(i_data.k, k);
-    BOOST_CHECK_EQUAL(strcmp(memo.c_str(), i_data.memo.c_str()), 0); // compare strings in a lexicographical manner, as we pad the memo in the coin
-    BOOST_CHECK_EQUAL(i_data.memo.size(), params->get_memo_bytes()); // check that it is padded
+    BOOST_CHECK_EQUAL(i_data.memo, memo);
+
     // Recover coin
     RecoveredCoinData r_data = coin.recover(full_view_key, i_data);
     BOOST_CHECK_EQUAL(
@@ -105,8 +106,7 @@ BOOST_AUTO_TEST_CASE(spend_identify_recover)
     BOOST_CHECK_EQUAL_COLLECTIONS(i_data.d.begin(), i_data.d.end(), address.get_d().begin(), address.get_d().end());
     BOOST_CHECK_EQUAL(i_data.v, v);
     BOOST_CHECK_EQUAL(i_data.k, k);
-    BOOST_CHECK_EQUAL(strcmp(memo.c_str(), i_data.memo.c_str()), 0); // compare strings in a lexicographical manner, as we pad the memo in the coin
-    BOOST_CHECK_EQUAL(i_data.memo.size(), params->get_memo_bytes()); // check that it is padded
+    BOOST_CHECK_EQUAL(i_data.memo, memo);
 
     // Recover coin
     RecoveredCoinData r_data = coin.recover(full_view_key, i_data);


### PR DESCRIPTION
When a recipient decrypts a memo during coin identification, the memo is still padded, which is poor user experience.

This PR includes the memo length as part of encrypted recipient data, and removes the padding during coin identification. This ensures that the original unpadded memo is provided to the recipient.

Closes #1380.