### PR TITLE
Add a warning about AEAD use

### DIFF
--- a/src/libspark/aead.cpp
+++ b/src/libspark/aead.cpp
@@ -3,6 +3,8 @@
 namespace spark {
 
 // Perform authenticated encryption with ChaCha20-Poly1305 using key commitment
+// NOTE: This uses a fixed zero nonce, which is safe when used in Spark as directed
+// It is NOT safe in general to do this!
 AEADEncryptedData AEAD::encrypt(const GroupElement& prekey, const std::string additional_data, CDataStream& data) {
 	// Set up the result structure
 	AEADEncryptedData result;
@@ -43,6 +45,8 @@ AEADEncryptedData AEAD::encrypt(const GroupElement& prekey, const std::string ad
 }
 
 // Perform authenticated decryption with ChaCha20-Poly1305 using key commitment
+// NOTE: This uses a fixed zero nonce, which is safe when used in Spark as directed
+// It is NOT safe in general to do this!
 CDataStream AEAD::decrypt_and_verify(const GroupElement& prekey, const std::string additional_data, AEADEncryptedData& data) {
 	// Derive the key and commitment
 	std::vector<unsigned char> key = SparkUtils::kdf_aead(prekey);


### PR DESCRIPTION
## PR intention
Adds a warning to Spark AEAD code.

## Code changes brief
Spark uses an AEAD for encrypting recipient data. For this purpose, it's safe and efficient to use a fixed zero nonce. However, this is not safe for broader use.

This PR adds a scary warning.