### PR TITLE
Firo-QT cosmetic fixes  

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -477,6 +477,7 @@ void BitcoinGUI::createMenuBar()
 #else
     // Get the main window's menu bar on other platforms
     appMenuBar = menuBar();
+    appMenuBar->setStyleSheet("QMenuBar::item { color: #000000; }");
 #endif
 
     // Configure the menus

--- a/src/qt/res/css/firo.css
+++ b/src/qt/res/css/firo.css
@@ -820,7 +820,10 @@ QTableView::item:selected {
     color: #FFFFFF;
     font: 12pt 'Source Sans Pro';
 }
-
+/* QTreeView */
+QTreeView::item {
+    color: #000000;
+}
 /* QTableWidget */
 
 QTableWidget {

--- a/src/qt/res/css/firo.css
+++ b/src/qt/res/css/firo.css
@@ -351,7 +351,7 @@ QComboBox::drop-down {
 }
 
 QComboBox::indicator {
-    background-color: #f4f4f4;
+    background-color: transparent;
     selection-background-color: #3d3939;
     color: #110202;
     selection-color: #FFFFFF;
@@ -373,6 +373,7 @@ QComboBox QAbstractItemView::item {
 QComboBox::item {
     color: #110202;
     font: 12pt 'Source Sans Pro';
+    max-height: 25px;
 }
 
 QComboBox::item:alternate {


### PR DESCRIPTION
1. Dropdown Sizing in Comboboxes #1416 

Fixed oversized dropdowns that covered other UI elements. Adjustments:

Made combobox indicators transparent.
Set a max-height of 25px for dropdown items.

2. Top Bar Text Visibility on Fedora #1354 

Improved the top bar's text visibility by explicitly setting the text color to black, ensuring it does not rely on the OS's default colors, which caused readability issues.

3.Backup Wallet Menu Font Readability with Dark UI Theme #1422 

Enhanced the readability of the folder's fonts in the "Backup Wallet" menu when using a dark UI theme. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the menu bar items to have black text color for improved readability.
	- Enhanced dropdown elements' styles with transparent indicators and adjusted maximum height for better user interface consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->