### PR TITLE
New rpc calls for mobile

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -261,6 +261,8 @@ public:
     sigma::spend_info_container sigmaSpentSerials;
     std::unordered_map<Scalar, int> lelantusSpentSerials;
     std::unordered_map<GroupElement, int> spentLTags;
+    // linking tag hash mapped to tx hash
+    std::unordered_map<uint256, uint256> ltagTxhash;
 
     //! list of disabling sporks active at this block height
     //! std::map {feature name} -> {block number when feature is re-enabled again, parameter}
@@ -303,6 +305,7 @@ public:
         sparkMintedCoins.clear();
         sparkSetHash.clear();
         spentLTags.clear();
+        ltagTxhash.clear();
         sparkTxHashContext.clear();
         sigmaSpentSerials.clear();
         lelantusSpentSerials.clear();
@@ -563,6 +566,7 @@ public:
 
             if (GetBoolArg("-mobile", false)) {
                 READWRITE(sparkTxHashContext);
+                READWRITE(ltagTxhash);
             }
         }
 

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -194,6 +194,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getusedcoinserials", 0 },
     { "getlatestcoinids", 0 },
     { "getsparkmintmetadata", 0 },
+    { "getmempooltxs", 0 },
 
     //Lelantus
     { "mintspark", 0 },

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -1488,11 +1488,11 @@ UniValue getsparklatestcoinid(const JSONRPCRequest& request)
     return UniValue(latestCoinId);
 }
 
-UniValue getmempooltxids(const JSONRPCRequest& request)
+UniValue getmempoolsparktxids(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 0)
         throw std::runtime_error(
-                "getmempooltxids\n"
+                "getmempoolsparktxids\n"
                 "\nReturns all mempool transaction ids.\n"
         );
 
@@ -1507,11 +1507,11 @@ UniValue getmempooltxids(const JSONRPCRequest& request)
     return result;
 }
 
-UniValue getmempooltxs(const JSONRPCRequest& request)
+UniValue getmempoolsparktxs(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 1)
         throw std::runtime_error(
-                "getmempooltxs\n"
+                "getmempoolsparktxs\n"
                 "\nReturns spark data for each transaction.\n"
                 "\nArguments:\n"
                 "  \"txids\"\n"
@@ -1525,8 +1525,8 @@ UniValue getmempooltxs(const JSONRPCRequest& request)
                 "{\n"
                 "  \"txdata\"   (Pair<string,int>) nHeight and id for each coin\n"
                 "}\n"
-                + HelpExampleCli("getmempooltxs", "'{\"txids\": [\"b476ed2b374bb081ea51d111f68f0136252521214e213d119b8dc67b92f5a390\",\"b476ed2b374bb081ea51d111f68f0136252521214e213d119b8dc67b92f5a390\"]}'")
-                + HelpExampleRpc("getmempooltxs", "{\"txids\": [\"b476ed2b374bb081ea51d111f68f0136252521214e213d119b8dc67b92f5a390\",\"b476ed2b374bb081ea51d111f68f0136252521214e213d119b8dc67b92f5a390\"]}")
+                + HelpExampleCli("getmempoolsparktxs", "'{\"txids\": [\"b476ed2b374bb081ea51d111f68f0136252521214e213d119b8dc67b92f5a390\",\"b476ed2b374bb081ea51d111f68f0136252521214e213d119b8dc67b92f5a390\"]}'")
+                + HelpExampleRpc("getmempoolsparktxs", "{\"txids\": [\"b476ed2b374bb081ea51d111f68f0136252521214e213d119b8dc67b92f5a390\",\"b476ed2b374bb081ea51d111f68f0136252521214e213d119b8dc67b92f5a390\"]}")
 
         );
 
@@ -1920,8 +1920,8 @@ static const CRPCCommand commands[] =
     { "mobile",             "getusedcoinstags",       &getusedcoinstags,     false },
     { "mobile",             "getusedcoinstagstxhashes", &getusedcoinstagstxhashes, false },
     { "mobile",             "getsparklatestcoinid",   &getsparklatestcoinid, true  },
-    { "mobile",             "getmempooltxids",        &getmempooltxids,     true },
-    { "mobile",             "getmempooltxs",          &getmempooltxs,       true  },
+    { "mobile",             "getmempoolsparktxids",   &getmempoolsparktxids, true },
+    { "mobile",             "getmempoolsparktxs",     &getmempoolsparktxs,       true  },
 
     { "mobile",             "checkifmncollateral",   &checkifmncollateral, false  },
 

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -1525,12 +1525,12 @@ UniValue getmempooltxs(const JSONRPCRequest& request)
                 "{\n"
                 "  \"txdata\"   (Pair<string,int>) nHeight and id for each coin\n"
                 "}\n"
