### PR TITLE
Fix go private window behavior for exchange address

### DIFF
--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -164,6 +164,20 @@
            </widget>
           </item>
           <item>
+           <widget class="QCheckBox" name="disableGoToPrivateWindow">
+            <property name="toolTip">
+             <string>Disable go to private window.</string>
+            </property>
+            <property name="text">
+             <string>&amp;Disable go to private window</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+          <item>
            <widget class="QCheckBox" name="reindexLelantus">
             <property name="toolTip">
              <string>Restore all Lelantus transactions following a reindex.</string>

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -171,22 +171,18 @@
             <property name="text">
              <string>&amp;Disable go to private window</string>
             </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-          <item>
-           <widget class="QCheckBox" name="reindexLelantus">
-            <property name="toolTip">
-             <string>Restore all Lelantus transactions following a reindex.</string>
-            </property>
-            <property name="text">
-             <string>&amp;Reindex Lelantus</string>
-            </property>
-           </widget>
-          </item>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="reindexLelantus">
+           <property name="toolTip">
+            <string>Restore all Lelantus transactions following a reindex.</string>
+           </property>
+           <property name="text">
+            <string>&amp;Reindex Lelantus</string>
+           </property>
+         </widget>
+        </item>
          </layout>
         </widget>
        </item>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -165,6 +165,7 @@ void OptionsDialog::setModel(OptionsModel *_model)
     /* Wallet */
     connect(ui->spendZeroConfChange, &QCheckBox::clicked, this, &OptionsDialog::showRestartWarning);
     connect(ui->reindexLelantus, &QCheckBox::clicked, this, &OptionsDialog::handleEnabledZapChanged);
+    connect(ui->disableGoToPrivateWindow, &QCheckBox::clicked, this, &OptionsDialog::showRestartWarning);
     /* Network */
     connect(ui->allowIncoming, &QCheckBox::clicked, this, &OptionsDialog::showRestartWarning);
     connect(ui->connectSocks, &QCheckBox::clicked, this, &OptionsDialog::showRestartWarning);
@@ -184,6 +185,7 @@ void OptionsDialog::setMapper()
     /* Wallet */
     mapper->addMapping(ui->spendZeroConfChange, OptionsModel::SpendZeroConfChange);
     mapper->addMapping(ui->reindexLelantus, OptionsModel::ReindexLelantus);
+    mapper->addMapping(ui->disableGoToPrivateWindow, OptionsModel::DisableGoToPrivate);
     mapper->addMapping(ui->coinControlFeatures, OptionsModel::CoinControlFeatures);
 
     /* Lelantus */

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -81,6 +81,10 @@ void OptionsModel::Init(bool resetSettings)
         settings.setValue("fCoinControlFeatures", false);
     fCoinControlFeatures = settings.value("fCoinControlFeatures", false).toBool();
 
+    if (!settings.contains("fDisableGoToPrivate"))
+        settings.setValue("fDisableGoToPrivate", false);
+    fDisableGoToPrivate = settings.value("fDisableGoToPrivate", false).toBool();
+
     if (!settings.contains("fAutoAnonymize"))
         settings.setValue("fAutoAnonymize", false);
     fAutoAnonymize = settings.value("fAutoAnonymize", false).toBool();
@@ -277,6 +281,8 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
             return settings.value("language");
         case CoinControlFeatures:
             return fCoinControlFeatures;
+        case DisableGoToPrivate:
+            return fDisableGoToPrivate;
         case AutoAnonymize:
             return fAutoAnonymize;
         case LelantusPage:
@@ -423,6 +429,11 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             fCoinControlFeatures = value.toBool();
             settings.setValue("fCoinControlFeatures", fCoinControlFeatures);
             Q_EMIT coinControlFeaturesChanged(fCoinControlFeatures);
+            break;
+        case DisableGoToPrivate:
+            fDisableGoToPrivate = value.toBool();
+            settings.setValue("fDisableGoToPrivate", fDisableGoToPrivate);
+            Q_EMIT disableGoToPrivateChanged(fDisableGoToPrivate);
             break;
         case AutoAnonymize:
             fAutoAnonymize = value.toBool();

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -46,6 +46,7 @@ public:
         DatabaseCache,          // int
         SpendZeroConfChange,    // bool
         ReindexLelantus,        // bool
+        DisableGoToPrivate,     // bool
         Listen,                 // bool
         TorSetup,               // bool
         AutoAnonymize,          // bool
