### PR TITLE
Cmake build branch fix warnings

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -10,6 +10,10 @@ AM_CPPFLAGS = $(HARDENED_CPPFLAGS)
 AM_LIBTOOLFLAGS = --preserve-dup-deps
 EXTRA_LIBRARIES =
 
+AM_CPPFLAGS += -I$(srcdir) -I$(srcdir)/../src
+# Add the directory containing compat_macros.h
+AM_CPPFLAGS += -I$(srcdir)/../src
+
 noinst_LTLIBRARIES =
 
 if ENABLE_CRASH_HOOKS
@@ -894,7 +898,8 @@ CLEANFILES += zmq/*.gcda zmq/*.gcno
 
 DISTCLEANFILES = obj/build.h
 
-EXTRA_DIST = $(CTAES_DIST)
+EXTRA_DIST = $(CTAES_DIST) \
+    compat_macros.h
 
 config/bitcoin-config.h: config/stamp-h1
 	@$(MAKE) -C $(top_builddir) $(subdir)/$(@)

--- a/src/bls/bls_worker.cpp
+++ b/src/bls/bls_worker.cpp
@@ -133,8 +133,8 @@ struct Aggregator {
     size_t batchSize{16};
     std::shared_ptr<std::vector<const T*> > inputVec;
 
-    bool parallel;
     ctpl::thread_pool& workerPool;
+    bool parallel;
 
     std::mutex m;
     // items in the queue are all intermediate aggregation results of finished batches.
@@ -336,15 +336,16 @@ struct VectorAggregator {
     typedef std::shared_ptr<VectorType> VectorPtrType;
     typedef std::vector<VectorPtrType> VectorVectorType;
     typedef std::function<void(const VectorPtrType& agg)> DoneCallback;
-    DoneCallback doneCallback;
 
     const VectorVectorType& vecs;
+    bool parallel;
     size_t start;
     size_t count;
-    bool parallel;
     ctpl::thread_pool& workerPool;
 
     std::atomic<size_t> doneCount;
+
+    DoneCallback doneCallback;
 
     VectorPtrType result;
     size_t vecSize;
@@ -761,7 +762,7 @@ std::future<bool> CBLSWorker::AsyncVerifyContributionShare(const CBLSId& forId,
         return std::move(p.second);
     }
 
-    auto f = [this, &forId, &vvec, &skContribution](int threadId) {
+    auto f = [&forId, &vvec, &skContribution](int threadId) {
         CBLSPublicKey pk1;
         if (!pk1.PublicKeyShare(*vvec, forId)) {
             return false;

--- a/src/compat_macros.h
+++ b/src/compat_macros.h
@@ -1,0 +1,15 @@
+#ifndef COMPAT_MACROS_H
+#define COMPAT_MACROS_H
+
+#if defined(__cplusplus) && (__cplusplus >= 201703L) \
+    && defined(__has_cpp_attribute) && __has_cpp_attribute(fallthrough)
+  #define FIRO_FALLTHROUGH [[fallthrough]]
+#elif defined(__has_cpp_attribute) && __has_cpp_attribute(gnu::fallthrough)
+  #define FIRO_FALLTHROUGH [[gnu::fallthrough]]
+#elif defined(__GNUC__) && (__GNUC__ >= 7) && !defined(__clang__)
+  #define FIRO_FALLTHROUGH __attribute__((fallthrough))
+#else
+  #define FIRO_FALLTHROUGH /* fallthrough */
+#endif
+
+#endif // COMPAT_MACROS_H

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -7,6 +7,8 @@
 #include "crypto/hmac_sha512.h"
 #include "pubkey.h"
 
