### PR TITLE
Update Github Actions workflow to v4

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -37,13 +37,13 @@ jobs:
       run: tar -czf depends.tar.gz depends
     - name: Prepare Files for Artifact
       run: |
-        mkdir -p $ARTIFACT_DIR
-        mv depends.tar.gz firo-*.tar.gz $ARTIFACT_DIR
+        mkdir -p $SOURCE_ARTIFACT_DIR
+        mv depends.tar.gz firo-*.tar.gz $OURCE_ARTIFACT_DIR
     - name: Upload Artifact
       uses: actions/upload-artifact@v4
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
-        path: ${{ env.ARTIFACT_DIR }}
+        path: ${{ env.sOURCE_ARTIFACT_DIR }}
   build-linux:
     name: Build for Linux
     needs: create-source-distribution
@@ -56,6 +56,7 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
+        path: ${{ env.SOURCE_ARTIFACT_DIR }}
     - name: Extract Archives
       run: |
         tar -xzf depends.tar.gz
@@ -122,6 +123,7 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
+        path: ${{ env.SOURCE_ARTIFACT_DIR }}
     - name: Extract Archives
       run: |
         tar -xzf depends.tar.gz
@@ -163,6 +165,7 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
+        path: ${{ env.SOURCE_ARTIFACT_DIR }}
     - name: Extract Archives
       run: |
         tar -xzf depends.tar.gz

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -38,12 +38,12 @@ jobs:
     - name: Prepare Files for Artifact
       run: |
         mkdir -p $SOURCE_ARTIFACT_DIR
-        mv depends.tar.gz firo-*.tar.gz $OURCE_ARTIFACT_DIR
+        mv depends.tar.gz firo-*.tar.gz $SOURCE_ARTIFACT_DIR
     - name: Upload Artifact
       uses: actions/upload-artifact@v4
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
-        path: ${{ env.sOURCE_ARTIFACT_DIR }}
+        path: ${{ env.SOURCE_ARTIFACT_DIR }}
   build-linux:
     name: Build for Linux
     needs: create-source-distribution

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -14,12 +14,11 @@ on:
     - master
 env:
   SOURCE_ARTIFACT: source
+  SOURCE_ARTIFACT_DIR: source
 jobs:
   create-source-distribution:
     name: Create Source Distribution
     runs-on: ubuntu-latest
-    env:
-      ARTIFACT_DIR: source
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -22,7 +22,7 @@ jobs:
       ARTIFACT_DIR: source
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install Required Packages
       run: |
         sudo apt-get update
@@ -41,7 +41,7 @@ jobs:
         mkdir -p $ARTIFACT_DIR
         mv depends.tar.gz firo-*.tar.gz $ARTIFACT_DIR
     - name: Upload Artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
         path: ${{ env.ARTIFACT_DIR }}
@@ -54,7 +54,7 @@ jobs:
       TEST_LOG_ARTIFACT_DIR: test-logs
     steps:
     - name: Getting Source
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v4
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
     - name: Extract Archives
@@ -87,7 +87,7 @@ jobs:
         mkdir -p $ARTIFACT_DIR
         mv $SOURCE_ARTIFACT/src/{firo-cli,firo-tx,firod,qt/firo-qt} $ARTIFACT_DIR
     - name: Upload Artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: linux-binaries
         path: ${{ env.ARTIFACT_DIR }}
@@ -108,7 +108,7 @@ jobs:
         fi
     - name: Upload Test Logs Artifact
       if: failure()
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: test-logs
         path: ${{ env.TEST_LOG_ARTIFACT_DIR }}
@@ -120,7 +120,7 @@ jobs:
       ARTIFACT_DIR: windows-binaries
     steps:
     - name: Getting Source
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v4
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
     - name: Extract Archives
@@ -149,7 +149,7 @@ jobs:
         mkdir -p $ARTIFACT_DIR
         mv $SOURCE_ARTIFACT/src/{firo-cli.exe,firo-tx.exe,firod.exe,qt/firo-qt.exe} $ARTIFACT_DIR
     - name: Upload Artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: windows-binaries
         path: ${{ env.ARTIFACT_DIR }}
@@ -161,7 +161,7 @@ jobs:
       ARTIFACT_DIR: mac-binaries
     steps:
     - name: Getting Source
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v4
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
     - name: Extract Archives
@@ -189,7 +189,7 @@ jobs:
         mkdir -p $ARTIFACT_DIR
         mv $SOURCE_ARTIFACT/src/{firo-cli,firo-tx,firod,qt/firo-qt} $ARTIFACT_DIR
     - name: Upload Artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: mac-binaries
         path: ${{ env.ARTIFACT_DIR }}


### PR DESCRIPTION
## PR intention
Github is deprecating `actions/checkout`, `download-artifact`, and `upload-artifact` v1 and v2.

## Code changes brief
Updates `actions/checkout`, `download-artifact`, and `upload-artifact` to v4. This will also reduce the warnings in Actions.

Closes #1459.
