### PR TITLE
Added sparkname output type

### DIFF
--- a/src/addresstype.h
+++ b/src/addresstype.h
@@ -1,5 +1,6 @@
 #ifndef ADDRESSTYPE_H
 #define ADDRESSTYPE_H
+#include <iostream>
 
 enum struct AddressType
 {
@@ -18,6 +19,7 @@ enum struct AddressType
     , sparksMint = 12
     , sparkSpend = 13
     , payToExchangeAddress = 14
+    , sparkName = 15
 };
 
 namespace zerocoin { namespace utils {
@@ -80,6 +82,10 @@ inline bool isSparkSMint(std::string const & str){
 
 inline bool isSparkSpend(std::string const & str){
     return str == "Sparkspend";
+}
+
+inline bool isSparkName(std::string const & str){
+    return str == "Sparkname";
 }
 
 }}

--- a/src/addresstype.h
+++ b/src/addresstype.h
@@ -1,6 +1,5 @@
 #ifndef ADDRESSTYPE_H
 #define ADDRESSTYPE_H
-#include <iostream>
 
 enum struct AddressType
 {

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -235,6 +235,8 @@ UniValue getsparknametxdetails(const JSONRPCRequest &request)
             "[\n"
             "  \"Name (string)\n"
             "  \"Address (string)\"\n"
+            "  \"Validity blocks (int)\n"
+            "  \"Additional Info (string)\n"
             "  ...\n"
             "]\n"
             "\nExamples:\n"
@@ -270,6 +272,11 @@ UniValue getsparknametxdetails(const JSONRPCRequest &request)
     UniValue result(UniValue::VOBJ);
     result.push_back(Pair("name", sparkNameData.name));
     result.push_back(Pair("address", sparkNameData.sparkAddress));
+    uint64_t nameBlockHeight = sparkNameManager->GetSparkNameBlockHeight(sparkNameData.name);
+    result.push_back(Pair("validUntil", nameBlockHeight));
+    if (sparkNameData.additionalInfo != "")
+        result.push_back(Pair("additionalInfo", sparkNameData.additionalInfo));
+
     return result;
 }
 

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -685,6 +685,8 @@ void handleSingleAddress(const UniValue& uniAddress, std::vector<std::pair<uint1
 
     } else if(zerocoin::utils::isZerocoinRemint(addr)) {
         addresses.push_back(std::make_pair(uint160(), AddressType::zerocoinRemint));
+    } else if(zerocoin::utils::isSparkName(addr)) {
+        addresses.push_back(std::make_pair(uint160(), AddressType::sparkName));
     } else {
         CBitcoinAddress address(addr);
         uint160 hashBytes;

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -648,6 +648,17 @@ void handleZerocoinSpend(Iterator const begin, Iterator const end, uint256 const
         addrType = AddressType::sigmaSpend;
     }  else if(tx.IsSparkSpend()){
         addrType = AddressType::sparkSpend;
+
+        if (height >= Params().GetConsensus().nSparkNamesStartBlock) {
+            spark::SpendTransaction spendTx(spark::Params::get_default());
+            CSparkNameTxData sparkNameData;
+            size_t pos;
+            CSparkNameManager* sparkNameManager = CSparkNameManager::GetInstance();
+
+            if (sparkNameManager->ParseSparkNameTxData(tx, spendTx, sparkNameData, pos))
+                addressIndex->push_back(std::make_pair(
+                    CAddressIndexKey(AddressType::sparkName, uint160(), height, txNumber, txHash, 0, true), -spendAmount));
+        }
     }
 
     addressIndex->push_back(std::make_pair(CAddressIndexKey(addrType, uint160(), height, txNumber, txHash, 0, true), -spendAmount));
@@ -676,7 +687,6 @@ void handleOutput(const CTxOut &out, size_t outNo, uint256 const & txHash, int h
 
     if(out.scriptPubKey.IsSparkSMint())
         addressIndex->push_back(std::make_pair(CAddressIndexKey(AddressType::sparksMint, uint160(), height, txNumber, txHash, outNo, false), out.nValue));
-
 
     txnouttype type;
     std::vector<std::vector<unsigned char> > addresses;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3991,7 +3991,10 @@ UniValue getsparknames(const JSONRPCRequest &request)
                 continue;
             entry.push_back(Pair("name", name));
             entry.push_back(Pair("address", sparkAddress));
-
+            entry.push_back(Pair("validUntil", sparkNameManager->GetSparkNameBlockHeight(name)));
+            std::string addData = sparkNameManager->GetSparkNameAdditionalData(name);
+            if (addData != "")
+                entry.push_back(Pair("additionalInfo", addData));
             result.push_back(entry);
         }
     }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3954,7 +3954,7 @@ UniValue getsparknames(const JSONRPCRequest &request)
     if (request.fHelp || request.params.size() > 1) {
         throw std::runtime_error(
             "getsparknames [fOnlyOwn] \n"
-            "\nReturns a list of all Spark names.\n"
+            "\nReturns a list of all Spark names and additional info.\n"
             "\nArguments:\n"
             "1. onlyown       (boolean, optional, default=false) Display only the spark names that belong to this wallet\n"
             "\nResult:\n"


### PR DESCRIPTION
The changes introduce a new output address type, sparkName, and extend Spark name support on insight. This includes  enhancing RPC methods to provide more detailed Spark name information, and modifying transaction indexing logic to recognize and process Spark name transactions.

These changes are mostly necessary for the integration of Spark names into Insight, as we have added a new output type sparkname to the explorer and enabled the ability to view all Spark names along with additional information about them.