### PR TITLE
Implement new rpc calls to get anonymity sets

### DIFF
--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -1418,6 +1418,8 @@ UniValue getsparkanonymitysetsector(const JSONRPCRequest& request)
                     &chainActive,
                     chainActive.Height() - (ZC_MINT_CONFIRMATIONS - 1),
                     coinGroupId,
+                    startIndex,
+                    endIndex,
                     blockHash,
                     coins);
         } catch (std::exception & e) {
@@ -1428,15 +1430,8 @@ UniValue getsparkanonymitysetsector(const JSONRPCRequest& request)
     UniValue ret(UniValue::VOBJ);
     UniValue mints(UniValue::VARR);
 
-    std::size_t counter = 0;
+
     for (const auto& coin : coins) {
-        if (counter < startIndex) {
-            ++counter;
-            continue;
-        }
-        if (counter >= endIndex) {
-            break;
-        }
         CDataStream serializedCoin(SER_NETWORK, PROTOCOL_VERSION);
         serializedCoin << coin;
         std::vector<unsigned char> vch(serializedCoin.begin(), serializedCoin.end());
@@ -1449,8 +1444,6 @@ UniValue getsparkanonymitysetsector(const JSONRPCRequest& request)
         UniValue entity(UniValue::VARR);
         entity.push_backV(data);
         mints.push_back(entity);
-
-        ++counter;
     }
 
     ret.push_back(Pair("coins", mints));

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -340,6 +340,8 @@ static const CRPCCommand vRPCCommands[] =
 
         /* Mobile Spark */
     { "mobile",             "getsparkanonymityset",   &getsparkanonymityset, false },
+    { "mobile",             "getsparkanonymitysetmeta",   &getsparkanonymitysetmeta, false },
+    { "mobile",             "getsparkanonymitysetsector",   &getsparkanonymitysetsector, false },
     { "mobile",             "getsparkmintmetadata",   &getsparkmintmetadata, true  },
     { "mobile",             "getusedcoinstags",       &getusedcoinstags,     false },
     { "mobile",             "getusedcoinstagstxhashes", &getusedcoinstagstxhashes, false },

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -214,6 +214,8 @@ extern UniValue getfeerate(const JSONRPCRequest& params);
 extern UniValue getlatestcoinid(const JSONRPCRequest& params);
 
 extern UniValue getsparkanonymityset(const JSONRPCRequest& params);
+extern UniValue getsparkanonymitysetmeta(const JSONRPCRequest& params);
+extern UniValue getsparkanonymitysetsector(const JSONRPCRequest& params);
 extern UniValue getsparkmintmetadata(const JSONRPCRequest& params);
 extern UniValue getusedcoinstags(const JSONRPCRequest& params);
 extern UniValue getusedcoinstagstxhashes(const JSONRPCRequest& params);

--- a/src/spark/state.cpp
+++ b/src/spark/state.cpp
@@ -1330,6 +1330,85 @@ void CSparkState::GetCoinsForRecovery(
     }
 }
 
