### PR TITLE
update contrib native_clang version

### DIFF
--- a/depends/packages/native_clang.mk
+++ b/depends/packages/native_clang.mk
@@ -1,15 +1,10 @@
 package=native_clang
-$(package)_version=10.0.1
+$(package)_version=19.1.7
 $(package)_download_path=https://github.com/llvm/llvm-project/releases/download/llvmorg-$($(package)_version)
-ifneq (,$(findstring aarch64,$(BUILD)))
 $(package)_download_file=clang+llvm-$($(package)_version)-aarch64-linux-gnu.tar.xz
 $(package)_file_name=clang+llvm-$($(package)_version)-aarch64-linux-gnu.tar.xz
-$(package)_sha256_hash=90dc69a4758ca15cd0ffa45d07fbf5bf4309d47d2c7745a9f0735ecffde9c31f
-else
-$(package)_download_file=clang+llvm-$($(package)_version)-x86_64-linux-gnu-ubuntu-16.04.tar.xz
-$(package)_file_name=clang+llvm-$($(package)_version)-x86_64-linux-gnu-ubuntu-16.04.tar.xz
-$(package)_sha256_hash=48b83ef827ac2c213d5b64f5ad7ed082c8bcb712b46644e0dc5045c6f462c231
-endif
+$(package)_sha256_hash=a73d9326e5d756e3937df6a9f621664d76403b59119f741901106b387e53a6ae
+
 
 define $(package)_preprocess_cmds
   rm -f $($(package)_extract_dir)/lib/libc++abi.so*


### PR DESCRIPTION
## PR intention
update native_clang: 

URL: https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.7

```
$ >> gpg --keyserver keyserver.ubuntu.com --recv-keys 0FB96824606D15FDD54C3D092FFC629D3F563BDC 
gpg: key 2FFC629D3F563BDC: public key "Muhammad Omair Javaid (LLVM Release Signing Key) <omair.javaid@linaro.org>" imported
gpg: Total number processed: 1
gpg:               imported: 1

$ >> sha256sum clang+llvm-19.1.7-aarch64-linux-gnu.tar.xz
a73d9326e5d756e3937df6a9f621664d76403b59119f741901106b387e53a6ae  clang+llvm-19.1.7-aarch64-linux-gnu.tar.xz

$ >> gpg --verify clang+llvm-19.1.7-aarch64-linux-gnu.tar.xz.sig clang+llvm-19.1.7-aarch64-linux-gnu.tar.xz 
gpg: Signature made Tue 11 Feb 2025 11:14:26 PM GMT
gpg:                using EDDSA key 0FB96824606D15FDD54C3D092FFC629D3F563BDC
gpg: Good signature from "Muhammad Omair Javaid (LLVM Release Signing Key) <omair.javaid@linaro.org>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: 0FB9 6824 606D 15FD D54C  3D09 2FFC 629D 3F56 3BDC

```