### PR TITLE
Automate spend from spark to EX-address in Qt

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -525,8 +525,8 @@ void SendCoinsDialog::on_sendButton_clicked()
     if (fGoThroughTransparentAddress) {
         QString transparentAddress = "<span style='font-family: monospace;'>" + recipients[recipients.size()-1].address + "</span>";
         formatted.append("<br />");
-        formatted.append(tr("It's impossible to send directly to exchange address."
-            " The transaction will go through a new auto-generated transparent address  %1.").arg(transparentAddress));
+        formatted.append(tr("EX-addresses can only receive FIRO from transparent addresses.<br /><br />"
+            "Your FIRO will go from Spark to a newly generated transparent address %1 and then immediately be sent to the EX-address.").arg(transparentAddress));
     }
 
     QString questionString = tr("Are you sure you want to send?");
@@ -556,10 +556,12 @@ void SendCoinsDialog::on_sendButton_clicked()
         questionString.append(" (" + QString::number(txSize / 1000) + " kB)");
 
         if (fGoThroughTransparentAddress) {
-            questionString.append(tr(". Note: the transaction will go through a transparent address, fee for the second transaction is "));
-            questionString.append("<span style='color:#aa0000;'>");
-            questionString.append(BitcoinUnits::formatHtmlWithUnit(model->getOptionsModel()->getDisplayUnit(), extraFee));
-            questionString.append("</span>.");
+            QString feeString;
+            feeString.append("<span style='color:#aa0000;'>");
+            feeString.append(BitcoinUnits::formatHtmlWithUnit(model->getOptionsModel()->getDisplayUnit(), extraFee));
+            feeString.append("</span>");
+            
+            questionString.append(tr(". An additional transaction fee of %1 will apply to complete the send from the transparent address to the EX-address.").arg(feeString));
         }
     }
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -272,6 +272,12 @@ bool WalletModel::validateAddress(const QString &address)
     return addressParsed.IsValid();
 }
 
+bool WalletModel::validateExchangeAddress(const QString &address)
+{
+    CBitcoinAddress addressParsed(address.toStdString());
+    return addressParsed.IsValid() && addressParsed.Get().type() == typeid(CExchangeKeyID);
+}
+
 WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransaction &transaction, const CCoinControl *coinControl)
 {
     CAmount total = 0;

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -153,6 +153,7 @@ public:
 
     // Check address for validity
     bool validateAddress(const QString &address);
+    bool validateExchangeAddress(const QString &address);
     bool validateSparkAddress(const QString &address);
     std::pair<CAmount, CAmount> getSparkBalance();
 

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -24,6 +24,8 @@ class CCoinControl
 {
 public:
     CTxDestination destChange;
+    //! If true, don't use any change
+    bool fNoChange;
     //! If false, allows unselected inputs, but requires all selected inputs be used
     bool fAllowOtherInputs;
     //! Includes watch only addresses which match the ISMINE_WATCH_SOLVABLE criteria
@@ -49,6 +51,7 @@ public:
     void SetNull()
     {
         destChange = CNoDestination();
+        fNoChange = false;
         fAllowOtherInputs = false;
         fRequireAllInputs = true;
         fAllowWatchOnly = false;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4450,7 +4450,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                 const CAmount nChange = nValueIn - nValueToSelect;
                 CTxOut newTxOut;
 
-                if (nChange > 0)
+                if (nChange > 0 && !(coinControl && coinControl->fNoChange))
                 {
                     // Fill a vout to ourself
                     // TODO: pass in scriptChange instead of reservekey so


### PR DESCRIPTION
## PR intention
When spending private funds to EX-address in Qt client automatically create an intermediate transaction.

## Code changes brief
Changed Qt code handling "Send" page to support this scenario.
