### PR TITLE
Faster initial block index load for low memory machines

### DIFF
--- a/src/txdb.h
+++ b/src/txdb.h
@@ -47,6 +47,8 @@ static const int64_t nMaxCoinsDBCache = 8;
 static const bool DEFAULT_FULL_BLOCKINDEX_CHECK = false;
 //! If not doing full check of block index, check only N of the latest blocks
 static const int DEFAULT_BLOCKINDEX_NUMBER_OF_BLOCKS_TO_CHECK = 10000;
+//! Check fewer blocks if low on memory
+static const int DEFAULT_BLOCKINDEX_LOWMEM_NUMBER_OF_BLOCKS_TO_CHECK = 50;
 
 struct CDiskTxPos : public CDiskBlockPos
 {


### PR DESCRIPTION
## Code changes brief
Linux only: detect if there is <2GB available RAM and then lower the number of block headers to perform a full check on during startup


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced startup performance for systems with lower RAM by adjusting the number of blocks checked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->