### PR TITLE
Update macOS Build Instructions for Dependency and Configuration IssuesMac os build fix

### DIFF
--- a/doc/build-macos.md
+++ b/doc/build-macos.md
@@ -4,14 +4,14 @@ The commands in this guide should be executed in a Terminal application.
 The built-in one is located in `/Applications/Utilities/Terminal.app`.
 
 ## Preparation
-1. **Install macOS Command Line Tools** (if not already installed):
+1. Install macOS Command Line Tools (if not already installed):
    ```bash
    xcode-select --install
    ```
    When the popup appears, click `Install`.
 
 
-2. **Install Homebrew** (if not already installed):
+2. Install Homebrew (if not already installed):
    ```bash
    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
    ```
@@ -101,7 +101,10 @@ Download and install the community edition of [Qt Creator](https://www.qt.io/dow
 Uncheck everything except Qt Creator during the installation process.
 
 1. Make sure you installed everything through Homebrew mentioned above
-2. Do a proper  ``` ./configure --prefix=`pwd`/depends/`depends/config.guess` --enable-debug   ```
+2. Properly configure the build environment:
+   ```bash
+   ./configure --prefix=`pwd`/depends/`depends/config.guess` --enable-debug
+   ```
 3. In Qt Creator do "New Project" -> Import Project -> Import Existing Project
 4. Enter "bitcoin-qt" as project name, enter `src/qt` as location
 5. Leave the file selection as it is

--- a/doc/build-macos.md
+++ b/doc/build-macos.md
@@ -3,24 +3,29 @@ macOS Build Instructions and Notes
 The commands in this guide should be executed in a Terminal application.
 The built-in one is located in `/Applications/Utilities/Terminal.app`.
 
-Preparation
------------
-Install the macOS command line tools:
+## Preparation
+1. **Install macOS Command Line Tools** (if not already installed):
+   ```bash
+   xcode-select --install
+   ```
+   When the popup appears, click `Install`.
 
-`xcode-select --install`
 
-When the popup appears, click `Install`.
+2. **Install Homebrew** (if not already installed):
+   ```bash
+   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+   ```
 
-Then install [Homebrew](http://brew.sh).
+## Dependencies
+Install the required dependencies using Homebrew:
+```bash
+brew install automake berkeley-db4 libtool boost miniupnpc openssl pkg-config protobuf python qt libevent qrencode python-setuptools m4
+```
 
-Dependencies
-----------------------
-
-    brew install automake berkeley-db4 libtool boost miniupnpc openssl pkg-config protobuf python qt libevent qrencode
 
 In case you want to build the disk image with `make deploy` (.dmg / optional), you need RSVG
 
-      brew install librsvg
+    brew install librsvg
       
 Berkley DB
 ------------------------
@@ -29,30 +34,40 @@ It is recommended to use Berkeley DB 4.8. If you have to build it yourself, you 
 
 from the root of the repository.
 
-Note: You only need Berkeley DB if the wallet is enabled (see Disable-wallet mode).
-      
-      
-Build Firo Core
-------------------------
-1.  Build Firo-core:
+*Note*: You only need Berkeley DB if the wallet is enabled (see Disable-wallet mode).
 
-    Configure and build the headless Firo binaries as well as the GUI (if Qt is found).
-    
-    In case you want to build the disk image with `make deploy` (.dmg / optional), by passing `--with-gui` to configure.
-    
-    You can disable the GUI build by passing `--without-gui` to configure.
+#### Download the Source
+Before building, download the Firo source code:
+```bash
+git clone https://github.com/firoorg/firo
+cd firo
+```
+
+#### Build Firo Core
+1. **Prepare the build environment**:
+   ```bash
+   cd depends
+   make
+   cd ..
+   ```
+
+2. **Configure and build Firo-core**:
+   ```bash
+   ./autogen.sh
+   ./configure --prefix=`pwd`/depends/`depends/config.guess`
+   make
+   ```
+
+3. (optional) **It is recommended to build and run the unit tests**:
+
+   ```bash
+   ./configure --prefix=`pwd`/depends/`depends/config.guess` --enable-tests
+   make check
+   ```
         
-        ./autogen.sh
-        ./configure
-        make
+4. (optional)**You can also create a .dmg that contains the .app bundle (optional)**:
 
-2.  It is recommended to build and run the unit tests:
-
-       ` make check`
-        
-3.   You can also create a .dmg that contains the .app bundle (optional):
-
-       ` make deploy`
+        make deploy
 
 
 Running
@@ -86,7 +101,7 @@ Download and install the community edition of [Qt Creator](https://www.qt.io/dow
 Uncheck everything except Qt Creator during the installation process.
 
 1. Make sure you installed everything through Homebrew mentioned above
-2. Do a proper `./configure --enable-debug`
+2. Do a proper  ``` ./configure --prefix=`pwd`/depends/`depends/config.guess` --enable-debug   ```
 3. In Qt Creator do "New Project" -> Import Project -> Import Existing Project
 4. Enter "bitcoin-qt" as project name, enter `src/qt` as location
 5. Leave the file selection as it is
@@ -99,7 +114,6 @@ Uncheck everything except Qt Creator during the installation process.
 Notes
 -----
 
-* Tested on macOS 10.11 through 10.14 on 64-bit Intel processors only.
+* Tested on macOS 10.11 through 10.14 on 64-bit Intel processors, and on macOS 14.5 on an M2 chip.
 
 * Building with downloaded Qt binaries is not officially supported. See the notes in [#7714](https://github.com/bitcoin/bitcoin/issues/7714)
-

--- a/doc/build-macos.md
+++ b/doc/build-macos.md
@@ -27,6 +27,23 @@ In case you want to build the disk image with `make deploy` (.dmg / optional), y
 ```bash
 brew install librsvg
 ```
+### Ensure `m4` is Found
+After installing `m4`, ensure that it is correctly linked and available in your PATH:
+```bash
+brew link m4
+```
+
+You can verify that `m4` is properly installed by running:
+```bash
+which m4
+```
+This should output the path to the `m4` binary, typically `/opt/homebrew/bin/m4` on Apple Silicon Macs.
+
+### Troubleshooting `m4` Issues
+If `m4` is not found even after installation, and running `brew link m4` does not resolve the issue, you may need to install Xcode to ensure that `m4` is recognized:
+
+1. Install Xcode from the Mac App Store.
+2. Once installed, open Xcode at least once to complete the setup.
 
 #### Berkeley DB
 It is recommended to use Berkeley DB 4.8. If you have to build it yourself, you can use [the installation script included in contrib/](https://github.com/bitcoin/bitcoin/blob/master/contrib/install_db4.sh) like so:

--- a/doc/build-macos.md
+++ b/doc/build-macos.md
@@ -16,25 +16,28 @@ The built-in one is located in `/Applications/Utilities/Terminal.app`.
    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
    ```
 
+
 ## Dependencies
 Install the required dependencies using Homebrew:
 ```bash
 brew install automake berkeley-db4 libtool boost miniupnpc openssl pkg-config protobuf python qt libevent qrencode python-setuptools m4
 ```
 
+In case you want to build the disk image with `make deploy` (.dmg / optional), you need RSVG:
+```bash
+brew install librsvg
+```
 
-In case you want to build the disk image with `make deploy` (.dmg / optional), you need RSVG
-
-    brew install librsvg
-      
-Berkley DB
-------------------------
+#### Berkeley DB
 It is recommended to use Berkeley DB 4.8. If you have to build it yourself, you can use [the installation script included in contrib/](https://github.com/bitcoin/bitcoin/blob/master/contrib/install_db4.sh) like so:
-    ./contrib/install_db4.sh .
-
+```bash
+./contrib/install_db4.sh .
+```
 from the root of the repository.
 
 *Note*: You only need Berkeley DB if the wallet is enabled (see Disable-wallet mode).
+
+## Build Instructions
 
 #### Download the Source
 Before building, download the Firo source code:
@@ -59,15 +62,15 @@ cd firo
    ```
 
 3. (optional) **It is recommended to build and run the unit tests**:
-
    ```bash
    ./configure --prefix=`pwd`/depends/`depends/config.guess` --enable-tests
    make check
    ```
         
-4. (optional)**You can also create a .dmg that contains the .app bundle (optional)**:
-
-        make deploy
+4. (optional) **You can also create a .dmg that contains the .app bundle**:
+    ```bash
+    make deploy
+    ```
 
 
 Running

--- a/doc/build-macos.md
+++ b/doc/build-macos.md
@@ -27,20 +27,21 @@ In case you want to build the disk image with `make deploy` (.dmg / optional), y
 ```bash
 brew install librsvg
 ```
+
 ### Ensure `m4` is Found
-After installing `m4`, ensure that it is correctly linked and available in your PATH:
+After installing `m4`, it is important to note that `m4` is a `keg-only` formula in Homebrew. This means it is not symlinked into `/usr/local` by default. To make sure `m4` is available in your PATH, you'll need to link it manually with the `--force` flag:
 ```bash
-brew link m4
+brew link m4 --force
 ```
 
-You can verify that `m4` is properly installed by running:
+You can verify that `m4` is properly linked and available by running:
 ```bash
 which m4
 ```
-This should output the path to the `m4` binary, typically `/opt/homebrew/bin/m4` on Apple Silicon Macs.
+This should output the path to the `m4` binary, typically `/opt/homebrew/bin/m4` on Apple Silicon Macs. If you do not use the `--force` flag, `which m4` will likely output `/usr/bin/m4`, which is the system version and not the one installed via Homebrew.
 
 ### Troubleshooting `m4` Issues
-If `m4` is not found even after installation, and running `brew link m4` does not resolve the issue, you may need to install Xcode to ensure that `m4` is recognized:
+If `m4` is not found even after installation and linking with `--force`, you may need to install Xcode to ensure that `m4` is recognized:
 
 1. Install Xcode from the Mac App Store.
 2. Once installed, open Xcode at least once to complete the setup.
@@ -48,7 +49,7 @@ If `m4` is not found even after installation, and running `brew link m4` does no
 #### Berkeley DB
 It is recommended to use Berkeley DB 4.8. If you have to build it yourself, you can use [the installation script included in contrib/](https://github.com/bitcoin/bitcoin/blob/master/contrib/install_db4.sh) like so:
 ```bash
-./contrib/install_db4.sh .
+./contrib/install_db4.sh 
 ```
 from the root of the repository.
 


### PR DESCRIPTION
### Description
This pull request revises the macOS build instructions for the Firo wallet, addressing dependency recognition and configuration issues on macOS Sonoma 14.5 with an M chip Mac.

#### Key Changes Include:
1. **Boost Library Configuration**:
   - Adjusted the build instructions to ensure proper recognition of the Boost libraries, which were not initially recognized. This includes specifying the correct paths for the Boost headers and libraries in the configuration settings.

2. **Dependency Installation Adjustments**:
   - Updated the instructions to include `m4` and `python-setuptools` in the Homebrew installation commands, addressing issues where these tools were not recognized post-installation. This ensures a more streamlined setup and reduces configuration errors during the build process.

3. **Environment Setup**:
   - Outlined the necessary steps for setting up the development environment on macOS, with considerations for the specific challenges posed by the latest macOS versions and hardware configurations.

#### Purpose:
The updates aim to streamline the setup process for developers on macOS, ensuring all key dependencies like Boost, `m4`, and `python-setuptools` are installed and recognized correctly, enhancing the clarity and accuracy of the build instructions.

#### Testing:
These revised instructions have been tested on macOS Sonoma 14.5 with an M chip Mac. 