### PR TITLE
Fix missing text in help

### DIFF
--- a/doc/README_windows.txt
+++ b/doc/README_windows.txt
@@ -1,4 +1,4 @@
-Firo Core 0.14.11.x
+Firo Core 0.14.13.x
 =====================
 
 Intro

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3730,7 +3730,8 @@ UniValue automintspark(const JSONRPCRequest& request) {
 
     if (request.fHelp || request.params.size() != 0)
         throw std::runtime_error(
-                "This function automatically mints all unspent transparent funds\n"
+                "automintspark\n"
+                "This function automatically mints all unspent transparent funds to Spark.\n"
         );
 
     EnsureWalletIsUnlocked(pwallet);
@@ -4134,7 +4135,8 @@ UniValue autoMintlelantus(const JSONRPCRequest& request) {
 
     if (request.fHelp || request.params.size() != 0)
         throw std::runtime_error(
-                "This function automatically mints all unspent transparent funds\n"
+                "autoMintlelantus\n"
+                "This function automatically mints all unspent transparent funds to Lelantus.\n"
         );
 
     EnsureWalletIsUnlocked(pwallet);


### PR DESCRIPTION
![firo-qt_sJnKeRl0uo](https://github.com/firoorg/firo/assets/42809091/6599b3c7-ae21-41b2-8bd5-05b2a8d8f5c6)

This fixes `automintspark` and `autoMintlelantus` not showing up in `help`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated Firo Core version details in Windows installation guide.
- **Bug Fixes**
	- Improved error messages for specific wallet functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->