### PR TITLE
Spork for managing Spark functionality

### DIFF
--- a/src/evo/spork.h
+++ b/src/evo/spork.h
@@ -17,6 +17,8 @@ struct CSporkAction
     static constexpr const char *featureLelantusTransparentLimit = "lelantustransparentlimit";
     static constexpr const char *featureChainlocks = "chainlocks";
     static constexpr const char *featureInstantSend = "instantsend";
+    static constexpr const char *featureSpark = "spark";
+    static constexpr const char *featureSparkTransparentLimit = "sparktransparentlimit";
 
     enum ActionType {
         sporkDisable = 1,

--- a/src/miner.h
+++ b/src/miner.h
@@ -232,6 +232,11 @@ private:
 
     /** Fill txBlackList set */
     void FillBlackListForBlockTemplate();
+
+    /** Ensure spark/lelantus txs don't exceed specific limit */
+    void BlacklistTxsExceedingLimit(CAmount limit,
+                                    std::function<bool (const CTransaction &)> txTypeFilter,
+                                    std::function<CAmount (const CTransaction &)> txAmount);
 };
 
 /** Modify the extranonce in a block */

--- a/src/rpc/rpcevo.cpp
+++ b/src/rpc/rpcevo.cpp
@@ -1405,7 +1405,9 @@ UniValue spork(const JSONRPCRequest& request)
         CSporkAction::featureLelantus,
         CSporkAction::featureChainlocks,
         CSporkAction::featureInstantSend,
-        CSporkAction::featureLelantusTransparentLimit
+        CSporkAction::featureLelantusTransparentLimit,
+        CSporkAction::featureSpark,
+        CSporkAction::featureSparkTransparentLimit
     };
 
     for (const CSporkAction &action: sporkTx.actions) {

--- a/src/test/evospork_tests.cpp
+++ b/src/test/evospork_tests.cpp
@@ -448,6 +448,7 @@ struct SparkSporkTestingSetup : public SparkTestingSetup
 
     ~SparkSporkTestingSetup() {
         mutableParams = originalParams;
+        spark::CSparkState::GetState()->Reset();
     }
 
 };

--- a/src/test/evospork_tests.cpp
+++ b/src/test/evospork_tests.cpp
@@ -442,6 +442,8 @@ struct SparkSporkTestingSetup : public SparkTestingSetup
 
     SparkSporkTestingSetup() : SparkTestingSetup(), mutableParams(const_cast<Consensus::Params&>(Params().GetConsensus()))
     {
+        spark::CSparkState::GetState()->Reset();
+        mempool.clear();
         originalParams = mutableParams;
         mutableParams.nEvoSporkStopBlock = 2000;
     }
@@ -449,6 +451,7 @@ struct SparkSporkTestingSetup : public SparkTestingSetup
     ~SparkSporkTestingSetup() {
         mutableParams = originalParams;
         spark::CSparkState::GetState()->Reset();
+        mempool.clear();
     }
 
 };

--- a/src/test/evospork_tests.cpp
+++ b/src/test/evospork_tests.cpp
@@ -593,13 +593,8 @@ BOOST_AUTO_TEST_CASE(limit)
 
     auto params = spark::Params::get_default();
 