-                + HelpExampleCli("getmempooltxs", "'{[\"b476ed2b374bb081ea51d111f68f0136252521214e213d119b8dc67b92f5a390\",\"b476ed2b374bb081ea51d111f68f0136252521214e213d119b8dc67b92f5a390\"]}'")
-                + HelpExampleRpc("getmempooltxs", "{[\"b476ed2b374bb081ea51d111f68f0136252521214e213d119b8dc67b92f5a390\",\"b476ed2b374bb081ea51d111f68f0136252521214e213d119b8dc67b92f5a390\"]}")
+                + HelpExampleCli("getmempooltxs", "'{\"txids\": [\"b476ed2b374bb081ea51d111f68f0136252521214e213d119b8dc67b92f5a390\",\"b476ed2b374bb081ea51d111f68f0136252521214e213d119b8dc67b92f5a390\"]}'")
+                + HelpExampleRpc("getmempooltxs", "{\"txids\": [\"b476ed2b374bb081ea51d111f68f0136252521214e213d119b8dc67b92f5a390\",\"b476ed2b374bb081ea51d111f68f0136252521214e213d119b8dc67b92f5a390\"]}")
 
         );
 
-    UniValue txids = request.params[0].get_obj();
+    UniValue txids = find_value(request.params[0].get_obj(), "txids");
 
     UniValue result(UniValue::VARR);
     for(UniValue const & element : txids.getValues()){

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -1444,9 +1444,7 @@ UniValue getmempooltxids(const JSONRPCRequest& request)
     for (auto it = txs.begin(); it != txs.end(); it++) {
         if (!it->tx->IsSparkTransaction())
             continue;
-        UniValue txid(UniValue::VOBJ);
-        txid.push_back(EncodeBase64(it->tx->GetHash().begin(), it->tx->GetHash().size()));
-        result.push_back(txid);
+        result.push_back(EncodeBase64(it->tx->GetHash().begin(), it->tx->GetHash().size()));
     }
 
     return result;

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -342,6 +342,7 @@ static const CRPCCommand vRPCCommands[] =
     { "mobile",             "getsparkanonymityset",   &getsparkanonymityset, false },
     { "mobile",             "getsparkmintmetadata",   &getsparkmintmetadata, true  },
     { "mobile",             "getusedcoinstags",       &getusedcoinstags,     false },
+    { "mobile",             "getusedcoinstagstxhashes", &getusedcoinstagstxhashes, false },
     { "mobile",             "getsparklatestcoinid",   &getsparklatestcoinid, true  },
     { "mobile",             "getmempooltxids",        &getmempooltxids,     true },
     { "mobile",             "getmempooltxs",          &getmempooltxs,       true  },

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -344,8 +344,8 @@ static const CRPCCommand vRPCCommands[] =
     { "mobile",             "getusedcoinstags",       &getusedcoinstags,     false },
     { "mobile",             "getusedcoinstagstxhashes", &getusedcoinstagstxhashes, false },
     { "mobile",             "getsparklatestcoinid",   &getsparklatestcoinid, true  },
-    { "mobile",             "getmempooltxids",        &getmempooltxids,     true },
-    { "mobile",             "getmempooltxs",          &getmempooltxs,       true  },
+    { "mobile",             "getmempoolsparktxids",   &getmempoolsparktxids, true },
+    { "mobile",             "getmempoolsparktxs",     &getmempoolsparktxs,   true  },
 
 
     { "mobile",             "checkifmncollateral",   &checkifmncollateral, false  },

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -343,6 +343,9 @@ static const CRPCCommand vRPCCommands[] =
     { "mobile",             "getsparkmintmetadata",   &getsparkmintmetadata, true  },
     { "mobile",             "getusedcoinstags",       &getusedcoinstags,     false },
     { "mobile",             "getsparklatestcoinid",   &getsparklatestcoinid, true  },
+    { "mobile",             "getmempooltxids",        &getmempooltxids,     true },
+    { "mobile",             "getmempooltxs",          &getmempooltxs,       true  },
+
 
     { "mobile",             "checkifmncollateral",   &checkifmncollateral, false  },
 

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -217,6 +217,8 @@ extern UniValue getsparkanonymityset(const JSONRPCRequest& params);
 extern UniValue getsparkmintmetadata(const JSONRPCRequest& params);
 extern UniValue getusedcoinstags(const JSONRPCRequest& params);
 extern UniValue getsparklatestcoinid(const JSONRPCRequest& params);
+extern UniValue getmempooltxids(const JSONRPCRequest& params);
+extern UniValue getmempooltxs(const JSONRPCRequest& params);
 
 extern UniValue checkifmncollateral(const JSONRPCRequest& params);
 

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -218,8 +218,8 @@ extern UniValue getsparkmintmetadata(const JSONRPCRequest& params);
 extern UniValue getusedcoinstags(const JSONRPCRequest& params);
 extern UniValue getusedcoinstagstxhashes(const JSONRPCRequest& params);
 extern UniValue getsparklatestcoinid(const JSONRPCRequest& params);
-extern UniValue getmempooltxids(const JSONRPCRequest& params);
-extern UniValue getmempooltxs(const JSONRPCRequest& params);
+extern UniValue getmempoolsparktxids(const JSONRPCRequest& params);
+extern UniValue getmempoolsparktxs(const JSONRPCRequest& params);
 
 extern UniValue checkifmncollateral(const JSONRPCRequest& params);
 

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -216,6 +216,7 @@ extern UniValue getlatestcoinid(const JSONRPCRequest& params);
 extern UniValue getsparkanonymityset(const JSONRPCRequest& params);
 extern UniValue getsparkmintmetadata(const JSONRPCRequest& params);
 extern UniValue getusedcoinstags(const JSONRPCRequest& params);
+extern UniValue getusedcoinstagstxhashes(const JSONRPCRequest& params);
 extern UniValue getsparklatestcoinid(const JSONRPCRequest& params);
 extern UniValue getmempooltxids(const JSONRPCRequest& params);
 extern UniValue getmempooltxs(const JSONRPCRequest& params);

--- a/src/spark/state.h
+++ b/src/spark/state.h
@@ -26,6 +26,7 @@ public:
 
     // linking tag for every spend (map from lTag to coin group id)
     std::unordered_map<GroupElement, int> spentLTags;
+    std::unordered_map<uint256, uint256> ltagTxhash;
 
     // information about transactions in the block is complete
     bool fInfoIsComplete;
@@ -168,6 +169,7 @@ public:
     void AddMintsToStateAndBlockIndex(CBlockIndex *index, const CBlock* pblock);
 
     void AddSpend(const GroupElement& lTag, int coinGroupId);
+    void AddLTagTxHash(const uint256& lTagHash, const uint256& txHash);
     void RemoveSpend(const GroupElement& lTag);
     // Add everything from the block to the state
     void AddBlock(CBlockIndex *index);
@@ -213,6 +215,7 @@ public:
 
     std::unordered_map<spark::Coin, CMintedCoinInfo, spark::CoinHash> const & GetMints() const;
     std::unordered_map<GroupElement, int, spark::CLTagHash> const & GetSpends() const;
+    std::unordered_map<uint256, uint256> const& GetSpendTxIds() const;
     std::unordered_map<int, SparkCoinGroupInfo> const & GetCoinGroups() const;
     std::unordered_map<GroupElement, uint256, spark::CLTagHash> const & GetMempoolLTags() const;
 
@@ -238,6 +241,8 @@ private:
     std::unordered_map<spark::Coin, CMintedCoinInfo, spark::CoinHash> mintedCoins;
     // Set of all used coin linking tags.
     std::unordered_map<GroupElement, int, spark::CLTagHash> usedLTags;
+    // linking tag hash mapped to tx hash
+    std::unordered_map<uint256, uint256> ltagTxhash;
 
     typedef std::map<int, size_t> metainfo_container_t;
     metainfo_container_t extendedMintMetaInfo, mintMetaInfo, spendMetaInfo;

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -425,6 +425,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts(boost::function<CBlockIndex*(const uint256
                 pindexNew->sparkSetHash       = diskindex.sparkSetHash;
                 pindexNew->spentLTags         = diskindex.spentLTags;
                 pindexNew->sparkTxHashContext = diskindex.sparkTxHashContext;
+                pindexNew->ltagTxhash         = diskindex.ltagTxhash;
 
                 pindexNew->activeDisablingSporks = diskindex.activeDisablingSporks;
 


### PR DESCRIPTION
Added new rpc calls,
- `getusedcoinstagstxhashes`, this rpc returns all spent coin serials attached to the hash of spending transaction, previously we had `getusedcoinstags` , the new call allows to get also in which transaction is spent the coin, to do this we add field inside block index, and in spark state, when tx is being checked during block acceptance, we add the pair of ltag and tx hash into block index, and each time we construct the state, we get the data from the index. this fields are constructed in case `-mobile` is passed,
- `getmempooltxids` gives the list of spark tx hashes inside mempool, this allow to get spark state not only for blockchian but also from mempool.
- `getmempooltxs` returns spark metadata for each tx hash, existing in mempool, in case there is no data for particular tx, that means tx is removed from mempool, confirmed or removed for another reason.