### PR TITLE
Make initial block index loading faster

### DIFF
--- a/src/txdb.h
+++ b/src/txdb.h
@@ -43,6 +43,11 @@ static const int64_t nMaxBlockDBAndTxIndexCache = 1024;
 //! Max memory allocated to coin DB specific cache (MiB)
 static const int64_t nMaxCoinsDBCache = 8;
 
+//! By default don't check block index PoW on client startup
+static const bool DEFAULT_FULL_BLOCKINDEX_CHECK = false;
+//! If not doing full check of block index, check only N of the latest blocks
+static const int DEFAULT_BLOCKINDEX_NUMBER_OF_BLOCKS_TO_CHECK = 10000;
+
 struct CDiskTxPos : public CDiskBlockPos
 {
     unsigned int nTxOffset; // after header


### PR DESCRIPTION
## PR intention
Speed up loading block index from disk.

## Code changes brief
Code eliminates the check of PoW for all the block headers except last 10000.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an option to enforce Proof of Work (PoW) verification for the last N blocks at startup, enhancing the security and integrity of the block index.
- **Refactor**
	- Updated block index checks handling for improved efficiency and flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->