-    // Generate keys
-    const spark::SpendKey spend_key(params);
-    const spark::FullViewKey full_view_key(spend_key);
-    const spark::IncomingViewKey incoming_view_key(full_view_key);
-
-    // Generate address
-    const spark::Address address(incoming_view_key, 12345);
+    BOOST_ASSERT(pwalletMain->sparkWallet);
+    spark::Address address = pwalletMain->sparkWallet->generateNewAddress();
 
     std::vector<CMutableTransaction> sparkMints;
     for (int i=0; i<10; i++) {

--- a/src/test/evospork_tests.cpp
+++ b/src/test/evospork_tests.cpp
@@ -433,3 +433,255 @@ BOOST_AUTO_TEST_CASE(startstopblock)
 
 
 BOOST_AUTO_TEST_SUITE_END()
+
+// Extend spork stop block to 2000
+struct SparkSporkTestingSetup : public SparkTestingSetup
+{
+    Consensus::Params &mutableParams;
+    Consensus::Params originalParams;
+
+    SparkSporkTestingSetup() : SparkTestingSetup(), mutableParams(const_cast<Consensus::Params&>(Params().GetConsensus()))
+    {
+        originalParams = mutableParams;
+        mutableParams.nEvoSporkStopBlock = 2000;
+    }
+
+    ~SparkSporkTestingSetup() {
+        mutableParams = originalParams;
+    }
+
+};
+
+BOOST_FIXTURE_TEST_SUITE(evospork_spark_tests, SparkSporkTestingSetup)
+
+BOOST_AUTO_TEST_CASE(general)
+{
+    int prevHeight;
+    pwalletMain->SetBroadcastTransactions(true);
+
+    for (int n=chainActive.Height(); n<1000; n++)
+        GenerateBlock({});
+
+    auto utxos = BuildSimpleUtxoMap(coinbaseTxns);
+    CMutableTransaction sporkTx1 = CreateSporkTx(utxos, coinbaseKey, {
+        {CSporkAction::sporkDisable, CSporkAction::featureSpark, 0, 1075}
+    });
+    CMutableTransaction sporkTx2 = CreateSporkTx(utxos, coinbaseKey, {
+        {CSporkAction::sporkDisable, CSporkAction::featureSpark, 0, 1085}
+    });
+    CMutableTransaction sporkTx3 = CreateSporkTx(utxos, coinbaseKey, {
+        {CSporkAction::sporkEnable, CSporkAction::featureSpark, 0, 0}
+    });
+
+    prevHeight = chainActive.Height();
+    GenerateBlock({sporkTx1});
+    // spork should be accepted
+    BOOST_ASSERT(chainActive.Height() == prevHeight+1);
+
+    std::vector<CMutableTransaction> sparkMints;
+    GenerateMints({1*COIN, 2*COIN}, sparkMints);
+
+    prevHeight = chainActive.Height();
+    GenerateBlock(sparkMints);
+    // can't accept spark tx after spark
+    BOOST_ASSERT(chainActive.Height() == prevHeight);
+
+    // wait until the spork expires
+    for (int n=chainActive.Height(); n<1075; n++)
+        GenerateBlock({});
+    prevHeight = chainActive.Height();
+    GenerateBlock({sparkMints[0]});
+    BOOST_ASSERT(chainActive.Height() == prevHeight+1);
+
+    // another disabling spork
+    GenerateBlock({sporkTx2});
+    // ensure lelantus is disabled
+    prevHeight = chainActive.Height();
+    GenerateBlock({sparkMints[1]});
+    BOOST_ASSERT(chainActive.Height() == prevHeight);
+
+    // block with enabling spork
+    GenerateBlock({sporkTx3});
+    // ensure lelantus is enabled now
+    prevHeight = chainActive.Height();
+    GenerateBlock({sparkMints[1]});
+    BOOST_ASSERT(chainActive.Height() == prevHeight+1);
+}
+
+BOOST_AUTO_TEST_CASE(mempool)
+{
+    int prevHeight;
+    pwalletMain->SetBroadcastTransactions(true);
+
+    for (int n=chainActive.Height(); n<1000; n++)
+        GenerateBlock({});
+
+    auto utxos = BuildSimpleUtxoMap(coinbaseTxns);
+    CMutableTransaction sporkTx1 = CreateSporkTx(utxos, coinbaseKey, {
+        {CSporkAction::sporkDisable, CSporkAction::featureSpark, 0, 1075}
+    });
+    CMutableTransaction sporkTx2 = CreateSporkTx(utxos, coinbaseKey, {
+        {CSporkAction::sporkDisable, CSporkAction::featureSpark, 0, 1085}
+    });
+
+    std::vector<CMutableTransaction> sparkMints;
+    GenerateMints({1*COIN, 2*COIN}, sparkMints);
+    ::mempool.removeRecursive(sparkMints[0]);
+    ::mempool.removeRecursive(sparkMints[1]);
+
+    CBlock blockWithSparkMint = CreateBlock({sparkMints[0]}, coinbaseKey);
+
+    // put one mint into the mempool
+    CommitToMempool(sparkMints[0]);
+    BOOST_ASSERT(::mempool.size() == 1);
+
+    // push spork to mempool
+    CommitToMempool(sporkTx1);
+    // spork should be in the mempool, spark mint should be pushed out of it
+    BOOST_ASSERT(::mempool.size() == 1);
+    BOOST_ASSERT(::mempool.exists(sporkTx1.GetHash()) && !::mempool.exists(sparkMints[0].GetHash()));
+
+    // another spark tx shouldn't get to the mempool
+    CommitToMempool(sparkMints[1]);
+    BOOST_ASSERT(::mempool.size() == 1);
+
+    // but should be accepted in block
+    prevHeight = chainActive.Height();
+    ProcessNewBlock(Params(), std::make_shared<CBlock>(blockWithSparkMint), true, nullptr);
+    BOOST_ASSERT(chainActive.Height() == prevHeight+1);
+
+    // mine spork into the block
+    CreateAndProcessBlock({sporkTx1}, coinbaseKey);
+    // mempool should clear
+    BOOST_ASSERT(::mempool.size() == 0);
+
+    // because there is active spork at the tip spark mint shouldn't get into the mempool
+    BOOST_ASSERT(!CommitToMempool(sparkMints[1]));
+
+    for (int n=chainActive.Height(); n<1075; n++)
+        CreateAndProcessBlock({}, coinbaseKey);
+
+    // spork expired, should accept now
+    BOOST_ASSERT(CommitToMempool(sparkMints[1]));
+    // try and generate a block with second spork without it ever entering the mempool
+    CreateAndProcessBlock({sporkTx2}, coinbaseKey);
+    // now we have a mint in the mempool and active spork. Verify that miner correctly blocks the mint
+    // from being mined
+    fAllowMempoolTxsInCreateBlock = true;
+    CBlock block = CreateBlock({}, coinbaseKey);
+    for (CTransactionRef tx: block.vtx) {
+        BOOST_ASSERT(!tx->IsSparkTransaction());
+    }
+    BOOST_ASSERT(::mempool.exists(sparkMints[1].GetHash()));
+    prevHeight = chainActive.Height();
+    ProcessNewBlock(Params(), std::make_shared<CBlock>(block), true, nullptr);
+    BOOST_CHECK_EQUAL(chainActive.Height(), prevHeight+1);
+}
+
+BOOST_AUTO_TEST_CASE(limit)
+{
+    int prevHeight;
+    pwalletMain->SetBroadcastTransactions(true);
+
+    for (int n=chainActive.Height(); n<1000; n++)
+        GenerateBlock({});
+
+    auto utxos = BuildSimpleUtxoMap(coinbaseTxns);
+    CMutableTransaction sporkTx1 = CreateSporkTx(utxos, coinbaseKey, {
+        {CSporkAction::sporkLimit, CSporkAction::featureSparkTransparentLimit, 100*COIN, 1050}
+    });
+
+    auto params = spark::Params::get_default();
+
+    // Generate keys
+    const spark::SpendKey spend_key(params);
+    const spark::FullViewKey full_view_key(spend_key);
+    const spark::IncomingViewKey incoming_view_key(full_view_key);
+
+    // Generate address
+    const spark::Address address(incoming_view_key, 12345);
+
+    std::vector<CMutableTransaction> sparkMints;
+    for (int i=0; i<10; i++) {
+        std::vector<std::pair<CWalletTx, CAmount>> wtxAndFee;
+        std::vector<spark::MintedCoinData> mints{{address, 50*COIN, ""}};
+        std::string error = pwalletMain->MintAndStoreSpark(mints, wtxAndFee, false);
+        BOOST_ASSERT(error.empty());
+        for (auto &w: wtxAndFee)
+            sparkMints.emplace_back(*w.first.tx);
+    }
+
+    GenerateBlock(sparkMints);
+
+    for (int i=0; i<10; i++)
+        GenerateBlock({});
+
+    CAmount fee = 0;
+    CWalletTx spendWalletTx = pwalletMain->SpendAndStoreSpark({{script, 120*COIN, false, ""}}, {}, fee);
+
+    CMutableTransaction spendTx = *spendWalletTx.tx;
+
+    ::mempool.removeRecursive(spendWalletTx);
+
+    auto sparkSpend = spark::ParseSparkSpend(spendTx);
+    std::vector<GroupElement> lTags = sparkSpend.getUsedLTags();
+
+    // generate two smaller spark spend txs
+    CWalletTx smallSparkWalletTxs[2] = {
+        pwalletMain->SpendAndStoreSpark({{script, 70*COIN, false, ""}}, {}, fee),
+        pwalletMain->SpendAndStoreSpark({{script, 70*COIN, false, ""}}, {}, fee),
+    };
+
+    CMutableTransaction smallSparkTxs[2] = {*smallSparkWalletTxs[0].tx, *smallSparkWalletTxs[1].tx};
+
+    CommitToMempool(sporkTx1);
+    BOOST_ASSERT(::mempool.size() == 3);    // two small spark spends and spork
+
+    fAllowMempoolTxsInCreateBlock = true;
+    CBlock block = CreateBlock({}, script);
+    // should only have one spark spend transaction in the block
+    int nSparkSpends = 0;
+    for (CTransactionRef ptx: block.vtx) {
+        if (ptx->IsSparkSpend())
+            nSparkSpends++;
+    }
+    BOOST_ASSERT(nSparkSpends == 1);
+    prevHeight = chainActive.Height();
+    ProcessNewBlock(Params(), std::make_shared<CBlock>(block), true, nullptr);
+    BOOST_ASSERT(chainActive.Height() == prevHeight+1);
+    // one spark spend should be left at the mempool
+    BOOST_ASSERT(::mempool.size() == 1);
+
+    // mine remaining spark spend into the block
+    prevHeight = chainActive.Height();
+    GenerateBlock({});
+    BOOST_ASSERT(chainActive.Height() == prevHeight+1);
+    BOOST_ASSERT(::mempool.size() == 0);
+    fAllowMempoolTxsInCreateBlock = false;
+
+    // large spark spend tx is out of range, should fail now
+    BOOST_ASSERT(!CommitToMempool(spendTx));
+    // should fail in block as well
+    prevHeight = chainActive.Height();
+    GenerateBlock({spendTx});
+    BOOST_ASSERT(chainActive.Height() == prevHeight);
+
+    // skip to 1050 (spork expiration block)
+    for (int n=chainActive.Height(); n<1050; n++)
+        GenerateBlock({});
+
+    // should be accepted into the mempool
+    BOOST_ASSERT(CommitToMempool(spendTx));
+    // and be mined into the block
+    prevHeight = chainActive.Height();
+    GenerateBlock({spendTx});
+    BOOST_ASSERT(chainActive.Height() == prevHeight+1);
+    // mempool should be clear
+    BOOST_ASSERT(::mempool.size() == 0);
+    // lTags should go into the state
+    spark::CSparkState *sparkState = spark::CSparkState::GetState();
+    for (const GroupElement &lTag : lTags)
+        BOOST_ASSERT(sparkState->IsUsedLTag(lTag));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -186,10 +186,12 @@ CBlock TestChain100Setup::CreateBlock(const std::vector<CMutableTransaction>& tx
     }
 
     // Replace mempool-selected txns with just coinbase plus passed-in txns:
-    if (!fAllowMempoolTxsInCreateBlock)
+    if (!fAllowMempoolTxsInCreateBlock) {
         block.vtx.resize(1);
-    // Re-add quorum commitments
-    block.vtx.insert(block.vtx.end(), llmqCommitments.begin(), llmqCommitments.end());
+        // Re-add quorum commitments
+        block.vtx.insert(block.vtx.end(), llmqCommitments.begin(), llmqCommitments.end());
+    }
+    
     BOOST_FOREACH(const CMutableTransaction& tx, txns)
         block.vtx.push_back(MakeTransactionRef(tx));
 


### PR DESCRIPTION
## PR intention
Introduction of `spark` and `sparktransparentlimit` sporks to manage spark transactions

## Code changes brief
Extends existing lelantus spork code to support spark
