### PR TITLE
Allow `validateaddress` to print `hdkeypath` information for exchange addresses

### DIFF
--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -320,6 +320,17 @@ bool CBitcoinAddress::GetKeyID(CKeyID& keyID) const
     return true;
 }
 
+bool CBitcoinAddress::GetKeyIDExt(CKeyID& keyID) const
+{
+    if (!IsValid() || !(vchVersion == Params().Base58Prefix(CChainParams::PUBKEY_ADDRESS) ||
+                        vchVersion == Params().Base58Prefix(CChainParams::EXCHANGE_PUBKEY_ADDRESS)))
+        return false;
+    uint160 id;
+    memcpy(&id, &vchData[0], 20);
+    keyID = CKeyID(id);
+    return true;
+}
+
 bool CBitcoinAddress::IsScript() const
 {
     return IsValid() && vchVersion == Params().Base58Prefix(CChainParams::SCRIPT_ADDRESS);

--- a/src/base58.h
+++ b/src/base58.h
@@ -127,6 +127,7 @@ public:
     CTxDestination Get() const;
     bool GetIndexKey(uint160& hashBytes, AddressType & type) const;
     bool GetKeyID(CKeyID &keyID) const;
+    bool GetKeyIDExt(CKeyID &keyID) const; // same as GetKeyID() but also works in case of exchange address
     bool IsScript() const;
 };
 

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -233,7 +233,7 @@ UniValue validateaddress(const JSONRPCRequest& request)
         CKeyID keyID;
         if (pwallet) {
             const auto& meta = pwallet->mapKeyMetadata;
-            auto it = address.GetKeyID(keyID) ? meta.find(keyID) : meta.end();
+            auto it = address.GetKeyIDExt(keyID) ? meta.find(keyID) : meta.end();
             if (it == meta.end()) {
                 it = meta.find(CScriptID(scriptPubKey));
             }


### PR DESCRIPTION
## PR intention
Print more extended information if the input is an exchange address

## Code changes brief
Additional member of `CBitcoinAddress` class called `GetKeyIDExt` is introduced and used in `validateaddress` RPC call
