### PR TITLE
fix sparktest segfault

### DIFF
--- a/src/liblelantus/threadpool.h
+++ b/src/liblelantus/threadpool.h
@@ -68,26 +68,13 @@ private:
         // start missing threads
         while (threads.size() < number_of_threads)
             threads.emplace_back(std::bind(&ParallelOpThreadPool::ThreadProc, this));
-    }
+        }
 
 public:
     ParallelOpThreadPool(std::size_t thread_number) : number_of_threads(thread_number), shutdown(false) {}
 
     ~ParallelOpThreadPool() {
-        std::list<boost::thread> threadsToJoin;
-
-        {
-            boost::mutex::scoped_lock lock(task_queue_mutex);
-            shutdown = true;
-            task_queue_condition.notify_all();
-
-            // move the list to separate variable to wait for the shutdown process to complete
-            threadsToJoin.swap(threads);
-        }
-
-        // wait for all the threads
-        for (boost::thread &t: threadsToJoin)
-            t.join();
+        Shutdown();
     }
 
     // Post a task to the thread pool and return a future to wait for its completion
@@ -109,6 +96,23 @@ public:
 
     int GetNumberOfThreads() const {
         return number_of_threads;
+    }
+
+    void Shutdown() {
+        std::list<boost::thread> threadsToJoin;
+
+        {
+            boost::mutex::scoped_lock lock(task_queue_mutex);
+            shutdown = true;
+            task_queue_condition.notify_all();
+
+            // move the list to separate variable to wait for the shutdown process to complete
+            threadsToJoin.swap(threads);
+        }
+
+        // wait for all the threads
+        for (boost::thread &t: threadsToJoin)
+            t.join();
     }
 };
 

--- a/src/spark/sparkwallet.cpp
+++ b/src/spark/sparkwallet.cpp
@@ -84,6 +84,10 @@ CSparkWallet::~CSparkWallet() {
     delete (ParallelOpThreadPool<void>*)threadPool;
 }
 
+void CSparkWallet::FinishTasks() {
+    ((ParallelOpThreadPool<void>*)threadPool)->Shutdown();
+}
+
 void CSparkWallet::resetDiversifierFromDB(CWalletDB& walletdb) {
     walletdb.readDiversifier(lastDiversifier);
 }

--- a/src/spark/sparkwallet.h
+++ b/src/spark/sparkwallet.h
@@ -153,6 +153,8 @@ public:
     // Returns the list of pairs of coins and metadata for that coin,
     std::list<CSparkMintMeta> GetAvailableSparkCoins(const CCoinControl *coinControl = NULL) const;
 
+    void FinishTasks();
+
 public:
     // to protect coinMeta
     mutable CCriticalSection cs_spark_wallet;

--- a/src/spark/state.cpp
+++ b/src/spark/state.cpp
@@ -950,6 +950,7 @@ CSparkState::CSparkState(
 }
 
 void CSparkState::Reset() {
+    ShutdownWallet();
     coinGroups.clear();
     latestCoinId = 0;
     mintedCoins.clear();

--- a/src/spark/state.h
+++ b/src/spark/state.h
@@ -7,6 +7,7 @@
 
 #include "libspark/coin.h"
 #include "chain.h"
+#include "../wallet/wallet.h"
 #include "../libspark/mint_transaction.h"
 #include "../libspark/spend_transaction.h"
 #include "primitives.h"

--- a/src/test/fixtures.cpp
+++ b/src/test/fixtures.cpp
@@ -423,4 +423,5 @@ CTransaction SparkTestingSetup::GenerateSparkSpend(
 
 SparkTestingSetup::~SparkTestingSetup()
 {
+    pwalletMain->sparkWallet->FinishTasks();
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -8265,6 +8265,14 @@ bool CMerkleTx::AcceptToMemoryPool(const CAmount &nAbsurdFee, CValidationState &
 bool CompSigmaHeight(const CSigmaEntry &a, const CSigmaEntry &b) { return a.nHeight < b.nHeight; }
 bool CompSigmaID(const CSigmaEntry &a, const CSigmaEntry &b) { return a.id < b.id; }
 
+void ShutdownWallet() {
+    if (pwalletMain) {
+        if (pwalletMain->sparkWallet) {
+            pwalletMain->sparkWallet->FinishTasks();
+        }
+    }
+}
+
 bool CWallet::CreateSparkMintTransactions(
     const std::vector<spark::MintedCoinData>& outputs,
     std::vector<std::pair<CWalletTx, CAmount>>& wtxAndFee,

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1489,6 +1489,7 @@ public:
 
 bool CompSigmaHeight(const CSigmaEntry& a, const CSigmaEntry& b);
 bool CompSigmaID(const CSigmaEntry& a, const CSigmaEntry& b);
+void ShutdownWallet();
 
 // Helper for producing a bunch of max-sized low-S signatures (eg 72 bytes)
 // ContainerType is meant to hold pair<CWalletTx *, int>, and be iterable


### PR DESCRIPTION
## PR intention
Fixing spark test random fails:

https://github.com/firoorg/firo/actions/runs/14621407026/job/41022138619#step:9:265
https://github.com/aleflm/firo/actions/runs/14784900125/job/41511473433#step:9:265
https://github.com/aleflm/firo/actions/runs/14783545040/job/41507522710#step:9:211

`CSparkWallet` has its own thread pool. The problem is `CSparkWallet::threadPool`, which has type of `ParallelOpThreadPool` might still be active with active tasks, while we are removing `pmainwallet` here: 

https://github.com/firoorg/firo/blob/7f56324324d45ff2a17b5ad8bcf2d21ebd375446/src/test/test_bitcoin.cpp#L141

