### PR TITLE
Tokenomics update

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -532,7 +532,7 @@ public:
         consensus.stage3DevelopmentFundAddress = "TWDxLLKsFp6qcV1LL4U2uNmW4HwMcapmMU";
         consensus.stage3CommunityFundAddress = "TCkC4uoErEyCB4MK3d6ouyJELoXnuyqe9L";
 
-        consensus.stage4StartBlock = 168500;
+        consensus.stage4StartBlock = 167500;
         consensus.stage4CommunityFundShare = 10;
         consensus.stage4DevelopmentFundShare = 15;
         consensus.stage4MasternodeShare = 70;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -807,7 +807,7 @@ public:
         consensus.stage2DevelopmentFundAddress = "Tq99tes2sRbQ1yNUJPJ7BforYnKcitgwWq";
 
         consensus.stage3StartTime = 1653382800;
-        consensus.stage3StartBlock = 1514;
+        consensus.stage3StartBlock = 1514;  // this is incorrect value but we have to leave it for now
         consensus.stage3DevelopmentFundShare = 15;
         consensus.stage3CommunityFundShare = 10;
         consensus.stage3MasternodeShare = 50;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -206,6 +206,12 @@ public:
         consensus.stage3DevelopmentFundAddress = "aLgRaYSFk6iVw2FqY1oei8Tdn2aTsGPVmP";
         consensus.stage3CommunityFundAddress = "aFA2TbqG9cnhhzX5Yny2pBJRK5EaEqLCH7";
 
+        consensus.stage4StartBlock = consensus.nSubsidyHalvingSecond;
+        consensus.stage4CommunityFundShare = 10;
+        consensus.stage4DevelopmentFundShare = 15;
+        consensus.stage4MasternodeShare = 70;
+        consensus.tailEmissionBlockSubsidy = 4 * COIN; // real value would be 1 FIRO (because of two halvings due to different block times)
+
         consensus.nStartBlacklist = 293990;
         consensus.nStartDuplicationCheck = 293526;
 
@@ -528,6 +534,7 @@ public:
         consensus.stage3DevelopmentFundAddress = "TWDxLLKsFp6qcV1LL4U2uNmW4HwMcapmMU";
         consensus.stage3CommunityFundAddress = "TCkC4uoErEyCB4MK3d6ouyJELoXnuyqe9L";
 
+        consensus.stage4StartBlock = 168500;
         consensus.stage4CommunityFundShare = 10;
         consensus.stage4DevelopmentFundShare = 15;
         consensus.stage4MasternodeShare = 70;
@@ -794,7 +801,7 @@ public:
         consensus.chainType = Consensus::chainDevnet;
 
         consensus.nSubsidyHalvingFirst = 1;
-        consensus.nSubsidyHalvingSecond = 100000;
+        consensus.nSubsidyHalvingSecond = 3500;
         consensus.nSubsidyHalvingInterval = 100000;
         consensus.nSubsidyHalvingStopBlock = 1000000;
 
@@ -809,6 +816,12 @@ public:
         consensus.stage3MasternodeShare = 50;
         consensus.stage3DevelopmentFundAddress = "TfvbHyGTo8hexoKBBS8fz9Gq7g9VZQQpcg";
         consensus.stage3CommunityFundAddress = "TgoL9nh8vDTz7UB5WkBbknBksBdUaD9qbT";
+
+        consensus.stage4StartBlock = consensus.nSubsidyHalvingSecond;
+        consensus.stage4CommunityFundShare = 10;
+        consensus.stage4DevelopmentFundShare = 15;
+        consensus.stage4MasternodeShare = 70;
+        consensus.tailEmissionBlockSubsidy = 4 * COIN; // real value would be 1 FIRO (because of two halvings due to different block times)
 
         consensus.nStartBlacklist = 0;
         consensus.nStartDuplicationCheck = 0;
@@ -1044,12 +1057,18 @@ public:
         consensus.stage2ZnodeShare = 35;
 
         consensus.stage3StartTime = INT_MAX;
