### PR TITLE
ci: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/test-dockerfile.yml
+++ b/.github/workflows/test-dockerfile.yml
@@ -14,7 +14,7 @@ jobs:
    runs-on: ubuntu-latest
   
    steps:
-     - uses: actions/checkout@v3
+     - uses: actions/checkout@v4
      - name: Build Docker image 
        run: docker build -t firo .
 


### PR DESCRIPTION
Hey ! GitHub‑hosted runners now use Node 20, so checkout v4 is required
This PR updates all workflows to actions/checkout@v4 , no functional changes expected