### PR TITLE
Fix bug creating large spark spend tx

### DIFF
--- a/src/spark/sparkwallet.cpp
+++ b/src/spark/sparkwallet.cpp
@@ -1525,9 +1525,6 @@ CWalletTx CSparkWallet::CreateSparkSpendTransaction(
                 i++;
             }
 
-            // check fee
-            wtxNew.SetTx(MakeTransactionRef(std::move(tx)));
-
             if (GetTransactionWeight(tx) >= MAX_NEW_TX_WEIGHT) {
                 throw std::runtime_error(_("Transaction too large"));
             }
@@ -1546,6 +1543,8 @@ CWalletTx CSparkWallet::CreateSparkSpendTransaction(
                 throw std::invalid_argument(_("Not enough fee estimated"));
             }
 
+            wtxNew.SetTx(MakeTransactionRef(std::move(tx)));
+            
             result.push_back(wtxNew);
         }
     }


### PR DESCRIPTION
`GetTransactionWeight(tx) >= MAX_NEW_TX_WEIGHT` this check should be true and tx creation will fail in case tx size is bigger then 130,000 byte, MAX_NEW_TX_WEIGHT is defined as 520000 and weight is calculated actual tx size * 4, 