### PR TITLE
Removed checks slowing down spark

### DIFF
--- a/src/libspark/grootle.cpp
+++ b/src/libspark/grootle.cpp
@@ -413,16 +413,6 @@ bool Grootle::verify(
         return false;
     }
 
-    // Check for zero inputs
-    for (std::size_t t = 0; t < S1.size(); t++) {
-        for (std::size_t i = 0; i < S.size(); i++) {
-            if (S[i] == S1[t] || V[i] == V1[t]) {
-                LogPrintf("Invalid offset commitment");
-                return false;
-            }
-        }
-    }
-
     // Check proof semantics
     for (std::size_t t = 0; t < M; t++) {
         GrootleProof proof = proofs[t];


### PR DESCRIPTION
In this PR [1387](https://github.com/firoorg/firo/pull/1387) a nested loop was added to harden grootle proof verification,
it does equality checks like  2 * 16k * 16k times,