### PR TITLE
Update Linux build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ sudo apt-get install git curl python build-essential libtool automake pkg-config
 sudo apt-get install qttools5-dev qttools5-dev-tools libxcb-xkb-dev bison
 ```
 
+If you use a later version of Ubuntu, you may need to replace `python` with `python3`.
+
 - Redhat/Fedora:
 
 ```sh


### PR DESCRIPTION
Recent versions of Ubuntu require `python3` be specified as a dependency instead of `python`. This PR updates the documentation accordingly.

Closes #1452.