### PR TITLE
Fix a crash on startup when ulimits are set to unlimited.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -62,6 +62,7 @@
 #include "llmq/quorums_init.h"
 
 #include <stdint.h>
+#include <sys/resource.h>
 #include <stdio.h>
 #include <memory>
 
@@ -1070,9 +1071,9 @@ void InitLogging() {
 namespace { // Variables internal to initialization process only
 
 ServiceFlags nRelevantServices = NODE_NETWORK;
-int nMaxConnections;
-int nUserMaxConnections;
-int nFD;
+rlim_t nMaxConnections;
+rlim_t nUserMaxConnections;
+rlim_t nFD;
 ServiceFlags nLocalServices = NODE_NETWORK;
 
 }
@@ -1168,10 +1169,10 @@ bool AppInitParameterInteraction()
                 (mapMultiArgs.count("-bind") ? mapMultiArgs.at("-bind").size() : 0) +
                 (mapMultiArgs.count("-whitebind") ? mapMultiArgs.at("-whitebind").size() : 0), size_t(1));
     nUserMaxConnections = GetArg("-maxconnections", DEFAULT_MAX_PEER_CONNECTIONS);
-    nMaxConnections = std::max(nUserMaxConnections, 0);
+    nMaxConnections = std::max(nUserMaxConnections, (rlim_t)0);
 
     // Trim requested connection counts, to fit into system limitations
-    nMaxConnections = std::max(std::min(nMaxConnections, (int)(FD_SETSIZE - nBind - MIN_CORE_FILEDESCRIPTORS - MAX_ADDNODE_CONNECTIONS)), 0);
+    nMaxConnections = std::max(std::min(nMaxConnections, (rlim_t)(FD_SETSIZE - nBind - MIN_CORE_FILEDESCRIPTORS - MAX_ADDNODE_CONNECTIONS)), (rlim_t)0);
     nFD = RaiseFileDescriptorLimit(nMaxConnections + MIN_CORE_FILEDESCRIPTORS + MAX_ADDNODE_CONNECTIONS);
     if (nFD < MIN_CORE_FILEDESCRIPTORS)
         return InitError(_("Not enough file descriptors available."));


### PR DESCRIPTION
## PR intention
Fix a crash on startup.

## Code changes brief
If ulimit is set to unlimited, getrlimit will return a value of UINT_MAX, but it was being interpreted as an int, so this was evaluated as -1 and led to a crash on startup thinking resource limits had been hit.