### PR TITLE
Run Actions when commit is pushed to any branch

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -5,7 +5,7 @@ on:
     - 'doc/**'
     - '**/README.md'
     branches:
-    - master
+    - '**'
   pull_request:
     paths-ignore:
     - 'doc/**'


### PR DESCRIPTION
## PR intention
Currently Github Actions doesn't run if commit(s) are pushed to a branch without an open PR. This change allows branches with no PR to be built, and any problems with compilation or tests found earlier.
