### PR TITLE
add org.firo.firo-qt.metainfo.xml for flathub

### DIFF
--- a/contrib/flathub/org.firo.firo-qt.metainfo.xml
+++ b/contrib/flathub/org.firo.firo-qt.metainfo.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>org.firo.firo-qt</id>
+  <name>Firo</name>
+  <metadata_license>MIT</metadata_license>
+  <project_license>MIT</project_license>
+  <summary>
+    Fully validating Firo peer-to-peer network node, wallet and graphical interface
+  </summary>
+  <url type="homepage">
+    https://firo.org/
+  </url>
+  <url type="bugtracker">
+    https://github.com/firoorg/firo/issues/new?title=[flatpak]
+  </url>
+  <launchable type="desktop-id">
+    org.firo.firo-qt.desktop
+  </launchable>
+  <description>
+    <p>Firo is a privacy preserving cryptocurrency and ecosystem. Firo believes in the importance of financial privacy in cryptocurrency as an essential element in maintaining the original goal of cryptocurrency: to be a public utility for money. 
+    We have seen how freedom of commerce or even access to our savings are things that are no longer things that can be taken for granted and authoritarian governments have increasingly used money as a tool of control.</p>
+
+    <p>As fiat currencies go increasingly digital with some going as far as totally replacing physical cash, we lose control over our own money instead relying on intermediaries. 
+    Bitcoin was originally created as an answer to this by ensuring you can be self sovereign over your money and to serve as uncensorable and unseizable money that isn't controlled by any one entity.</p>
+
+    <p>Bitcoin's lack of privacy however has now made it much easier to seize or blacklist funds and due to ossification of the protocol, is unlikely to take serious steps to address this.
+    Firo has dedicated itself to being a privacy preserving cryptocurrency and have designed and built trustless privacy protocols such as Lelantus and Lelantus Spark that have inspired and shaped the designs of other privacy protocols (for e.g. Triptych, Seraphis, Lelantus-MW).</p>
+  </description>
+  <screenshots>
+    <screenshot>
+      <image type="source">
+        https://raw.githubusercontent.com/firoorg/firo/0f9d27dfef6f27f5c4d97a060c0954846d3ea547/contrib/debian/qt-screenshot.jpg
+      </image>
+    </screenshot>
+  </screenshots>
+  <releases>
+    <release date="2024-02-19" version="0.14.13.2"/>
+  </releases>
+  <content_rating type="oars-1.1"/>
+  <developer_name>Firo</developer_name>
+</component>


### PR DESCRIPTION
Adding this file upstream, as asked by Flathub's team: https://github.com/flathub/flathub/pull/4932#discussion_r1484496323