-        consensus.stage3StartBlock = 0;
+        consensus.stage3StartBlock = 2000;
         consensus.stage3DevelopmentFundShare = 15;
         consensus.stage3CommunityFundShare = 10;
         consensus.stage3MasternodeShare = 50;
         consensus.stage3DevelopmentFundAddress = "TGEGf26GwyUBE2P2o2beBAfE9Y438dCp5t";  // private key cMrz8Df36VR9TvZjtvSqLPhUQR7pcpkXRXaLNYUxfkKsRuCzHpAN
         consensus.stage3CommunityFundAddress = "TJmPzeJF4DECrBwUftc265U7rTPxKmpa4F";  // private key cTyPWqTMM1CgT5qy3K3LSgC1H6Q2RHvnXZHvjWtKB4vq9qXqKmMu
+
+        consensus.stage4StartBlock = consensus.nSubsidyHalvingSecond;
+        consensus.stage4CommunityFundShare = 15;
+        consensus.stage4DevelopmentFundShare = 25;
+        consensus.stage4MasternodeShare = 50;
+        consensus.tailEmissionBlockSubsidy = 4 * COIN; // real value would be 1 FIRO (because of two halvings due to different block times)
 
         consensus.nMajorityEnforceBlockUpgrade = 750;
         consensus.nMajorityRejectBlockOutdated = 950;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -799,8 +799,8 @@ public:
         consensus.chainType = Consensus::chainDevnet;
 
         consensus.nSubsidyHalvingFirst = 1;
-        consensus.nSubsidyHalvingSecond = 3500;
-        consensus.nSubsidyHalvingInterval = 100000;
+        consensus.nSubsidyHalvingSecond = 3000;
+        consensus.nSubsidyHalvingInterval = 10000;
 
         consensus.stage2DevelopmentFundShare = 15;
         consensus.stage2ZnodeShare = 35;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -1052,15 +1052,15 @@ public:
         consensus.stage2DevelopmentFundShare = 15;
         consensus.stage2ZnodeShare = 35;
 
-        consensus.stage3StartTime = INT_MAX;
-        consensus.stage3StartBlock = 2000;
+        consensus.stage3StartTime = 0;
+        consensus.stage3StartBlock = 1500;
         consensus.stage3DevelopmentFundShare = 15;
         consensus.stage3CommunityFundShare = 10;
         consensus.stage3MasternodeShare = 50;
         consensus.stage3DevelopmentFundAddress = "TGEGf26GwyUBE2P2o2beBAfE9Y438dCp5t";  // private key cMrz8Df36VR9TvZjtvSqLPhUQR7pcpkXRXaLNYUxfkKsRuCzHpAN
         consensus.stage3CommunityFundAddress = "TJmPzeJF4DECrBwUftc265U7rTPxKmpa4F";  // private key cTyPWqTMM1CgT5qy3K3LSgC1H6Q2RHvnXZHvjWtKB4vq9qXqKmMu
 
-        consensus.stage4StartBlock = consensus.nSubsidyHalvingSecond;
+        consensus.stage4StartBlock = consensus.nSubsidyHalvingSecond + 500;
         consensus.stage4CommunityFundShare = 15;
         consensus.stage4DevelopmentFundShare = 25;
         consensus.stage4MasternodeShare = 50;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -192,7 +192,6 @@ public:
         consensus.nSubsidyHalvingFirst = 302438;
         consensus.nSubsidyHalvingSecond = AdjustEndingBlockNumberAfterSubsidyHalving(302438, 420000, 486221); // =958655
         consensus.nSubsidyHalvingInterval = 420000*2;
-        consensus.nSubsidyHalvingStopBlock = AdjustEndingBlockNumberAfterSubsidyHalving(0, 3646849, 486221);  // =6807477
 
         consensus.stage2DevelopmentFundShare = 15;
         consensus.stage2ZnodeShare = 35;