+#include "compat_macros.h"
+
 
 inline uint32_t ROTL32(uint32_t x, int8_t r)
 {
@@ -49,8 +51,10 @@ unsigned int MurmurHash3(unsigned int nHashSeed, const std::vector<unsigned char
         switch (vDataToHash.size() & 3) {
         case 3:
             k1 ^= tail[2] << 16;
+            FIRO_FALLTHROUGH;
         case 2:
             k1 ^= tail[1] << 8;
+            FIRO_FALLTHROUGH;
         case 1:
             k1 ^= tail[0];
             k1 *= c1;

--- a/src/hdmint/wallet.cpp
+++ b/src/hdmint/wallet.cpp
@@ -819,8 +819,8 @@ bool CHDMintWallet::CreateMintSeed(CWalletDB& walletdb, uint512& mintSeed, const
     }
 
     // HMAC-SHA512(SHA256(count),key)
-    unsigned char countHash[CSHA256().OUTPUT_SIZE];
-    std::vector<unsigned char> result(CSHA512().OUTPUT_SIZE);
+    unsigned char countHash[CSHA256::OUTPUT_SIZE];
+    std::vector<unsigned char> result(CSHA512::OUTPUT_SIZE);
 
     std::string nCountStr = std::to_string(nCount);
     CSHA256().Write(reinterpret_cast<const unsigned char*>(nCountStr.c_str()), nCountStr.size()).Finalize(countHash);

--- a/src/liblelantus/threadpool.h
+++ b/src/liblelantus/threadpool.h
@@ -33,8 +33,8 @@ private:
     boost::mutex                                task_queue_mutex;
     boost::condition_variable                   task_queue_condition;
 
-    bool                                      shutdown;
     size_t const                              number_of_threads;
+    bool                                      shutdown;
 
     void ThreadProc() {
         for (;;) {

--- a/src/libspark/keys.h
+++ b/src/libspark/keys.h
@@ -20,6 +20,7 @@ public:
 	const Scalar& get_s2() const;
 	const Scalar& get_r() const;
 
+	SpendKey(const SpendKey&) = default;
     SpendKey& operator=(const SpendKey& other);
     bool operator==(const SpendKey& other) const;
 

--- a/src/qt/recentrequeststablemodel.cpp
+++ b/src/qt/recentrequeststablemodel.cpp
@@ -11,6 +11,8 @@
 #include "clientversion.h"
 #include "streams.h"
 
+#include "../compat_macros.h"
+
 #include <boost/foreach.hpp>
 
 const QString RecentRequestsTableModel::Transparent = "Transparent";
@@ -84,6 +86,7 @@ QVariant RecentRequestsTableModel::data(const QModelIndex &index, int role) cons
             {
                 return tr("spark");
             }
+            FIRO_FALLTHROUGH;
         case Message:
             if(rec->recipient.message.isEmpty() && role == Qt::DisplayRole)
             {

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -9,6 +9,8 @@
 #include "rpcconsole.h"
 #include "ui_debugwindow.h"
 
+#include "../compat_macros.h"
+
 #include "bantablemodel.h"
 #include "clientmodel.h"
 #include "guiutil.h"
@@ -201,7 +203,7 @@ bool RPCConsole::RPCParseCommandLine(std::string &strResult, const std::string &
         char ch = strCommandTerminated[chpos];
         switch(state)
         {
-            case STATE_COMMAND_EXECUTED_INNER:
+            case STATE_COMMAND_EXECUTED_INNER:     FIRO_FALLTHROUGH;
             case STATE_COMMAND_EXECUTED:
             {
                 bool breakParsing = true;
@@ -264,10 +266,11 @@ bool RPCConsole::RPCParseCommandLine(std::string &strResult, const std::string &
                 }
                 if (breakParsing)
                     break;
+                FIRO_FALLTHROUGH;
             }
-            case STATE_ARGUMENT: // In or after argument
-            case STATE_EATING_SPACES_IN_ARG:
-            case STATE_EATING_SPACES_IN_BRACKETS:
+            case STATE_ARGUMENT:                    FIRO_FALLTHROUGH;// In or after argument 
+            case STATE_EATING_SPACES_IN_ARG:        FIRO_FALLTHROUGH;
+            case STATE_EATING_SPACES_IN_BRACKETS:   FIRO_FALLTHROUGH;
             case STATE_EATING_SPACES: // Handle runs of whitespace
                 switch(ch)
             {
@@ -370,7 +373,9 @@ bool RPCConsole::RPCParseCommandLine(std::string &strResult, const std::string &
                 strResult = lastResult.get_str();
             else
                 strResult = lastResult.write(2);
+            FIRO_FALLTHROUGH;
         case STATE_ARGUMENT:
+            FIRO_FALLTHROUGH;
         case STATE_EATING_SPACES:
             return true;
         default: // ERROR to end in one of the other states

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -496,6 +496,8 @@ bool WalletView::eventFilter(QObject *watched, QEvent *event)
     case QEvent::Type::Move:
         repositionAutomintSparkNotification();
         break;
+    default:
+        break;
     }
 
     return QStackedWidget::eventFilter(watched, event);

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -16,6 +16,8 @@
 #include "utilstrencodings.h"
 #include "version.h"
 
+#include "compat_macros.h"
+
 #include <boost/algorithm/string.hpp>
 
 #include <univalue.h>
@@ -462,6 +464,7 @@ static bool rest_getutxos(HTTPRequest* req, const std::string& strURIPart)
         // convert hex to bin, continue then with bin part
         std::vector<unsigned char> strRequestV = ParseHex(strRequestMutable);
         strRequestMutable.assign(strRequestV.begin(), strRequestV.end());
+        FIRO_FALLTHROUGH;
     }
 
     case RF_BINARY: {

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -26,6 +26,8 @@
 #include "utilstrencodings.h"
 #include "validationinterface.h"
 
+#include "../compat_macros.h"
+
 #include "masternode-payments.h"
 #include "masternode-sync.h"
 
@@ -760,6 +762,7 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
                 // Ensure bit is set in block version
                 pblock->nVersion |= VersionBitsMask(consensusParams, pos);
                 // FALL THROUGH to get vbavailable set...
+                FIRO_FALLTHROUGH;
             case THRESHOLD_STARTED:
             {
                 const struct BIP9DeploymentInfo& vbinfo = VersionBitsDeploymentInfo[pos];

--- a/src/script/ismine.cpp
+++ b/src/script/ismine.cpp
@@ -11,6 +11,8 @@
 #include "script/standard.h"
 #include "script/sign.h"
 
+#include "../compat_macros.h"
+
 #include <boost/foreach.hpp>
 
 typedef std::vector<unsigned char> valtype;
@@ -148,7 +150,7 @@ isminetype IsMine(const CKeyStore &keystore, const CScript& scriptPubKey, bool& 
             return ISMINE_SPENDABLE;
         break;
     }
-    case TX_SPARKMINT: {}
+    case TX_SPARKMINT: { FIRO_FALLTHROUGH; }
     case TX_SPARKSMINT: {}
     }
 

--- a/src/spark/state.cpp
+++ b/src/spark/state.cpp
@@ -175,7 +175,7 @@ spark::SpendTransaction ParseSparkSpend(const CTransaction &tx)
     const spark::Params* params = spark::Params::get_default();
     spark::SpendTransaction spendTransaction(params);
     serialized >> spendTransaction;
-    return std::move(spendTransaction);
+    return spendTransaction;
 }
 
 

--- a/src/tinyformat.h
+++ b/src/tinyformat.h
@@ -138,6 +138,8 @@ namespace tfm = tinyformat;
 #include <sstream>
 #include <stdexcept>
 
+#include "compat_macros.h"
+
 #ifndef TINYFORMAT_ERROR
 #   define TINYFORMAT_ERROR(reason) assert(0 && reason)
 #endif
@@ -705,23 +707,29 @@ inline const char* streamStateFromFormat(std::ostream& out, bool& spacePadPositi
             break;
         case 'X':
             out.setf(std::ios::uppercase);
-        case 'x': case 'p':
+            FIRO_FALLTHROUGH;
+        case 'x':
+            FIRO_FALLTHROUGH;
+        case 'p':
             out.setf(std::ios::hex, std::ios::basefield);
             intConversion = true;
             break;
         case 'E':
             out.setf(std::ios::uppercase);
+            FIRO_FALLTHROUGH;
         case 'e':
             out.setf(std::ios::scientific, std::ios::floatfield);
             out.setf(std::ios::dec, std::ios::basefield);
             break;
         case 'F':
             out.setf(std::ios::uppercase);
+            FIRO_FALLTHROUGH;
         case 'f':
             out.setf(std::ios::fixed, std::ios::floatfield);
             break;
         case 'G':
             out.setf(std::ios::uppercase);
+            FIRO_FALLTHROUGH;
         case 'g':
             out.setf(std::ios::dec, std::ios::basefield);
             // As in boost::format, let stream decide float format.

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -125,6 +125,7 @@ public:
                     int64_t nSigOpsCost, LockPoints lp);
 
     CTxMemPoolEntry(const CTxMemPoolEntry& other);
+    CTxMemPoolEntry& operator=(const CTxMemPoolEntry& other) = default;
 
     const CTransaction& GetTx() const { return *this->tx; }
     CTransactionRef GetSharedTx() const { return this->tx; }

--- a/src/univalue/include/univalue.h
+++ b/src/univalue/include/univalue.h
@@ -278,6 +278,6 @@ static inline bool json_isspace(int ch)
 
 extern const UniValue NullUniValue;
 
-const UniValue& find_value( const UniValue& obj, const std::string& name);
+const UniValue& find_value(const UniValue& obj, const std::string& name);
 
 #endif // __UNIVALUE_H__

--- a/src/wallet/rpcwallet.h
+++ b/src/wallet/rpcwallet.h
@@ -16,7 +16,7 @@ void RegisterWalletRPCCommands(CRPCTable &t);
  * @param[in] request JSONRPCRequest that wishes to access a wallet
  * @return NULL if no wallet should be used, or a pointer to the CWallet
  */
-CWallet *GetWalletForJSONRPCRequest(const JSONRPCRequest&);
+CWallet *GetWalletForJSONRPCRequest(const JSONRPCRequest& request);
 
 std::string HelpRequiringPassphrase(CWallet *);
 void EnsureWalletIsUnlocked(CWallet *);


### PR DESCRIPTION
## PR intention
Fix warnings: 
1. initialization order warnings
2. unnecessary use of std::move
3. missing defaulted operators
4. fallthrough warning.
