### PR TITLE
Export View Keys

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -95,6 +95,7 @@ QT_TS = \
   qt/locale/bitcoin_zh_TW.ts
 
 QT_FORMS_UI = \
+  qt/forms/exportviewkeydialog.ui \
   qt/forms/addressbookpage.ui \
   qt/forms/askpassphrasedialog.ui \
   qt/forms/automintdialog.ui \
@@ -139,6 +140,7 @@ QT_MOC_CPP = \
   qt/moc_coincontroltreewidget.cpp \
   qt/moc_csvmodelwriter.cpp \
   qt/moc_editaddressdialog.cpp \
+  qt/moc_exportviewkeydialog.cpp \
   qt/moc_guiutil.cpp \
   qt/moc_intro.cpp \
   qt/moc_recover.cpp \
@@ -213,6 +215,7 @@ BITCOIN_QT_H = \
   qt/cancelpassworddialog.h \
   qt/clientmodel.h \
   qt/coincontroldialog.h \
+  qt/exportviewkeydialog.h \
   qt/manualmintdialog.h \
   qt/coincontroltreewidget.h \
   qt/csvmodelwriter.h \
@@ -427,6 +430,7 @@ BITCOIN_QT_WALLET_CPP = \
   qt/coincontroldialog.cpp \
   qt/coincontroltreewidget.cpp \
   qt/editaddressdialog.cpp \