@@ -520,7 +519,6 @@ public:
         consensus.nSubsidyHalvingFirst = 12000;
         consensus.nSubsidyHalvingSecond = 150000;
         consensus.nSubsidyHalvingInterval = 150000;
-        consensus.nSubsidyHalvingStopBlock = 1000000;
 
         consensus.stage2DevelopmentFundShare = 15;
         consensus.stage2ZnodeShare = 35;
@@ -803,7 +801,6 @@ public:
         consensus.nSubsidyHalvingFirst = 1;
         consensus.nSubsidyHalvingSecond = 3500;
         consensus.nSubsidyHalvingInterval = 100000;
-        consensus.nSubsidyHalvingStopBlock = 1000000;
 
         consensus.stage2DevelopmentFundShare = 15;
         consensus.stage2ZnodeShare = 35;
@@ -1049,7 +1046,6 @@ public:
         consensus.nSubsidyHalvingFirst = 1500;
         consensus.nSubsidyHalvingSecond = 2500;
         consensus.nSubsidyHalvingInterval = 1000;
-        consensus.nSubsidyHalvingStopBlock = 10000;
 
         consensus.nStartBlacklist = 0;
         consensus.nStartDuplicationCheck = 0;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -528,6 +528,11 @@ public:
         consensus.stage3DevelopmentFundAddress = "TWDxLLKsFp6qcV1LL4U2uNmW4HwMcapmMU";
         consensus.stage3CommunityFundAddress = "TCkC4uoErEyCB4MK3d6ouyJELoXnuyqe9L";
 
+        consensus.stage4CommunityFundShare = 10;
+        consensus.stage4DevelopmentFundShare = 15;
+        consensus.stage4MasternodeShare = 70;
+        consensus.tailEmissionBlockSubsidy = 4 * COIN; // real value would be 1 FIRO (because of two halvings due to different block times)
+
         consensus.nStartBlacklist = 0;
         consensus.nStartDuplicationCheck = 0;
         consensus.nMajorityEnforceBlockUpgrade = 51;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -1052,15 +1052,15 @@ public:
         consensus.stage2DevelopmentFundShare = 15;
         consensus.stage2ZnodeShare = 35;
 
-        consensus.stage3StartTime = 0;
-        consensus.stage3StartBlock = 1500;
+        consensus.stage3StartTime = INT_MAX;        // tests should set this value individually
+        consensus.stage3StartBlock = INT_MAX;       // same as above
         consensus.stage3DevelopmentFundShare = 15;
         consensus.stage3CommunityFundShare = 10;
         consensus.stage3MasternodeShare = 50;
         consensus.stage3DevelopmentFundAddress = "TGEGf26GwyUBE2P2o2beBAfE9Y438dCp5t";  // private key cMrz8Df36VR9TvZjtvSqLPhUQR7pcpkXRXaLNYUxfkKsRuCzHpAN
         consensus.stage3CommunityFundAddress = "TJmPzeJF4DECrBwUftc265U7rTPxKmpa4F";  // private key cTyPWqTMM1CgT5qy3K3LSgC1H6Q2RHvnXZHvjWtKB4vq9qXqKmMu
 