+void CSparkState::GetAnonSetMetaData(
+        CChain *chain,
+        int maxHeight,
+        int coinGroupID,
+        uint256& blockHash_out,
+        std::vector<unsigned char>& setHash_out,
+        int& size) {
+    if (coinGroups.count(coinGroupID) == 0) {
+        return;
+    }
+    SparkCoinGroupInfo &coinGroup = coinGroups[coinGroupID];
+    size = 0;
+    for (CBlockIndex *block = coinGroup.lastBlock;; block = block->pprev) {
+        // check coins in group coinGroupID - 1 in the case that using coins from prev group.
+        int id = 0;
+        if (CountCoinInBlock(block, coinGroupID)) {
+            id = coinGroupID;
+        } else if (CountCoinInBlock(block, coinGroupID - 1)) {
+            id = coinGroupID - 1;
+        }
+        if (id) {
+            if (size == 0) {
+                // latest block satisfying given conditions
+                // remember block hash and set hash
+                blockHash_out = block->GetBlockHash();
+                setHash_out =  GetAnonymitySetHash(block, id);
+            }
+            size += block->sparkMintedCoins[id].size();
+        }
+        if (block == coinGroup.firstBlock) {
+            break ;
+        }
+    }
+}
+
+void CSparkState::GetCoinsForRecovery(
+        CChain *chain,
+        int maxHeight,
+        int coinGroupID,
+        uint256& blockHash,
+        std::vector<std::pair<spark::Coin, std::pair<uint256, std::vector<unsigned char>>>>& coins) {
+    coins.clear();
+    if (coinGroups.count(coinGroupID) == 0) {
+        return;
+    }
+    SparkCoinGroupInfo &coinGroup = coinGroups[coinGroupID];
+    CBlockIndex *index = coinGroup.lastBlock;
+    // find index for block with hash of accumulatorBlockHash or set index to the coinGroup.firstBlock if not found
+    while (index != coinGroup.firstBlock && index->GetBlockHash() != blockHash)
+        index = index->pprev;
+
+    for (CBlockIndex *block = index;; block = block->pprev) {
+        // ignore block heigher than max height
+        if (block->nHeight > maxHeight) {
+            continue;
+        }
+
+        // check coins in group coinGroupID - 1 in the case that using coins from prev group.
+        int id = 0;
+        if (CountCoinInBlock(block, coinGroupID)) {
+            id = coinGroupID;
+        } else if (CountCoinInBlock(block, coinGroupID - 1)) {
+            id = coinGroupID - 1;
+        }
+        if (id) {
+            if (block->sparkMintedCoins.count(id) > 0) {
+                for (const auto &coin : block->sparkMintedCoins[id]) {
+                    std::pair<uint256, std::vector<unsigned char>> txHashContext;
+                    if (block->sparkTxHashContext.count(coin.S))
+                        txHashContext = block->sparkTxHashContext[coin.S];
+                    coins.push_back({coin, txHashContext});
+                }
+            }
+        }
+        if (block == coinGroup.firstBlock) {
+            break ;
+        }
+    }
+}
 
 std::unordered_map<spark::Coin, CMintedCoinInfo, spark::CoinHash> const & CSparkState::GetMints() const {
     return mintedCoins;

--- a/src/spark/state.cpp
+++ b/src/spark/state.cpp
@@ -1373,13 +1373,17 @@ void CSparkState::GetCoinsForRecovery(
         std::vector<std::pair<spark::Coin, std::pair<uint256, std::vector<unsigned char>>>>& coins) {
     coins.clear();
     if (coinGroups.count(coinGroupID) == 0) {
-        return;
+        throw std::runtime_error(std::string("There is no anonymity set with this id: " + coinGroupID));
     }
     SparkCoinGroupInfo &coinGroup = coinGroups[coinGroupID];
     CBlockIndex *index = coinGroup.lastBlock;
     // find index for block with hash of accumulatorBlockHash or set index to the coinGroup.firstBlock if not found
     while (index != coinGroup.firstBlock && index->GetBlockHash() != blockHash)
         index = index->pprev;
+
+    if (index == coinGroup.firstBlock && coinGroup.firstBlock != coinGroup.lastBlock)
+        throw std::runtime_error(std::string("Incorrect blockHash provided: " + blockHash.GetHex()));
+
 
     for (CBlockIndex *block = index;; block = block->pprev) {
         // ignore block heigher than max height

--- a/src/spark/state.h
+++ b/src/spark/state.h
@@ -213,6 +213,21 @@ public:
             std::vector<std::pair<spark::Coin, std::pair<uint256, std::vector<unsigned char>>>>& coins,
             std::vector<unsigned char>& setHash_out);
 
+    void GetAnonSetMetaData(
+            CChain *chain,
+            int maxHeight,
+            int coinGroupID,
+            uint256& blockHash_out,
+            std::vector<unsigned char>& setHash_out,
+            int& size);
+
+    void GetCoinsForRecovery(
+            CChain *chain,
+            int maxHeight,
+            int coinGroupID,
+            uint256& blockHash,
+            std::vector<std::pair<spark::Coin, std::pair<uint256, std::vector<unsigned char>>>>& coins);
+
     std::unordered_map<spark::Coin, CMintedCoinInfo, spark::CoinHash> const & GetMints() const;
     std::unordered_map<GroupElement, int, spark::CLTagHash> const & GetSpends() const;
     std::unordered_map<uint256, uint256> const& GetSpendTxIds() const;

--- a/src/spark/state.h
+++ b/src/spark/state.h
@@ -225,6 +225,8 @@ public:
             CChain *chain,
             int maxHeight,
             int coinGroupID,
+            int startIndex,
+            int endIndex,
             uint256& blockHash,
             std::vector<std::pair<spark::Coin, std::pair<uint256, std::vector<unsigned char>>>>& coins);
 


### PR DESCRIPTION
Introducing two new RPC calls.
- `getsparkanonymitysetmeta` returns all metadata related to anonymity set. set size, latest block hash and anonymity set hash
- `getsparkanonymitysetsector` returns a sector of anonymity set based on provided range, set id and latest block hash