@@ -73,6 +74,7 @@ public:
     bool getRapAddresses() {    return fenableRapAddresses; }
     const QString& getOverriddenByCommandLine() { return strOverriddenByCommandLine; }
     bool getAutoAnonymize() { return fAutoAnonymize; }
+    bool getGoPrivateWindow() {return fDisableGoToPrivate;}
     bool getLelantusPage() {return fLelantusPage; }
 
     /* Restart flag helper */
@@ -90,6 +92,7 @@ private:
     bool fCoinControlFeatures;
     bool fAutoAnonymize;
     bool fLelantusPage;
+    bool fDisableGoToPrivate;
     bool fenableRapAddresses;
 
     /* settings that were overridden by command-line */
@@ -106,6 +109,7 @@ Q_SIGNALS:
     void enableRapAddressesChanged(bool);
     void autoAnonymizeChanged(bool);
     void lelantusPageChanged(bool);
+    void disableGoToPrivateChanged(bool);
     void hideTrayIconChanged(bool);
 };
 

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -74,7 +74,7 @@ public:
     bool getRapAddresses() {    return fenableRapAddresses; }
     const QString& getOverriddenByCommandLine() { return strOverriddenByCommandLine; }
     bool getAutoAnonymize() { return fAutoAnonymize; }
-    bool getGoPrivateWindow() {return fDisableGoToPrivate;}
+    bool getDisableGoToPrivate() {return fDisableGoToPrivate;}
     bool getLelantusPage() {return fLelantusPage; }
 
     /* Restart flag helper */

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -340,7 +340,7 @@ void SendCoinsDialog::on_sendButton_clicked()
             return;
         }
     } else if ((fAnonymousMode == false) && (sparkAddressCount == 0)) {
-        if (!model->getOptionsModel()->getGoPrivateWindow() && spark::IsSparkAllowed()) {
+        if (!model->getOptionsModel()->getDisableGoToPrivate() && spark::IsSparkAllowed()) {
             bool openPageTag = true;
             for(int i = 0; i < recipients.size(); ++i){
                 std::string address = recipients[i].address.toStdString();
@@ -349,6 +349,7 @@ void SendCoinsDialog::on_sendButton_clicked()
 
                 if (boost::get<CExchangeKeyID>(&dest)) {
                     openPageTag = false;
+                    break;
                 }
             }
 

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -340,7 +340,7 @@ void SendCoinsDialog::on_sendButton_clicked()
             return;
         }
     } else if ((fAnonymousMode == false) && (sparkAddressCount == 0)) {
-        if (spark::IsSparkAllowed()) {
+        if (!model->getOptionsModel()->getGoPrivateWindow() && spark::IsSparkAllowed()) {
             bool openPageTag = true;
             for(int i = 0; i < recipients.size(); ++i){
                 std::string address = recipients[i].address.toStdString();

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -341,12 +341,25 @@ void SendCoinsDialog::on_sendButton_clicked()
         }
     } else if ((fAnonymousMode == false) && (sparkAddressCount == 0)) {
         if (spark::IsSparkAllowed()) {
-            SendGoPrivateDialog goPrivateDialog;
-            bool clickedButton = goPrivateDialog.getClickedButton();
-            if (!clickedButton) {
-                setAnonymizeMode(true);
-                fNewRecipientAllowed = true;
-                return;
+            bool openPageTag = true;
+            for(int i = 0; i < recipients.size(); ++i){
+                std::string address = recipients[i].address.toStdString();
+                CBitcoinAddress add(address);
+                CTxDestination dest = add.Get();
+
+                if (boost::get<CExchangeKeyID>(&dest)) {
+                    openPageTag = false;
+                }
+            }
+
+            if (openPageTag) {
+                SendGoPrivateDialog goPrivateDialog;
+                bool clickedButton = goPrivateDialog.getClickedButton();
+                if (!clickedButton) {
+                    setAnonymizeMode(true);
+                    fNewRecipientAllowed = true;
+                    return;
+                }
             }
         }
         prepareStatus = model->prepareTransaction(currentTransaction, &ctrl);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
    - Added a new checkbox widget in the options dialog to disable the "Go To Private" functionality with corresponding tooltip and text.
    - Extended the OptionsModel functionality to handle the state of the "Disable Go To Private" feature in settings.

- **Bug Fixes**
    - Improved the logic for handling recipients in the send coins dialog to ensure private transactions are correctly initiated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->