### PR TITLE
improve warning when sending transparent tx

### DIFF
--- a/src/qt/forms/sendcoinsentry.ui
+++ b/src/qt/forms/sendcoinsentry.ui
@@ -162,7 +162,7 @@
       <item>
         <widget class="QLabel" name="textWarning">
           <property name="text">
-          <string> You are using a transparent transaction, please go private. If this is a masternode transaction, you do not have to go private</string>
+          <string> You are making a transparent transaction. Unless you are sending to an exchange or making a masternode transaction, consider going private</string>
           </property>
           <property name="styleSheet">
             <string>color: #FFA800; margin-left:-10px;</string>

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -1226,7 +1226,7 @@ SendGoPrivateDialog::SendGoPrivateDialog():QMessageBox()
     ic->setAlignment(Qt::AlignRight);
     ic->setStyleSheet("color:#92400E");
     QLabel *text = new QLabel();
-    text->setText(tr("You are using a transparent transaction, please go private. If this is a masternode transaction, you do not have to go private"));
+    text->setText(tr("You are making a transparent transaction. Unless you are sending to an exchange or making a masternode transaction, consider going private"));
     text->setAlignment(Qt::AlignLeft);
     text->setWordWrap(true);
     text->setStyleSheet("color:#92400E;");


### PR DESCRIPTION
## PR intention
Improve warning message when sending a transparent transaction. Feel free to suggest better wording.

Resolves #1403

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated user interface messages to emphasize privacy options for transactions, except when sending to exchanges or conducting masternode transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->