### PR TITLE
Harden Schnorr/Chaum proofs

### DIFF
--- a/src/libspark/chaum.cpp
+++ b/src/libspark/chaum.cpp
@@ -93,6 +93,11 @@ bool Chaum::verify(
     if (!(T.size() == n && proof.A2.size() == n && proof.t1.size() == n)) {
         throw std::invalid_argument("Bad Chaum semantics!");
     }
+    for (std::size_t i = 0; i < n; i++) {
+        if (S[i].isInfinity()) {
+            throw std::invalid_argument("Bad Chaum input!");
+        }
+    }
 
     Scalar c = challenge(mu, S, T, proof.A1, proof.A2);
     if (c.isZero()) {

--- a/src/libspark/schnorr.cpp
+++ b/src/libspark/schnorr.cpp
@@ -64,6 +64,12 @@ bool Schnorr::verify(const GroupElement& Y, const SchnorrProof& proof) {
 bool Schnorr::verify(const std::vector<GroupElement>& Y, const SchnorrProof& proof) {
     const std::size_t n = Y.size();
 
+    for (std::size_t i = 0; i < n; i++) {
+        if (Y[i].isInfinity()) {
+            throw std::invalid_argument("Bad Schnorr input key!");
+        }
+    }
+
     std::vector<GroupElement> points;
     points.reserve(n + 2);
     std::vector<Scalar> scalars;


### PR DESCRIPTION
## PR intention
Hardens Schnorr and Chaum proof verification in Spark transactions.

## Code changes brief
Input keys in Schnorr and Chaum proofs ought not to be zero. This PR ensures these things don't happen.