-        consensus.stage4StartBlock = consensus.nSubsidyHalvingSecond + 500;
+        consensus.stage4StartBlock = consensus.nSubsidyHalvingSecond;
         consensus.stage4CommunityFundShare = 15;
         consensus.stage4DevelopmentFundShare = 25;
         consensus.stage4MasternodeShare = 50;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -163,6 +163,17 @@ struct Params {
     /** percentage of block subsidy going to masternode */
     int stage3MasternodeShare;
 
+    /** parameters for coinbase payment distribution after stage three (aka stage 4) */
+    /** percentage of block subsidy going to developer fund */
+    int stage4DevelopmentFundShare;
+    /** percentage of block subsidy going to community fund */
+    int stage4CommunityFundShare;
+    /** percentage of block subsidy going to masternode */
+    int stage4MasternodeShare;
+
+    /**  tail emission (after stage 4) */
+    int tailEmissionBlockSubsidy;
+
     int nStartDuplicationCheck;
     int nStartBlacklist;
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -136,8 +136,6 @@ struct Params {
     int nSubsidyHalvingSecond;
     /** Subsequent subsidy halving intervals */
     int nSubsidyHalvingInterval;
-    /** Stop subsidy at this block number */
-    int nSubsidyHalvingStopBlock;
 
     /** parameters for coinbase payment distribution between first halving and stage 3 (aka stage 2) */
     /** P2PKH or P2SH address for developer funds */

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -164,6 +164,8 @@ struct Params {
     int stage3MasternodeShare;
 
     /** parameters for coinbase payment distribution after stage three (aka stage 4) */
+    /** start time of stage 4 (usually the same as nSubsidyHalvingSecond)*/
+    int stage4StartBlock;
     /** percentage of block subsidy going to developer fund */
     int stage4DevelopmentFundShare;
     /** percentage of block subsidy going to community fund */

--- a/src/test/firsthalving_tests.cpp
+++ b/src/test/firsthalving_tests.cpp
@@ -154,7 +154,7 @@ BOOST_FIXTURE_TEST_CASE(devpayout, TestChainDIP3BeforeActivationSetup)
 
     consensusParams.nSubsidyHalvingFirst = 600;
     consensusParams.stage3StartTime = INT_MAX;
-    consensusParams.nSubsidyHalvingSecond = 620;
+    consensusParams.nSubsidyHalvingSecond = consensusParams.stage4StartBlock = 620;
     consensusParams.nSubsidyHalvingInterval = 10;
 
     CScript devPayoutScript = GenerateRandomAddress();
@@ -225,6 +225,8 @@ BOOST_FIXTURE_TEST_CASE(devpayout, TestChainDIP3BeforeActivationSetup)
 
     // initiate stage3
     consensusParams.stage3StartTime = GetTime();
+    consensusParams.stage3StartBlock = chainActive.Height();
+
     // for stage3 there is dev payout and community payout
     for (int i=610; i<620; i++) {
         CBlock block = CreateAndProcessBlock({}, coinbaseKey);
@@ -259,39 +261,39 @@ BOOST_FIXTURE_TEST_CASE(devpayout, TestChainDIP3BeforeActivationSetup)
         CAmount nValue;
         auto dmnPayout = FindPayoutDmn(block, nValue);
 
-        BOOST_ASSERT(dmnPayout != nullptr && nValue == 3125*COIN/1000);   // 3.125 (6.25*0.5)
+        // stage 4: no real halving here
+        BOOST_ASSERT(dmnPayout != nullptr && nValue == 625*COIN/100);   // 6.25
 
         // there should be no more payment to devs fund
         for (const CTxOut &txout: block.vtx[0]->vout) {
             BOOST_ASSERT(txout.scriptPubKey != GetScriptForDestination(CBitcoinAddress(consensusParams.stage2DevelopmentFundAddress).Get()));
         }
 
-        // miner's reward should be 6.25-3.125 = 3.125
-        BOOST_ASSERT(block.vtx[0]->vout[0].nValue == 3125*COIN/1000);
-        // should be only 2 vouts in coinbase
-        BOOST_ASSERT(block.vtx[0]->vout.size() == 2);
+        // miner's reward should be 1.25 (10%)
+        BOOST_ASSERT(block.vtx[0]->vout[0].nValue == 125*COIN/100);
+
+        bool paymentToDevFound = false, paymentToCommunityFound = false;
+        for (const CTxOut &txout: block.vtx[0]->vout) {
+            if (txout.scriptPubKey == GetScriptForDestination(CBitcoinAddress(consensusParams.stage3DevelopmentFundAddress).Get())) {
+                BOOST_ASSERT(txout.nValue == 3125*COIN/1000); // 25/2*0.25
+                paymentToDevFound = true;
+            }
+            if (txout.scriptPubKey == GetScriptForDestination(CBitcoinAddress(consensusParams.stage3CommunityFundAddress).Get())) {
+                BOOST_ASSERT(txout.nValue == 1875*COIN/1000); // 25/2*0.15
+                paymentToCommunityFound = true;
+            }
+        }
+        BOOST_ASSERT(paymentToDevFound && paymentToCommunityFound);    
     }
 
-    // the third halving should occur at block 630
+    // tail emission should occur at block 630
     CBlock block = CreateAndProcessBlock({}, coinbaseKey);
     deterministicMNManager->UpdatedBlockTip(chainActive.Tip());
 
     CAmount nValue;
     auto dmnPayout = FindPayoutDmn(block, nValue);
 
-    BOOST_ASSERT(dmnPayout != nullptr && nValue == 3125*COIN/1000/2);   // 3.125/2 (3.125*0.5)
-
-    // there should be no more payment to devs/community funds fund
-    for (const CTxOut &txout: block.vtx[0]->vout) {
-        BOOST_ASSERT(txout.scriptPubKey != GetScriptForDestination(CBitcoinAddress(consensusParams.stage2DevelopmentFundAddress).Get()) &&
-                        txout.scriptPubKey != GetScriptForDestination(CBitcoinAddress(consensusParams.stage3DevelopmentFundAddress).Get()) &&
-                        txout.scriptPubKey != GetScriptForDestination(CBitcoinAddress(consensusParams.stage3CommunityFundAddress).Get()));
-    }
-
-    // miner's reward should be 3.125/2
-    BOOST_ASSERT(block.vtx[0]->vout[0].nValue == 3125*COIN/1000/2);
-    // should be only 2 vouts in coinbase
-    BOOST_ASSERT(block.vtx[0]->vout.size() == 2);
+    BOOST_ASSERT(dmnPayout != nullptr && nValue == COIN);
 
     consensusParams = consensusParamsBackup;
 }
@@ -303,6 +305,7 @@ BOOST_FIXTURE_TEST_CASE(devpayoutverification, TestChainDIP3BeforeActivationSetu
 
     consensusParams.nSubsidyHalvingFirst = 600;
     consensusParams.nSubsidyHalvingSecond = 610;
+    consensusParams.stage3StartTime = INT_MAX;    
     consensusParams.nSubsidyHalvingInterval = 10;
 
     // skip to block 600

--- a/src/test/firsthalving_tests.cpp
+++ b/src/test/firsthalving_tests.cpp
@@ -156,7 +156,6 @@ BOOST_FIXTURE_TEST_CASE(devpayout, TestChainDIP3BeforeActivationSetup)
     consensusParams.stage3StartTime = INT_MAX;
     consensusParams.nSubsidyHalvingSecond = 620;
     consensusParams.nSubsidyHalvingInterval = 10;
-    consensusParams.nSubsidyHalvingStopBlock = 1000;
 
     CScript devPayoutScript = GenerateRandomAddress();
     CTxDestination devPayoutDest{CScriptID(devPayoutScript)};
@@ -305,7 +304,6 @@ BOOST_FIXTURE_TEST_CASE(devpayoutverification, TestChainDIP3BeforeActivationSetu
     consensusParams.nSubsidyHalvingFirst = 600;
     consensusParams.nSubsidyHalvingSecond = 610;
     consensusParams.nSubsidyHalvingInterval = 10;
-    consensusParams.nSubsidyHalvingStopBlock = 1000;
 
     // skip to block 600
     for (int i=498; i<600; i++)

--- a/src/test/mtp_halving_tests.cpp
+++ b/src/test/mtp_halving_tests.cpp
@@ -42,8 +42,17 @@ CScript scriptPubKeyMtpHalving;
 
 
 struct MtpHalvingTestingSetup : public TestingSetup {
-    MtpHalvingTestingSetup() : TestingSetup(CBaseChainParams::REGTEST)
+    Consensus::Params &mutableParams;
+    Consensus::Params oldParams;
+
+    MtpHalvingTestingSetup() : TestingSetup(CBaseChainParams::REGTEST), mutableParams(const_cast<Consensus::Params&>(Params().GetConsensus()))
     {
+        oldParams = mutableParams;
+
+        // disable stage 3 stuff for now
+        mutableParams.stage3StartTime = INT_MAX;
+        mutableParams.stage3StartBlock = INT_MAX;
+
         CPubKey newKey;
         BOOST_CHECK(pwalletMain->GetKeyFromPool(newKey));
 
@@ -64,6 +73,10 @@ struct MtpHalvingTestingSetup : public TestingSetup {
                 pwalletMain->AddToWalletIfInvolvingMe(*b.vtx[0], chainActive.Tip(), 0, true);
             }   
         }
+    }
+
+    ~MtpHalvingTestingSetup() {
+        mutableParams = oldParams;
     }
 
     CBlock CreateBlock(const CScript& scriptPubKeyMtpHalving, bool mtp = false) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1943,17 +1943,17 @@ CAmount GetBlockSubsidyWithMTPFlag(int nHeight, const Consensus::Params &consens
 CAmount GetBlockSubsidy(int nHeight, const Consensus::Params &consensusParams, int nTime) {
     return GetBlockSubsidyWithMTPFlag(nHeight, consensusParams,
             nTime >= (int)consensusParams.nMTPSwitchTime,
-            nHeight >= (int)consensusParams.stage3StartBlock);
+            nTime >= (int)consensusParams.stage3StartTime);
 }
 
 CAmount GetMasternodePayment(int nHeight, int nTime, CAmount blockValue)
 {
     const Consensus::Params &params = Params().GetConsensus();
-    if (nHeight >= params.stage4MasternodeShare)
+    if (nHeight >= params.stage4StartBlock)
         return blockValue*params.stage4MasternodeShare/100;
     else if (nHeight >= params.nSubsidyHalvingSecond)
         return blockValue/2;
-    else if (nHeight >= params.stage3StartBlock)
+    else if (nTime >= params.stage3StartTime)
         return blockValue*params.stage3MasternodeShare/100;
     else if (nHeight >= params.nSubsidyHalvingFirst)
         return blockValue*params.stage2ZnodeShare/100;
@@ -4832,7 +4832,7 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, const Co
     }
 
     if (nHeight >= consensusParams.nSubsidyHalvingFirst) {
-        if (nHeight >= consensusParams.stage3StartBlock) {
+        if (block.nTime >= consensusParams.stage3StartTime) {
             bool fStage4 = nHeight >= consensusParams.nSubsidyHalvingSecond;
             int  devPayoutShare = fStage4 ? consensusParams.stage4DevelopmentFundShare : consensusParams.stage3DevelopmentFundShare;
             int  communityPayoutShare = fStage4 ? consensusParams.stage4CommunityFundShare : consensusParams.stage3CommunityFundShare;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1918,11 +1918,6 @@ CAmount GetBlockSubsidyWithMTPFlag(int nHeight, const Consensus::Params &consens
     if (nHeight == 0)
         return 0;
 
-    // Subsidy is cut in half after nSubsidyHalvingFirst block, then after nSubsidyHalvingSecond, then every nSubsidyHalvingInterval blocks.
-    // After block nSubsidyHalvingStopBlock there will be no subsidy at all
-    if (nHeight >= consensusParams.nSubsidyHalvingStopBlock)
-        return 0;
-
     CAmount nSubsidy;
 
     if (nHeight < consensusParams.nSubsidyHalvingFirst)


### PR DESCRIPTION
## PR intention
Change of emission rules. According to the new rules instead of second halving at block 958655 block subsidy remains the same and the split of funds are: development fund - 15%, community fund - 10%, masternode reward - 70%, miner's reward - 5%.

Instead of the third halving (block 1798655) blockchain enters the tail emission phase and block subsidy becomes 1 FIRO. Split remains the same as above.

## Code changes brief
Multiple changes in generation and verification functions as well as chain parameters and tests.