+  qt/exportviewkeydialog.cpp \
   qt/manualmintdialog.cpp \
   qt/openuridialog.cpp \
   qt/overviewpage.cpp \

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -116,6 +116,7 @@ BitcoinGUI::BitcoinGUI(const PlatformStyle *_platformStyle, const NetworkStyle *
     encryptWalletAction(0),
     backupWalletAction(0),
     changePassphraseAction(0),
+    exportViewKeyAction(0),
     aboutQtAction(0),
     openRPCConsoleAction(0),
     openAction(0),
@@ -408,6 +409,8 @@ void BitcoinGUI::createActions()
 #endif // ENABLE_WALLET
     backupWalletAction = new QAction(tr("&Backup Wallet..."), this);
     backupWalletAction->setStatusTip(tr("Backup wallet to another location"));
+    exportViewKeyAction = new QAction(tr("&Export View Key..."), this);
+    exportViewKeyAction->setStatusTip(tr("Export Spark view key"));
     changePassphraseAction = new QAction(tr("&Change Passphrase..."), this);
     changePassphraseAction->setStatusTip(tr("Change the passphrase used for wallet encryption"));
     signMessageAction = new QAction(tr("Sign &message..."), this);
@@ -447,6 +450,7 @@ void BitcoinGUI::createActions()
     {
         connect(encryptWalletAction, &QAction::triggered, walletFrame, &WalletFrame::encryptWallet);
         connect(backupWalletAction, &QAction::triggered, walletFrame, &WalletFrame::backupWallet);
+        connect(exportViewKeyAction, &QAction::triggered, walletFrame, &WalletFrame::exportViewKey);
         connect(changePassphraseAction, &QAction::triggered, walletFrame, &WalletFrame::changePassphrase);
         connect(signMessageAction, &QAction::triggered, [this]{ gotoSignMessageTab(); });
         connect(verifyMessageAction, &QAction::triggered, [this]{ gotoVerifyMessageTab(); });
@@ -479,6 +483,7 @@ void BitcoinGUI::createMenuBar()
         file->addAction(backupWalletAction);
         file->addAction(signMessageAction);
         file->addAction(verifyMessageAction);
+        file->addAction(exportViewKeyAction);
         file->addSeparator();
         file->addAction(usedSendingAddressesAction);
         file->addAction(usedReceivingAddressesAction);
@@ -651,6 +656,7 @@ void BitcoinGUI::setWalletActionsEnabled(bool enabled)
     encryptWalletAction->setEnabled(enabled);
     backupWalletAction->setEnabled(enabled);
     changePassphraseAction->setEnabled(enabled);
+    exportViewKeyAction->setEnabled(enabled);
     signMessageAction->setEnabled(enabled);
     verifyMessageAction->setEnabled(enabled);
     usedSendingAddressesAction->setEnabled(enabled);

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_QT_BITCOINGUI_H
 #define BITCOIN_QT_BITCOINGUI_H
 
+#include "exportviewkeydialog.h"
 #if defined(HAVE_CONFIG_H)
 #include "config/bitcoin-config.h"
 #endif
@@ -115,6 +116,7 @@ private:
     QAction *toggleHideAction;
     QAction *encryptWalletAction;
     QAction *backupWalletAction;
+    QAction *exportViewKeyAction;
     QAction *changePassphraseAction;
     QAction *aboutQtAction;
     QAction *openRPCConsoleAction;

--- a/src/qt/exportviewkeydialog.cpp
+++ b/src/qt/exportviewkeydialog.cpp
@@ -1,0 +1,13 @@
+#include "exportviewkeydialog.h"
+#include "ui_exportviewkeydialog.h"
+
+ExportViewKeyDialog::ExportViewKeyDialog(QWidget *parent, std::string sparkViewKeyStr) : QDialog(parent), ui(new Ui::ExportViewKeyDialog)
+{
+    ui->setupUi(this);
+    QString text(QString::fromStdString(sparkViewKeyStr));
+    ui->key->setText(text);
+}
+
+ExportViewKeyDialog::~ExportViewKeyDialog() {
+    delete ui;
+}

--- a/src/qt/exportviewkeydialog.h
+++ b/src/qt/exportviewkeydialog.h
@@ -1,0 +1,26 @@
+#ifndef VIEWKEYDIALOG_H
+#define VIEWKEYDIALOG_H
+
+#include <QMessageBox>
+#include <QPushButton>
+#include <QDialog>
+
+namespace Ui {
+    class ExportViewKeyDialog;
+}
+
+class ExportViewKeyDialog : public QDialog
+{
+    Q_OBJECT
+public:
+    ExportViewKeyDialog(QWidget *parent, std::string sparkViewKeyStr);
+    ~ExportViewKeyDialog();
+
+private:
+    Ui::ExportViewKeyDialog *ui;
+    QDialog *viewkey;
+};
+
+
+#endif
+

--- a/src/qt/forms/exportviewkeydialog.ui
+++ b/src/qt/forms/exportviewkeydialog.ui
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ExportViewKeyDialog</class>
+ <widget class="QDialog" name="ExportViewKeyDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>800</width>
+    <height>150</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Export View Key</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="key">
+       <property name="text">
+         <string></string>
+       </property>
+       <property name="textInteractionFlags">
+         <set>Qt::TextSelectableByMouse</set>
+       </property>
+       <property name="wordWrap">
+         <bool>true</bool>
+       </property>
+       <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>1</verstretch>
+         </sizepolicy>
+        </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+
+   <item>
+    <spacer name="verticalSpacer">
+    <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>ExportViewKeyDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -188,6 +188,13 @@ void WalletFrame::backupWallet()
         walletView->backupWallet();
 }
 
+void WalletFrame::exportViewKey()
+{
+    WalletView *walletView = currentWalletView();
+    if (walletView)
+        walletView->exportViewKey();
+}
+
 void WalletFrame::changePassphrase()
 {
     WalletView *walletView = currentWalletView();

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -92,6 +92,8 @@ public Q_SLOTS:
     void backupWallet();
     /** Change encrypted wallet passphrase */
     void changePassphrase();
+    /** Export the Spark View Key */
+    void exportViewKey();
     /** Ask for passphrase to unlock wallet temporarily */
     void unlockWallet();
 

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -10,6 +10,7 @@
 #include "automintmodel.h"
 #include "bitcoingui.h"
 #include "clientmodel.h"
+#include "exportviewkeydialog.h"
 #include "guiutil.h"
 #include "lelantusdialog.h"
 #include "lelantusmodel.h"
@@ -385,6 +386,12 @@ void WalletView::backupWallet()
         Q_EMIT message(tr("Backup Successful"), tr("The wallet data was successfully saved to %1.").arg(filename),
             CClientUIInterface::MSG_INFORMATION);
     }
+}
+
+void WalletView::exportViewKey()
+{
+    ExportViewKeyDialog dlg(this, walletModel->getWallet()->GetSparkViewKeyStr());
+    dlg.exec();
 }
 
 void WalletView::changePassphrase()

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -128,6 +128,8 @@ public Q_SLOTS:
     void backupWallet();
     /** Change encrypted wallet passphrase */
     void changePassphrase();
+    /** Show the Spark view key */
+    void exportViewKey();
     /** Ask for passphrase to unlock wallet temporarily */
     void unlockWallet(const QString & info = "");
 

--- a/src/wallet/bip39.cpp
+++ b/src/wallet/bip39.cpp
@@ -41,7 +41,7 @@ SecureString Mnemonic::mnemonic_generate(int strength)
 
 SecureString Mnemonic::mnemonic_from_data(const SecureVector& data, int len)
 {
-    if (len % 4 || len < 16 || len > 32) {
+    if (len % 4) {
         return SecureString();
     }
 

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -4,6 +4,7 @@
 
 #include "base58.h"
 #include "chain.h"
+#include "libspark/keys.h"
 #include "rpc/server.h"
 #include "init.h"
 #include "validation.h"
@@ -583,6 +584,18 @@ UniValue importwallet(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_WALLET_ERROR, "Error adding some keys to wallet");
 
     return NullUniValue;
+}
+
+UniValue dumpsparkviewkey(const JSONRPCRequest& request) {
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp)) {
+        throw std::runtime_error("wallet not available");
+    }
+
+    if (request.fHelp || request.params.size() != 0)
+        throw std::runtime_error("dumpviewkey\n\nDisplay our Spark View Key.\n");
+
+  return {pwallet->GetSparkViewKeyStr()};
 }
 
 UniValue dumpprivkey(const JSONRPCRequest& request)

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -5702,6 +5702,7 @@ UniValue setusednumber(const JSONRPCRequest& request)
 /******************************************************************************/
 
 extern UniValue dumpprivkey(const JSONRPCRequest& request); // in rpcdump.cpp
