### PR TITLE
Update binding hash function signature

### DIFF
--- a/src/libspark/spend_transaction.cpp
+++ b/src/libspark/spend_transaction.cpp
@@ -409,6 +409,8 @@ bool SpendTransaction::verify(
 // Hash function H_bind_inner
 // This function pre-hashes auxiliary data that makes things easier for a limited signer who cannot process the data directly
 // Its value is then used as part of the binding hash, which a limited signer can verify as part of the signing process
+// 
+// Note that transparent components of the transaction are bound into `cover_set_representation`, so they don't appear separately.
 std::vector<unsigned char> SpendTransaction::hash_bind_inner(
 	const std::unordered_map<uint64_t, std::vector<unsigned char>>& cover_set_representations,
 	const std::vector<GroupElement>& S1,

--- a/src/libspark/spend_transaction.cpp
+++ b/src/libspark/spend_transaction.cpp
@@ -178,7 +178,9 @@ SpendTransaction::SpendTransaction(
 	Scalar mu = hash_bind(
 		hash_bind_inner(
 			this->cover_set_representations,
+			this->S1,
 			this->C1,
+			this->T,
 			this->grootle_proofs,
 			this->balance_proof,
 			this->range_proof
@@ -293,9 +295,11 @@ bool SpendTransaction::verify(
 
 		// Compute the binding hash
 		Scalar mu = hash_bind(
-			tx.hash_bind_inner(
+			hash_bind_inner(
 				tx.cover_set_representations,
+				tx.S1,
 				tx.C1,
+				tx.T,
 				tx.grootle_proofs,
 				tx.balance_proof,
 				tx.range_proof
@@ -407,7 +411,9 @@ bool SpendTransaction::verify(
 // Its value is then used as part of the binding hash, which a limited signer can verify as part of the signing process
 std::vector<unsigned char> SpendTransaction::hash_bind_inner(
 	const std::unordered_map<uint64_t, std::vector<unsigned char>>& cover_set_representations,
+	const std::vector<GroupElement>& S1,
 	const std::vector<GroupElement>& C1,
+	const std::vector<GroupElement>& T,
 	const std::vector<GrootleProof>& grootle_proofs,
 	const SchnorrProof& balance_proof,
 	const BPPlusProof& range_proof

--- a/src/libspark/spend_transaction.h
+++ b/src/libspark/spend_transaction.h
@@ -60,9 +60,11 @@ public:
 	static bool verify(const Params* params, const std::vector<SpendTransaction>& transactions, const std::unordered_map<uint64_t, std::vector<Coin>>& cover_sets);
 	static bool verify(const SpendTransaction& transaction, const std::unordered_map<uint64_t, std::vector<Coin>>& cover_sets);
     
-	std::vector<unsigned char> hash_bind_inner(
+	static std::vector<unsigned char> hash_bind_inner(
 		const std::unordered_map<uint64_t, std::vector<unsigned char>>& cover_set_representations,
+        const std::vector<GroupElement>& S1,
         const std::vector<GroupElement>& C1,
+        const std::vector<GroupElement>& T,
         const std::vector<GrootleProof>& grootle_proofs,
         const SchnorrProof& balance_proof,
 		const BPPlusProof& range_proof


### PR DESCRIPTION
## PR intention
Updates `SpendTransaction::hash_bind_inner` to make it static and take `S1` and `T` as arguments.

## Code changes brief
Previously, the function in question was not static, and inferred `S1` and `T` from the object. This was inconsistent and had a bad code smell.

This PR makes the function static and is explicit about all fields used in the hash.