+extern UniValue dumpsparkviewkey(const JSONRPCRequest& request); // in rpcdump.cpp
 extern UniValue importprivkey(const JSONRPCRequest& request);
 extern UniValue importaddress(const JSONRPCRequest& request);
 extern UniValue importpubkey(const JSONRPCRequest& request);
@@ -5722,6 +5723,7 @@ static const CRPCCommand commands[] =
     { "wallet",             "backupwallet",             &backupwallet,             true,   {"destination"} },
     { "wallet",             "bumpfee",                  &bumpfee,                  true,   {"txid", "options"} },
     { "wallet",             "dumpprivkey",              &dumpprivkey_firo,        true,   {"address"}  },
+    { "wallet",             "dumpsparkviewkey",         &dumpsparkviewkey,        true,   {}  },
     { "wallet",             "dumpwallet",               &dumpwallet_firo,         true,   {"filename"} },
     { "wallet",             "encryptwallet",            &encryptwallet,            true,   {"passphrase"} },
     { "wallet",             "getaccountaddress",        &getaccountaddress,        true,   {"account"} },

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5,6 +5,10 @@
 
 #include "wallet.h"
 #include "boost/filesystem/operations.hpp"
+#include "libspark/keys.h"
+#include "serialize.h"
+#include "support/allocators/secure.h"
+#include "sync.h"
 #include "walletexcept.h"
 #include "sigmaspendbuilder.h"
 #include "lelantusjoinsplitbuilder.h"
@@ -42,6 +46,7 @@
 #include "init.h"
 #include "hdmint/wallet.h"
 #include "rpc/protocol.h"
+#include "wallet/bip39.h"
 
 #include "crypto/hmac_sha512.h"
 #include "crypto/aes.h"
@@ -6850,6 +6855,33 @@ void CWallet::MarkReserveKeysAsUsed(int64_t keypool_id)
         walletdb.ErasePool(index);
         it = setKeyPool.erase(it);
     }
+}
+
+spark::FullViewKey CWallet::GetSparkViewKey() {
+  LOCK(cs_wallet);
+  CWalletDB walletdb(strWalletFile);
+  spark::FullViewKey key;
+  walletdb.readFullViewKey(key);
+
+  return key;
+}
+
+std::string CWallet::GetSparkViewKeyStr() {
+  spark::FullViewKey key = GetSparkViewKey();
+  int size = GetSerializeSize(key, SER_NETWORK, PROTOCOL_VERSION);
+  std::ostringstream keydata;
+  ::Serialize(keydata, key);
+
+  std::string keydata_s = keydata.str();
+  assert(keydata_s.size() % 4 == 0);
+
+  SecureVector seckeydata(keydata_s.begin(), keydata_s.end());
+
+  SecureString mnemonicsecstr = Mnemonic::mnemonic_from_data(seckeydata, seckeydata.size());
+  std::string mnemonicstr(mnemonicsecstr.begin(), mnemonicsecstr.end());
+  assert(!mnemonicstr.empty());
+
+  return mnemonicstr;
 }
 
 bool CWallet::UpdatedTransaction(const uint256 &hashTx)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -9,6 +9,7 @@
 #include "amount.h"
 #include "../sigma/coin.h"
 #include "../liblelantus/coin.h"
+#include "libspark/keys.h"
 #include "streams.h"
 #include "tinyformat.h"
 #include "ui_interface.h"
@@ -1166,6 +1167,9 @@ public:
      */
     void MarkReserveKeysAsUsed(int64_t keypool_id);
     const std::map<CKeyID, int64_t>& GetAllReserveKeys() const { return m_pool_key_to_index; }
+
+    spark::FullViewKey GetSparkViewKey();
+    std::string GetSparkViewKeyStr();
 
     std::set< std::set<CTxDestination> > GetAddressGroupings();
     std::map<CTxDestination, CAmount> GetAddressBalances();


### PR DESCRIPTION
## PR intention
Enable exporting Spark view keys in RPC and Qt.

## Code changes brief
This adds a RPC command to export Spark view keys (in mnemonic style) and adds a Qt dialog to show the same.