### PR TITLE
Compilation fix for macOS 15.5+

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -24,6 +24,7 @@ $(package)_patches += guix_cross_lib_path.patch
 $(package)_patches += fix-macos-linker.patch
 $(package)_patches += memory_resource.patch
 $(package)_patches += windows_lto.patch
+$(package)_patches += fix-libpng.patch
 
 $(package)_qttranslations_file_name=qttranslations-$($(package)_suffix)
 $(package)_qttranslations_sha256_hash=a31785948c640b7c66d9fe2db4993728ca07f64e41c560b3625ad191b276ff20
@@ -250,6 +251,7 @@ define $(package)_preprocess_cmds
   patch -p1 -i $($(package)_patch_dir)/fast_fixed_dtoa_no_optimize.patch && \
   patch -p1 -i $($(package)_patch_dir)/guix_cross_lib_path.patch && \
   patch -p1 -i $($(package)_patch_dir)/windows_lto.patch && \
+  patch -p1 -i $($(package)_patch_dir)/fix-libpng.patch && \
   mkdir -p qtbase/mkspecs/macx-clang-linux &&\
   cp -f qtbase/mkspecs/macx-clang/qplatformdefs.h qtbase/mkspecs/macx-clang-linux/ &&\
   cp -f $($(package)_patch_dir)/mac-qmake.conf qtbase/mkspecs/macx-clang-linux/qmake.conf && \

--- a/depends/patches/qt/fix-libpng.patch
+++ b/depends/patches/qt/fix-libpng.patch
@@ -1,0 +1,3656 @@
+diff --git old/qtbase/src/3rdparty/libpng/ANNOUNCE new/qtbase/src/3rdparty/libpng/ANNOUNCE
+index ecf9c7043b0..800446b059b 100644
+--- old/qtbase/src/3rdparty/libpng/ANNOUNCE
++++ new/qtbase/src/3rdparty/libpng/ANNOUNCE
+@@ -1,5 +1,5 @@
+-libpng 1.6.37 - April 14, 2019
+-==============================
++libpng 1.6.41 - January 24, 2024
++================================
+ 
+ This is a public release of libpng, intended for use in production code.
+ 
+@@ -9,13 +9,13 @@ Files available for download
+ 
+ Source files with LF line endings (for Unix/Linux):
+ 
+- * libpng-1.6.37.tar.xz (LZMA-compressed, recommended)
+- * libpng-1.6.37.tar.gz
++ * libpng-1.6.41.tar.xz (LZMA-compressed, recommended)
++ * libpng-1.6.41.tar.gz (deflate-compressed)
+ 
+ Source files with CRLF line endings (for Windows):
+ 
+- * lp1637.7z (LZMA-compressed, recommended)
+- * lp1637.zip
++ * lpng1641.7z (LZMA-compressed, recommended)
++ * lpng1641.zip (deflate-compressed)
+ 
+ Other information:
+ 
+@@ -25,20 +25,39 @@ Other information:
+  * TRADEMARK.md
+ 
+ 
+-Changes since the previous public release (version 1.6.36)
+-----------------------------------------------------------
+-
+- * Fixed a use-after-free vulnerability (CVE-2019-7317) in png_image_free.
+- * Fixed a memory leak in the ARM NEON implementation of png_do_expand_palette.
+- * Fixed a memory leak in pngtest.c.
+- * Fixed two vulnerabilities (CVE-2018-14048, CVE-2018-14550) in
+-   contrib/pngminus; refactor.
+- * Changed the license of contrib/pngminus to MIT; refresh makefile and docs.
+-   (Contributed by Willem van Schaik)
+- * Fixed a typo in the libpng license v2.
+-   (Contributed by Miguel Ojeda)
+- * Added makefiles for AddressSanitizer-enabled builds.
+- * Cleaned up various makefiles.
++Changes from version 1.6.40 to version 1.6.41
++---------------------------------------------
++
++ * Added SIMD-optimized code for the Loongarch LSX hardware.
++   (Contributed by GuXiWei, JinBo and ZhangLixia)
++ * Fixed the run-time discovery of MIPS MSA hardware.
++   (Contributed by Sui Jingfeng)
++ * Fixed an off-by-one error in the function `png_do_check_palette_indexes`,
++   which failed to recognize errors that might have existed in the first
++   column of a broken palette-encoded image. This was a benign regression
++   accidentally introduced in libpng-1.6.33. No pixel was harmed.
++   (Contributed by Adam Richter; reviewed by John Bowler)
++ * Fixed, improved and modernized the contrib/pngminus programs, i.e.,
++   png2pnm.c and pnm2png.c
++ * Removed old and peculiar portability hacks that were meant to silence
++   warnings issued by gcc version 7.1 alone.
++   (Contributed by John Bowler)
++ * Fixed and modernized the CMake file, and raised the minimum required
++   CMake version from 3.1 to 3.6.
++   (Contributed by Clinton Ingram, Timothy Lyanguzov, Tyler Kropp, et al.)
++ * Allowed the configure script to disable the building of auxiliary tools
++   and tests, thus catching up with the CMake file.
++   (Contributed by Carlo Bramini)
++ * Fixed a build issue on Mac.
++   (Contributed by Zixu Wang)
++ * Moved the Autoconf macro files to scripts/autoconf.
++ * Moved the CMake files (except for the main CMakeLists.txt) to
++   scripts/cmake and moved the list of their contributing authors to
++   scripts/cmake/AUTHORS.md
++ * Updated the CI configurations and scripts.
++ * Relicensed the CI scripts to the MIT License.
++ * Improved the test coverage.
++   (Contributed by John Bowler)
+ 
+ 
+ Send comments/corrections/commendations to png-mng-implement at lists.sf.net.
+diff --git old/qtbase/src/3rdparty/libpng/CHANGES new/qtbase/src/3rdparty/libpng/CHANGES
+index f0b0a9342c3..2d9a57e439e 100644
+--- old/qtbase/src/3rdparty/libpng/CHANGES
++++ new/qtbase/src/3rdparty/libpng/CHANGES
+@@ -204,7 +204,7 @@ Version 0.97 [January, 1998]
+   Added simple sRGB support (Glenn R-P)
+   Easier conditional compiling, e.g.,
+     define PNG_READ/WRITE_NOT_FULLY_SUPPORTED;
+-    all configurable options can be selected from command-line instead
++    all configurable options can be selected from command line instead
+     of having to edit pngconf.h (Glenn R-P)
+   Fixed memory leak in pngwrite.c (free info_ptr->text) (Glenn R-P)
+   Added more conditions for png_do_background, to avoid changing
+@@ -942,7 +942,7 @@ Version 1.0.8 [July 24, 2000]
+ Version 1.0.9beta1 [November 10, 2000]
+   Fixed typo in scripts/makefile.hpux
+   Updated makevms.com in scripts and contrib/* and contrib/* (Martin Zinser)
+-  Fixed seqence-point bug in contrib/pngminus/png2pnm (Martin Zinser)
++  Fixed sequence-point bug in contrib/pngminus/png2pnm (Martin Zinser)
+   Changed "cdrom.com" in documentation to "libpng.org"
+   Revised pnggccrd.c to get it all working, and updated makefile.gcmmx (Greg).
+   Changed type of "params" from voidp to png_voidp in png_read|write_png().
+@@ -2295,7 +2295,7 @@ Version 1.4.0beta58 [May 14, 2009]
+   Clarified usage of sig_bit versus sig_bit_p in example.c (Vincent Torri)
+ 
+ Version 1.4.0beta59 [May 15, 2009]
+-  Reformated sources in libpng style (3-space intentation, comment format)
++  Reformatted sources in libpng style (3-space indentation, comment format)
+   Fixed typo in libpng docs (PNG_FILTER_AVE should be PNG_FILTER_AVG)
+   Added sections about the git repository and our coding style to the
+     documentation
+@@ -2661,7 +2661,7 @@ Version 1.4.1beta06 [January 28, 2010]
+ 
+ Version 1.4.1beta07 [February 6, 2010]
+   Folded some long lines in the source files.
+-  Added defineable PNG_USER_CHUNK_CACHE_MAX, PNG_USER_CHUNK_MALLOC_MAX,
++  Added definable PNG_USER_CHUNK_CACHE_MAX, PNG_USER_CHUNK_MALLOC_MAX,
+     and a PNG_USER_LIMITS_SUPPORTED flag.
+   Eliminated use of png_ptr->irowbytes and reused the slot in png_ptr as
+     png_ptr->png_user_chunk_malloc_max.
+@@ -3886,7 +3886,7 @@ Version 1.6.0beta06 [January 24, 2012]
+ Version 1.6.0beta07 [January 28, 2012]
+   Eliminated Intel icc/icl compiler warnings. The Intel (GCC derived)
+     compiler issues slightly different warnings from those issued by the
+-    current vesions of GCC. This eliminates those warnings by
++    current versions of GCC. This eliminates those warnings by
+     adding/removing casts and small code rewrites.
+   Updated configure.ac from autoupdate: added --enable-werror option.
+     Also some layout regularization and removal of introduced tab characters
+@@ -3919,7 +3919,7 @@ Version 1.6.0beta08 [February 1, 2012]
+     version checking to configure.ac
+   Improved pngstest speed by not doing redundant tests and add const to
+     the background parameter of png_image_finish_read. The --background
+-    option is now done automagically only when required, so that commandline
++    option is now done automagically only when required, so that command-line
+     option no longer exists.
+   Cleaned up pngpriv.h to consistently declare all functions and data.
+     Also eliminated PNG_CONST_DATA, which is apparently not needed but we
+@@ -4052,7 +4052,7 @@ Version 1.6.0beta16 [March 6, 2012]
+     (in fact this is harmless, but the PNG data produced may be sub-optimal).
+ 
+ Version 1.6.0beta17 [March 10, 2012]
+-  Fixed PNG_LIBPNG_BUILD_BASE_TYPE definition. 
++  Fixed PNG_LIBPNG_BUILD_BASE_TYPE definition.
+   Reject all iCCP chunks after the first, even if the first one is invalid.
+   Deflate/inflate was reworked to move common zlib calls into single
+     functions [rw]util.c.  A new shared keyword check routine was also added
+@@ -4962,7 +4962,7 @@ Version 1.6.13beta01 [July 4, 2014]
+   Changed "if defined(__ARM_NEON__)" to
+     "if (defined(__ARM_NEON__) || defined(__ARM_NEON))" (James Wu).
+   Fixed clang no-warning builds: png_digit was defined but never used.
+-    
++
+ Version 1.6.13beta02 [July 21, 2014]
+   Fixed an incorrect separator ("/" should be "\") in scripts/makefile.vcwin32
+     (bug report from Wolfgang S. Kechel).  Bug was introduced in libpng-1.6.11.
+@@ -5453,7 +5453,7 @@ Version 1.6.21beta01 [December 11, 2015]
+ Version 1.6.21beta02 [December 14, 2015]
+   Moved png_check_keyword() from pngwutil.c to pngset.c
+   Removed LE/BE dependencies in pngvalid, to 'fix' the current problem
+-    in the BigEndian tests by not testing it, making the BE code the same 
++    in the BigEndian tests by not testing it, making the BE code the same
+     as the LE version.
+   Fixes to pngvalid for various reduced build configurations (eliminate unused
+     statics) and a fix for the case in rgb_to_gray when the digitize option
+@@ -5517,7 +5517,7 @@ Version 1.6.22beta03 [March 9, 2016]
+   Added a common-law trademark notice and export control information
+     to the LICENSE file, png.h, and the man page.
+   Restored "& 0xff" in png_save_uint_16() and png_save_uint_32() that
+-    were accidentally removed from libpng-1.6.17. 
++    were accidentally removed from libpng-1.6.17.
+   Changed PNG_INFO_cHNK and PNG_FREE_cHNK from 0xnnnn to 0xnnnnU in png.h
+     (Robert C. Seacord).
+   Removed dubious "#if INT_MAX" test from png.h that was added to
+@@ -5927,7 +5927,7 @@ Version 1.6.32beta03 [August 2, 2017]
+     (Bug report from the OSS-fuzz project).
+ 
+ Version 1.6.32beta04 [August 2, 2017]
+-  Replaced local eXIf_buf with info_ptr-eXIf_buf in png_handle_eXIf().
++  Replaced local eXIf_buf with info_ptr->eXIf_buf in png_handle_eXIf().
+   Update libpng.3 and libpng-manual.txt about eXIf functions.
+ 
+ Version 1.6.32beta05 [August 2, 2017]
+@@ -5950,7 +5950,7 @@ Version 1.6.32beta09 [August 3, 2017]
+   Require cmake-2.8.8 in CMakeLists.txt. Revised symlink creation,
+     no longer using deprecated cmake LOCATION feature (Clifford Yapp).
+   Fixed five-byte error in the calculation of IDAT maximum possible size.
+-  
++
+ Version 1.6.32beta10 [August 5, 2017]
+   Moved chunk-length check into a png_check_chunk_length() private
+     function (Suggested by Max Stepin).
+@@ -6103,6 +6103,64 @@ Version 1.6.37 [April 14, 2019]
+   Added makefiles for AddressSanitizer-enabled builds.
+   Cleaned up various makefiles.
+ 
++Version 1.6.38 [September 14, 2022]
++  Added configurations and scripts for continuous integration.
++  Fixed various errors in the handling of tRNS, hIST and eXIf.
++  Implemented many stability improvements across all platforms.
++  Updated the internal documentation.
++
++Version 1.6.39 [November 20, 2022]
++  Changed the error handler of oversized chunks (i.e. larger than
++    PNG_USER_CHUNK_MALLOC_MAX) from png_chunk_error to png_benign_error.
++  Fixed a buffer overflow error in contrib/tools/pngfix.
++  Fixed a memory leak (CVE-2019-6129) in contrib/tools/pngcp.
++  Disabled the ARM Neon optimizations by default in the CMake file,
++    following the default behavior of the configure script.
++  Allowed configure.ac to work with the trunk version of autoconf.
++  Removed the support for "install" targets from the legacy makefiles;
++    removed the obsolete makefile.cegcc.
++  Cleaned up the code and updated the internal documentation.
++
++Version 1.6.40 [June 21, 2023]
++  Fixed the eXIf chunk multiplicity checks.
++  Fixed a memory leak in pCAL processing.
++  Corrected the validity report about tRNS inside png_get_valid().
++  Fixed various build issues on *BSD, Mac and Windows.
++  Updated the configurations and the scripts for continuous integration.
++  Cleaned up the code, the build scripts, and the documentation.
++
++Version 1.6.41 [January 24, 2024]
++  Added SIMD-optimized code for the Loongarch LSX hardware.
++    (Contributed by GuXiWei, JinBo and ZhangLixia)
++  Fixed the run-time discovery of MIPS MSA hardware.
++    (Contributed by Sui Jingfeng)
++  Fixed an off-by-one error in the function `png_do_check_palette_indexes`,
++    which failed to recognize errors that might have existed in the first
++    column of a broken palette-encoded image. This was a benign regression
++    accidentally introduced in libpng-1.6.33. No pixel was harmed.
++    (Contributed by Adam Richter; reviewed by John Bowler)
++  Fixed, improved and modernized the contrib/pngminus programs, i.e.,
++    png2pnm.c and pnm2png.c
++  Removed old and peculiar portability hacks that were meant to silence
++    warnings issued by gcc version 7.1 alone.
++    (Contributed by John Bowler)
++  Fixed and modernized the CMake file, and raised the minimum required
++    CMake version from 3.1 to 3.6.
++    (Contributed by Clinton Ingram, Timothy Lyanguzov, Tyler Kropp, et al.)
++  Allowed the configure script to disable the building of auxiliary tools
++    and tests, thus catching up with the CMake file.
++    (Contributed by Carlo Bramini)
++  Fixed a build issue on Mac.
++    (Contributed by Zixu Wang)
++  Moved the Autoconf macro files to scripts/autoconf.
++  Moved the CMake files (except for the main CMakeLists.txt) to
++    scripts/cmake and moved the list of their contributing authors to
++    scripts/cmake/AUTHORS.md
++  Updated the CI configurations and scripts.
++  Relicensed the CI scripts to the MIT License.
++  Improved the test coverage.
++    (Contributed by John Bowler)
++
+ Send comments/corrections/commendations to png-mng-implement at lists.sf.net.
+ Subscription is required; visit
+ https://lists.sourceforge.net/lists/listinfo/png-mng-implement
+diff --git old/qtbase/src/3rdparty/libpng/INSTALL new/qtbase/src/3rdparty/libpng/INSTALL
+index 4c170225150..042d7292912 100644
+--- old/qtbase/src/3rdparty/libpng/INSTALL
++++ new/qtbase/src/3rdparty/libpng/INSTALL
+@@ -128,16 +128,18 @@ Your directory structure should look like this:
+           README
+           *.h, *.c  => libpng source files
+           CMakeLists.txt    =>  "cmake" script
++          ci
++             ci_*.sh
+           configuration files:
+              configure.ac, configure, Makefile.am, Makefile.in,
+              autogen.sh, config.guess, ltmain.sh, missing, libpng.pc.in,
+              libpng-config.in, aclocal.m4, config.h.in, config.sub,
+-             depcomp, install-sh, mkinstalldirs, test-pngtest.sh
++             depcomp, install-sh, mkinstalldirs, test-pngtest.sh, etc.
+           contrib
+              arm-neon, conftest, examples, gregbook, libtests, pngminim,
+              pngminus, pngsuite, tools, visupng
+           projects
+-             cbuilder5, owatcom, visualc71, vstudio, xcode
++             owatcom, visualc71, vstudio
+           scripts
+              makefile.*
+              *.def (module definition files)
+@@ -145,7 +147,7 @@ Your directory structure should look like this:
+           pngtest.png
+           etc.
+       zlib
+-          README, *.h, *.c contrib, etc.
++          README, *.h, *.c, contrib, etc.
+ 
+ If the line endings in the files look funny, you may wish to get the other
+ distribution of libpng.  It is available in both tar.gz (UNIX style line
+@@ -153,28 +155,27 @@ endings) and zip (DOS style line endings) formats.
+ 
+ VI. Building with project files
+ 
+-If you are building libpng with MSVC, you can enter the
+-libpng projects\visualc71 or vstudio directory and follow the instructions
+-in README.txt.
++If you are building libpng with Microsoft Visual Studio, you can enter
++the directory projects\visualc71 or projects\vstudio and follow the
++instructions in README.txt.
+ 
+-Otherwise enter the zlib directory and follow the instructions in zlib/README,
+-then come back here and run "configure" or choose the appropriate
+-makefile.sys in the scripts directory.
++Otherwise, enter the zlib directory and follow the instructions in
++zlib/README, then come back here and run "configure" or choose the
++appropriate makefile in the scripts directory.
+ 
+ VII. Building with makefiles
+ 
+ Copy the file (or files) that you need from the
+ scripts directory into this directory, for example
+ 
+-MSDOS example:
++UNIX example:
+ 
+-    copy scripts\makefile.msc makefile
+-    copy scripts\pnglibconf.h.prebuilt pnglibconf.h
++    cp scripts/makefile.std Makefile
++    make
+ 
+-UNIX example:
++Windows example:
+ 
+-    cp scripts/makefile.std makefile
+-    cp scripts/pnglibconf.h.prebuilt pnglibconf.h
++    nmake -f scripts\makefile.vcwin32
+ 
+ Read the makefile to see if you need to change any source or
+ target directories to match your preferences.
+@@ -191,36 +192,33 @@ test.  For more confidence, you can run another test by typing
+ Also, you can run "pngtest -m contrib/pngsuite/*.png" and compare
+ your output with the result shown in contrib/pngsuite/README.
+ 
+-Most of the makefiles will allow you to run "make install" to
+-put the library in its final resting place (if you want to
+-do that, run "make install" in the zlib directory first if necessary).
+-Some also allow you to run "make test-installed" after you have
+-run "make install".
+-
+-VIII. Configuring libpng for 16-bit platforms
++Most of the makefiles used to allow you to run "make install" to put
++the library in its final resting place, but that feature is no longer
++supported.  The only tested and supported manners to install libpng are
++the conventional build and install procedures driven by the configure
++script or by the CMake file.
+ 
+-You will want to look into zconf.h to tell zlib (and thus libpng) that
+-it cannot allocate more than 64K at a time.  Even if you can, the memory
+-won't be accessible.  So limit zlib and libpng to 64K by defining MAXSEG_64K.
++VIII. Configuring for DOS and other 16-bit platforms
+ 
+-IX. Configuring for DOS
++Officially, the support for 16-bit platforms has been removed.
+ 
+ For DOS users who only have access to the lower 640K, you will
+ have to limit zlib's memory usage via a png_set_compression_mem_level()
+ call.  See zlib.h or zconf.h in the zlib library for more information.
+ 
+-X. Configuring for Medium Model
++You may be or may not be in luck if you target the "large" memory model,
++but all the smaller models ("small", "compact" and "medium") are known
++to be unworkable.  For DOS users who have access beyond the lower 640K,
++a "flat" 32-bit DOS model (such as DJGPP) is strongly recommended.
+ 
+-Libpng's support for medium model has been tested on most of the popular
+-compilers.  Make sure MAXSEG_64K gets defined, USE_FAR_KEYWORD gets
+-defined, and FAR gets defined to far in pngconf.h, and you should be
+-all set.  Everything in the library (except for zlib's structure) is
+-expecting far data.  You must use the typedefs with the p or pp on
+-the end for pointers (or at least look at them and be careful).  Make
+-note that the rows of data are defined as png_bytepp, which is
+-an "unsigned char far * far *".
++For DOS users who only have access to the lower 640K, you will have to
++limit zlib's memory usage via a png_set_compression_mem_level() call.
++You will also have to look into zconf.h to tell zlib (and thus libpng)
++that it cannot allocate more than 64K at a time.  Even if you can, the
++memory won't be accessible.  Therefore, you should limit zlib and libpng
++to 64K by defining MAXSEG_64K.
+ 
+-XI. Prepending a prefix to exported symbols
++IX. Prepending a prefix to exported symbols
+ 
+ Starting with libpng-1.6.0, you can configure libpng (when using the
+ "configure" script) to prefix all exported symbols by means of the
+@@ -231,7 +229,7 @@ identifier).  This creates a set of macros in pnglibconf.h, so this is
+ transparent to applications; their function calls get transformed by
+ the macros to use the modified names.
+ 
+-XII. Configuring for compiler xxx:
++X. Configuring for compiler xxx:
+ 
+ All includes for libpng are in pngconf.h.  If you need to add, change
+ or delete an include, this is the place to do it.
+@@ -243,7 +241,7 @@ As of libpng-1.5.0, pngpriv.h also includes three other private header
+ files, pngstruct.h, pnginfo.h, and pngdebug.h, which contain material
+ that previously appeared in the public headers.
+ 
+-XIII. Removing unwanted object code
++XI. Removing unwanted object code
+ 
+ There are a bunch of #define's in pngconf.h that control what parts of
+ libpng are compiled.  All the defines end in _SUPPORTED.  If you are
+@@ -282,7 +280,7 @@ library to fail if they call functions not available in your library.
+ The size of the library itself should not be an issue, because only
+ those sections that are actually used will be loaded into memory.
+ 
+-XIV. Enabling or disabling hardware optimizations
++XII. Enabling or disabling hardware optimizations
+ 
+ Certain hardware capabilities, such as the Intel SSE instructions,
+ are normally detected at run time. Enable them with configure options
+@@ -332,7 +330,7 @@ or disable them all at once with
+ 
+     cmake . -DPNG_HARDWARE_OPTIMIZATIONS=no
+ 
+-XV. Changes to the build and configuration of libpng in libpng-1.5.x
++XIII. Changes to the build and configuration of libpng in libpng-1.5.x
+ 
+ Details of internal changes to the library code can be found in the CHANGES
+ file and in the GIT repository logs.  These will be of no concern to the vast
+@@ -423,7 +421,7 @@ $PREFIX/include directory).  Do not edit pnglibconf.h after you have built
+ libpng, because than the settings would not accurately reflect the settings
+ that were used to build libpng.
+ 
+-XVI. Setjmp/longjmp issues
++XIV. Setjmp/longjmp issues
+ 
+ Libpng uses setjmp()/longjmp() for error handling.  Unfortunately setjmp()
+ is known to be not thread-safe on some platforms and we don't know of
+@@ -441,7 +439,7 @@ This requires setjmp/longjmp, so you must either build the library
+ with PNG_SETJMP_SUPPORTED defined, or with PNG_SIMPLIFIED_READ_SUPPORTED
+ and PNG_SIMPLIFIED_WRITE_SUPPORTED undefined.
+ 
+-XVII. Common linking failures
++XV. Common linking failures
+ 
+ If your application fails to find libpng or zlib entries while linking:
+ 
+@@ -453,12 +451,13 @@ If your application fails to find libpng or zlib entries while linking:
+   If you are using the vstudio project, observe the WARNING in
+   project/vstudio/README.txt.
+ 
+-XVIII. Other sources of information about libpng:
++XVI. Other sources of information about libpng:
+ 
+ Further information can be found in the README and libpng-manual.txt
+ files, in the individual makefiles, in png.h, and the manual pages
+ libpng.3 and png.5.
+ 
++Copyright (c) 2022 Cosmin Truta
+ Copyright (c) 1998-2002,2006-2016 Glenn Randers-Pehrson
+ This document is released under the libpng license.
+ For conditions of distribution and use, see the disclaimer
+diff --git old/qtbase/src/3rdparty/libpng/LICENSE new/qtbase/src/3rdparty/libpng/LICENSE
+index e0c5b531cf5..25f298f0fcf 100644
+--- old/qtbase/src/3rdparty/libpng/LICENSE
++++ new/qtbase/src/3rdparty/libpng/LICENSE
+@@ -4,8 +4,8 @@ COPYRIGHT NOTICE, DISCLAIMER, and LICENSE
+ PNG Reference Library License version 2
+ ---------------------------------------
+ 
+- * Copyright (c) 1995-2019 The PNG Reference Library Authors.
+- * Copyright (c) 2018-2019 Cosmin Truta.
++ * Copyright (c) 1995-2024 The PNG Reference Library Authors.
++ * Copyright (c) 2018-2024 Cosmin Truta.
+  * Copyright (c) 2000-2002, 2004, 2006-2018 Glenn Randers-Pehrson.
+  * Copyright (c) 1996-1997 Andreas Dilger.
+  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
+diff --git old/qtbase/src/3rdparty/libpng/README new/qtbase/src/3rdparty/libpng/README
+index cfc1f0e3dc9..1f51a808f7f 100644
+--- old/qtbase/src/3rdparty/libpng/README
++++ new/qtbase/src/3rdparty/libpng/README
+@@ -1,178 +1,177 @@
+-README for libpng version 1.6.37 - April 14, 2019
+-=================================================
+-
+-See the note about version numbers near the top of png.h.
+-See INSTALL for instructions on how to install libpng.
+-
+-Libpng comes in several distribution formats.  Get libpng-*.tar.gz or
+-libpng-*.tar.xz or if you want UNIX-style line endings in the text
+-files, or lpng*.7z or lpng*.zip if you want DOS-style line endings.
+-
+-Version 0.89 was the first official release of libpng.  Don't let the
+-fact that it's the first release fool you.  The libpng library has been
+-in extensive use and testing since mid-1995.  By late 1997 it had
+-finally gotten to the stage where there hadn't been significant
+-changes to the API in some time, and people have a bad feeling about
+-libraries with versions < 1.0.  Version 1.0.0 was released in
+-March 1998.
+-
+-****
+-Note that some of the changes to the png_info structure render this
+-version of the library binary incompatible with libpng-0.89 or
+-earlier versions if you are using a shared library.  The type of the
+-"filler" parameter for png_set_filler() has changed from png_byte to
+-png_uint_32, which will affect shared-library applications that use
+-this function.
++README for libpng version 1.6.41
++================================
+ 
+-To avoid problems with changes to the internals of the png info_struct,
+-new APIs have been made available in 0.95 to avoid direct application
+-access to info_ptr.  These functions are the png_set_<chunk> and
+-png_get_<chunk> functions.  These functions should be used when
+-accessing/storing the info_struct data, rather than manipulating it
+-directly, to avoid such problems in the future.
++See the note about version numbers near the top of `png.h`.
++See `INSTALL` for instructions on how to install libpng.
+ 
+-It is important to note that the APIs did not make current programs
+-that access the info struct directly incompatible with the new
+-library, through libpng-1.2.x.  In libpng-1.4.x, which was meant to
+-be a transitional release, members of the png_struct and the
+-info_struct can still be accessed, but the compiler will issue a
+-warning about deprecated usage.  Since libpng-1.5.0, direct access
+-to these structs is not allowed, and the definitions of the structs
+-reside in private pngstruct.h and pnginfo.h header files that are not
+-accessible to applications.  It is strongly suggested that new
+-programs use the new APIs (as shown in example.c and pngtest.c), and
+-older programs be converted to the new format, to facilitate upgrades
+-in the future.
+-****
+-
+-Additions since 0.90 include the ability to compile libpng as a
+-Windows DLL, and new APIs for accessing data in the info struct.
+-Experimental functions include the ability to set weighting and cost
+-factors for row filter selection, direct reads of integers from buffers
+-on big-endian processors that support misaligned data access, faster
+-methods of doing alpha composition, and more accurate 16->8 bit color
+-conversion.
++Libpng comes in several distribution formats.  Get `libpng-*.tar.gz`
++or `libpng-*.tar.xz` if you want UNIX-style line endings in the text
++files, or `lpng*.7z` or `lpng*.zip` if you want DOS-style line endings.
+ 
+-The additions since 0.89 include the ability to read from a PNG stream
+-which has had some (or all) of the signature bytes read by the calling
+-application.  This also allows the reading of embedded PNG streams that
+-do not have the PNG file signature.  As well, it is now possible to set
+-the library action on the detection of chunk CRC errors.  It is possible
+-to set different actions based on whether the CRC error occurred in a
+-critical or an ancillary chunk.
++For a detailed description on using libpng, read `libpng-manual.txt`.
++For examples of libpng in a program, see `example.c` and `pngtest.c`.
++For usage information and restrictions (what little they are) on libpng,
++see `png.h`.  For a description on using zlib (the compression library
++used by libpng) and zlib's restrictions, see `zlib.h`.
+ 
+-For a detailed description on using libpng, read libpng-manual.txt.
+-For examples of libpng in a program, see example.c and pngtest.c.  For
+-usage information and restrictions (what little they are) on libpng,
+-see png.h.  For a description on using zlib (the compression library
+-used by libpng) and zlib's restrictions, see zlib.h
+-
+-I have included a general makefile, as well as several machine and
+-compiler specific ones, but you may have to modify one for your own
+-needs.
+-
+-You should use zlib 1.0.4 or later to run this, but it MAY work with
++You should use zlib 1.0.4 or later to run this, but it _may_ work with
+ versions as old as zlib 0.95.  Even so, there are bugs in older zlib
+ versions which can cause the output of invalid compression streams for
+ some images.
+ 
+ You should also note that zlib is a compression library that is useful
+ for more things than just PNG files.  You can use zlib as a drop-in
+-replacement for fread() and fwrite(), if you are so inclined.
++replacement for `fread()` and `fwrite()`, if you are so inclined.
+ 
+ zlib should be available at the same place that libpng is, or at
+-https://zlib.net.
++https://zlib.net .
+ 
+ You may also want a copy of the PNG specification.  It is available
+ as an RFC, a W3C Recommendation, and an ISO/IEC Standard.  You can find
+ these at http://www.libpng.org/pub/png/pngdocs.html .
+ 
+-This code is currently being archived at libpng.sourceforge.io in the
+-[DOWNLOAD] area, and at http://libpng.download/src .
++This code is currently being archived at https://libpng.sourceforge.io
++in the download area, and at http://libpng.download/src .
+ 
+ This release, based in a large way on Glenn's, Guy's and Andreas'
+ earlier work, was created and will be supported by myself and the PNG
+ development group.
+ 
+-Send comments/corrections/commendations to png-mng-implement at
+-lists.sourceforge.net (subscription required; visit
++Send comments, corrections and commendations to `png-mng-implement`
++at `lists.sourceforge.net`.  (Subscription is required; visit
+ https://lists.sourceforge.net/lists/listinfo/png-mng-implement
+-to subscribe).
+-
+-Send general questions about the PNG specification to png-mng-misc
+-at lists.sourceforge.net (subscription required; visit
+-https://lists.sourceforge.net/lists/listinfo/png-mng-misc to
+-subscribe).
+-
+-Files in this distribution:
+-
+-      ANNOUNCE      =>  Announcement of this version, with recent changes
+-      AUTHORS       =>  List of contributing authors
+-      CHANGES       =>  Description of changes between libpng versions
+-      KNOWNBUG      =>  List of known bugs and deficiencies
+-      LICENSE       =>  License to use and redistribute libpng
+-      README        =>  This file
+-      TODO          =>  Things not implemented in the current library
+-      TRADEMARK     =>  Trademark information
+-      example.c     =>  Example code for using libpng functions
+-      libpng.3      =>  manual page for libpng (includes libpng-manual.txt)
+-      libpng-manual.txt  =>  Description of libpng and its functions
+-      libpngpf.3    =>  manual page for libpng's private functions
+-      png.5         =>  manual page for the PNG format
+-      png.c         =>  Basic interface functions common to library
+-      png.h         =>  Library function and interface declarations (public)
+-      pngpriv.h     =>  Library function and interface declarations (private)
+-      pngconf.h     =>  System specific library configuration (public)
+-      pngstruct.h   =>  png_struct declaration (private)
+-      pnginfo.h     =>  png_info struct declaration (private)
+-      pngdebug.h    =>  debugging macros (private)
+-      pngerror.c    =>  Error/warning message I/O functions
+-      pngget.c      =>  Functions for retrieving info from struct
+-      pngmem.c      =>  Memory handling functions
+-      pngbar.png    =>  PNG logo, 88x31
+-      pngnow.png    =>  PNG logo, 98x31
+-      pngpread.c    =>  Progressive reading functions
+-      pngread.c     =>  Read data/helper high-level functions
+-      pngrio.c      =>  Lowest-level data read I/O functions
+-      pngrtran.c    =>  Read data transformation functions
+-      pngrutil.c    =>  Read data utility functions
+-      pngset.c      =>  Functions for storing data into the info_struct
+-      pngtest.c     =>  Library test program
+-      pngtest.png   =>  Library test sample image
+-      pngtrans.c    =>  Common data transformation functions
+-      pngwio.c      =>  Lowest-level write I/O functions
+-      pngwrite.c    =>  High-level write functions
+-      pngwtran.c    =>  Write data transformations
+-      pngwutil.c    =>  Write utility functions
+-      arm           =>  Contains optimized code for the ARM platform
+-      powerpc       =>  Contains optimized code for the PowerPC platform
+-      contrib       =>  Contributions
+-       arm-neon         =>  Optimized code for ARM-NEON platform
+-       powerpc-vsx      =>  Optimized code for POWERPC-VSX platform
+-       examples         =>  Example programs
+-       gregbook         =>  source code for PNG reading and writing, from
+-                            Greg Roelofs' "PNG: The Definitive Guide",
+-                            O'Reilly, 1999
+-       libtests         =>  Test programs
+-       mips-msa         =>  Optimized code for MIPS-MSA platform
+-       pngminim         =>  Minimal decoder, encoder, and progressive decoder
+-                            programs demonstrating use of pngusr.dfa
+-       pngminus         =>  Simple pnm2png and png2pnm programs
+-       pngsuite         =>  Test images
+-       testpngs
+-       tools            =>  Various tools
+-       visupng          =>  Contains a MSVC workspace for VisualPng
+-      intel             =>  Optimized code for INTEL-SSE2 platform
+-      mips              =>  Optimized code for MIPS platform
+-      projects      =>  Contains project files and workspaces for
+-                        building a DLL
+-       owatcom          =>  Contains a WATCOM project for building libpng
+-       visualc71        =>  Contains a Microsoft Visual C++ (MSVC)
+-                            workspace for building libpng and zlib
+-       vstudio          =>  Contains a Microsoft Visual C++ (MSVC)
+-                            workspace for building libpng and zlib
+-      scripts       =>  Directory containing scripts for building libpng:
+-                            (see scripts/README.txt for the list of scripts)
++to subscribe.)
++
++Send general questions about the PNG specification to `png-mng-misc`
++at `lists.sourceforge.net`.  (Subscription is required; visit
++https://lists.sourceforge.net/lists/listinfo/png-mng-misc
++to subscribe.)
++
++Historical notes
++----------------
++
++The libpng library has been in extensive use and testing since mid-1995.
++Version 0.89, published a year later, was the first official release.
++By late 1997, it had finally gotten to the stage where there hadn't
++been significant changes to the API in some time, and people have a bad
++feeling about libraries with versions below 1.0.  Version 1.0.0 was
++released in March 1998.
++
++Note that some of the changes to the `png_info` structure render this
++version of the library binary incompatible with libpng-0.89 or
++earlier versions if you are using a shared library.  The type of the
++`filler` parameter for `png_set_filler()` has changed from `png_byte`
++to `png_uint_32`, which will affect shared-library applications that
++use this function.
++
++To avoid problems with changes to the internals of the `info_struct`,
++new APIs have been made available in 0.95 to avoid direct application
++access to `info_ptr`.  These functions are the `png_set_<chunk>` and
++`png_get_<chunk>` functions.  These functions should be used when
++accessing/storing the `info_struct` data, rather than manipulating it
++directly, to avoid such problems in the future.
++
++It is important to note that the APIs did not make current programs
++that access the info struct directly incompatible with the new
++library, through libpng-1.2.x.  In libpng-1.4.x, which was meant to
++be a transitional release, members of the `png_struct` and the
++`info_struct` can still be accessed, but the compiler will issue a
++warning about deprecated usage.  Since libpng-1.5.0, direct access
++to these structs is not allowed, and the definitions of the structs
++reside in private `pngstruct.h` and `pnginfo.h` header files that are
++not accessible to applications.  It is strongly suggested that new
++programs use the new APIs (as shown in `example.c` and `pngtest.c`),
++and older programs be converted to the new format, to facilitate
++upgrades in the future.
++
++The additions since 0.89 include the ability to read from a PNG stream
++which has had some (or all) of the signature bytes read by the calling
++application.  This also allows the reading of embedded PNG streams that
++do not have the PNG file signature.  As well, it is now possible to set
++the library action on the detection of chunk CRC errors.  It is possible
++to set different actions based on whether the CRC error occurred in a
++critical or an ancillary chunk.
++
++The additions since 0.90 include the ability to compile libpng as a
++Windows DLL, and new APIs for accessing data in the `info_struct`.
++Experimental functions included the ability to set weighting and cost
++factors for row filter selection, direct reads of integers from buffers
++on big-endian processors that support misaligned data access, faster
++methods of doing alpha composition, and more accurate 16-to-8 bit color
++conversion.  Some of these experimental functions, such as the weighted
++filter heuristics, have since been removed.
++
++Files included in this distribution
++-----------------------------------
++
++    ANNOUNCE      =>  Announcement of this version, with recent changes
++    AUTHORS       =>  List of contributing authors
++    CHANGES       =>  Description of changes between libpng versions
++    INSTALL       =>  Instructions to install libpng
++    LICENSE       =>  License to use and redistribute libpng
++    README        =>  This file
++    TODO          =>  Things not implemented in the current library
++    TRADEMARK     =>  Trademark information
++    example.c     =>  Example code for using libpng functions
++    libpng.3      =>  Manual page for libpng (includes libpng-manual.txt)
++    libpng-manual.txt  =>  Description of libpng and its functions
++    libpngpf.3    =>  Manual page for libpng's private functions (deprecated)
++    png.5         =>  Manual page for the PNG format
++    png.c         =>  Basic interface functions common to library
++    png.h         =>  Library function and interface declarations (public)
++    pngpriv.h     =>  Library function and interface declarations (private)
++    pngconf.h     =>  System specific library configuration (public)
++    pngstruct.h   =>  png_struct declaration (private)
++    pnginfo.h     =>  png_info struct declaration (private)
++    pngdebug.h    =>  debugging macros (private)
++    pngerror.c    =>  Error/warning message I/O functions
++    pngget.c      =>  Functions for retrieving info from struct
++    pngmem.c      =>  Memory handling functions
++    pngbar.png    =>  PNG logo, 88x31
++    pngnow.png    =>  PNG logo, 98x31
++    pngpread.c    =>  Progressive reading functions
++    pngread.c     =>  Read data/helper high-level functions
++    pngrio.c      =>  Lowest-level data read I/O functions
++    pngrtran.c    =>  Read data transformation functions
++    pngrutil.c    =>  Read data utility functions
++    pngset.c      =>  Functions for storing data into the info_struct
++    pngtest.c     =>  Library test program
++    pngtest.png   =>  Library test sample image
++    pngtrans.c    =>  Common data transformation functions
++    pngwio.c      =>  Lowest-level write I/O functions
++    pngwrite.c    =>  High-level write functions
++    pngwtran.c    =>  Write data transformations
++    pngwutil.c    =>  Write utility functions
++    arm/          =>  Optimized code for the ARM platform
++    intel/        =>  Optimized code for the INTEL-SSE2 platform
++    mips/         =>  Optimized code for the MIPS platform
++    powerpc/      =>  Optimized code for the PowerPC platform
++    ci/           =>  Scripts for continuous integration
++    contrib/      =>  External contributions
++        arm-neon/     =>  Optimized code for the ARM-NEON platform
++        mips-msa/     =>  Optimized code for the MIPS-MSA platform
++        powerpc-vsx/  =>  Optimized code for the POWERPC-VSX platform
++        examples/     =>  Examples of libpng usage
++        gregbook/     =>  Source code for PNG reading and writing, from
++                          "PNG: The Definitive Guide" by Greg Roelofs,
++                          O'Reilly, 1999
++        libtests/     =>  Test programs
++        oss-fuzz/     =>  Files used by the OSS-Fuzz project for fuzz-testing
++                          libpng
++        pngminim/     =>  Minimal decoder, encoder, and progressive decoder
++                          programs demonstrating the use of pngusr.dfa
++        pngminus/     =>  Simple pnm2png and png2pnm programs
++        pngsuite/     =>  Test images
++        testpngs/     =>  Test images
++        tools/        =>  Various tools
++        visupng/      =>  VisualPng, a Windows viewer for PNG images
++    projects/     =>  Project files and workspaces for various IDEs
++        owatcom/      =>  OpenWatcom project
++        visualc71/    =>  Microsoft Visual C++ 7.1 workspace
++        vstudio/      =>  Microsoft Visual Studio workspace
++    scripts/      =>  Scripts and makefiles for building libpng
++                      (see scripts/README.txt for the complete list)
++    tests/        =>  Test scripts
+ 
+ Good luck, and happy coding!
+ 
+diff --git old/qtbase/src/3rdparty/libpng/libpng-manual.txt new/qtbase/src/3rdparty/libpng/libpng-manual.txt
+index 5dad92fbf74..dbb60af61d1 100644
+--- old/qtbase/src/3rdparty/libpng/libpng-manual.txt
++++ new/qtbase/src/3rdparty/libpng/libpng-manual.txt
+@@ -1,6 +1,6 @@
+ libpng-manual.txt - A description on how to use and modify libpng
+ 
+- Copyright (c) 2018-2019 Cosmin Truta
++ Copyright (c) 2018-2024 Cosmin Truta
+  Copyright (c) 1998-2018 Glenn Randers-Pehrson
+ 
+  This document is released under the libpng license.
+@@ -9,9 +9,9 @@ libpng-manual.txt - A description on how to use and modify libpng
+ 
+  Based on:
+ 
+- libpng version 1.6.36, December 2018, through 1.6.37 - April 2019
++ libpng version 1.6.36, December 2018, through 1.6.41 - January 2024
+  Updated and distributed by Cosmin Truta
+- Copyright (c) 2018-2019 Cosmin Truta
++ Copyright (c) 2018-2024 Cosmin Truta
+ 
+  libpng versions 0.97, January 1998, through 1.6.35 - July 2018
+  Updated and distributed by Glenn Randers-Pehrson
+@@ -877,7 +877,7 @@ described below (the latter being the two common names for associated alpha
+ color channels). Note that PNG files always contain non-associated color
+ channels; png_set_alpha_mode() with one of the modes causes the decoder to
+ convert the pixels to an associated form before returning them to your
+-application. 
++application.
+ 
+ Since it is not necessary to perform arithmetic on opaque color values so
+ long as they are not to be resampled and are in the final color space it is
+@@ -1792,7 +1792,7 @@ the information.  If, instead, you want to convert the image to an opaque
+ version with no alpha channel use png_set_background; see below.
+ 
+ As of libpng version 1.5.2, almost all useful expansions are supported, the
+-major ommissions are conversion of grayscale to indexed images (which can be
++major omissions are conversion of grayscale to indexed images (which can be
+ done trivially in the application) and conversion of indexed to grayscale (which
+ can be done by a trivial manipulation of the palette.)
+ 
+diff --git old/qtbase/src/3rdparty/libpng/libpng.pro new/qtbase/src/3rdparty/libpng/libpng.pro
+index b71dfefd200..cd81c7af893 100644
+--- old/qtbase/src/3rdparty/libpng/libpng.pro
++++ new/qtbase/src/3rdparty/libpng/libpng.pro
+@@ -11,7 +11,11 @@ MODULE_EXT_HEADERS = png.h pngconf.h
+ 
+ load(qt_helper_lib)
+ 
+-DEFINES += PNG_ARM_NEON_OPT=0 PNG_POWERPC_VSX_OPT=0
++DEFINES += PNG_ARM_NEON_OPT=0 \
++           PNG_POWERPC_VSX_OPT=0 \
++           PNG_IMPEXP= \
++           _CRT_SECURE_NO_DEPRECATE
++
+ SOURCES += \
+     png.c \
+     pngerror.c \
+diff --git old/qtbase/src/3rdparty/libpng/png.c new/qtbase/src/3rdparty/libpng/png.c
+index 757c755f97c..e411381f8f9 100644
+--- old/qtbase/src/3rdparty/libpng/png.c
++++ new/qtbase/src/3rdparty/libpng/png.c
+@@ -1,7 +1,7 @@
+ 
+ /* png.c - location for general purpose libpng functions
+  *
+- * Copyright (c) 2018-2019 Cosmin Truta
++ * Copyright (c) 2018-2024 Cosmin Truta
+  * Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson
+  * Copyright (c) 1996-1997 Andreas Dilger
+  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
+@@ -14,27 +14,7 @@
+ #include "pngpriv.h"
+ 
+ /* Generate a compiler error if there is an old png.h in the search path. */
+-typedef png_libpng_version_1_6_37 Your_png_h_is_not_version_1_6_37;
+-
+-#ifdef __GNUC__
+-/* The version tests may need to be added to, but the problem warning has
+- * consistently been fixed in GCC versions which obtain wide-spread release.
+- * The problem is that many versions of GCC rearrange comparison expressions in
+- * the optimizer in such a way that the results of the comparison will change
+- * if signed integer overflow occurs.  Such comparisons are not permitted in
+- * ANSI C90, however GCC isn't clever enough to work out that that do not occur
+- * below in png_ascii_from_fp and png_muldiv, so it produces a warning with
+- * -Wextra.  Unfortunately this is highly dependent on the optimizer and the
+- * machine architecture so the warning comes and goes unpredictably and is
+- * impossible to "fix", even were that a good idea.
+- */
+-#if __GNUC__ == 7 && __GNUC_MINOR__ == 1
+-#define GCC_STRICT_OVERFLOW 1
+-#endif /* GNU 7.1.x */
+-#endif /* GNU */
+-#ifndef GCC_STRICT_OVERFLOW
+-#define GCC_STRICT_OVERFLOW 0
+-#endif
++typedef png_libpng_version_1_6_41 Your_png_h_is_not_version_1_6_41;
+ 
+ /* Tells libpng that we have already handled the first "num_bytes" bytes
+  * of the PNG file signature.  If the PNG data is embedded into another
+@@ -73,21 +53,21 @@ png_set_sig_bytes(png_structrp png_ptr, int num_bytes)
+ int PNGAPI
+ png_sig_cmp(png_const_bytep sig, size_t start, size_t num_to_check)
+ {
+-   png_byte png_signature[8] = {137, 80, 78, 71, 13, 10, 26, 10};
++   static const png_byte png_signature[8] = {137, 80, 78, 71, 13, 10, 26, 10};
+ 
+    if (num_to_check > 8)
+       num_to_check = 8;
+ 
+    else if (num_to_check < 1)
+-      return (-1);
++      return -1;
+ 
+    if (start > 7)
+-      return (-1);
++      return -1;
+ 
+    if (start + num_to_check > 8)
+       num_to_check = 8 - start;
+ 
+-   return ((int)(memcmp(&sig[start], &png_signature[start], num_to_check)));
++   return memcmp(&sig[start], &png_signature[start], num_to_check);
+ }
+ 
+ #endif /* READ */
+@@ -447,7 +427,6 @@ png_info_init_3,(png_infopp ptr_ptr, size_t png_info_struct_size),
+    memset(info_ptr, 0, (sizeof *info_ptr));
+ }
+ 
+-/* The following API is not called internally */
+ void PNGAPI
+ png_data_freer(png_const_structrp png_ptr, png_inforp info_ptr,
+     int freer, png_uint_32 mask)
+@@ -686,9 +665,9 @@ png_voidp PNGAPI
+ png_get_io_ptr(png_const_structrp png_ptr)
+ {
+    if (png_ptr == NULL)
+-      return (NULL);
++      return NULL;
+ 
+-   return (png_ptr->io_ptr);
++   return png_ptr->io_ptr;
+ }
+ 
+ #if defined(PNG_READ_SUPPORTED) || defined(PNG_WRITE_SUPPORTED)
+@@ -720,7 +699,7 @@ png_init_io(png_structrp png_ptr, png_FILE_p fp)
+  *
+  * Where UNSIGNED_MAX is the appropriate maximum unsigned value, so when the
+  * negative integral value is added the result will be an unsigned value
+- * correspnding to the 2's complement representation.
++ * corresponding to the 2's complement representation.
+  */
+ void PNGAPI
+ png_save_int_32(png_bytep buf, png_int_32 i)
+@@ -752,7 +731,7 @@ png_convert_to_rfc1123_buffer(char out[29], png_const_timep ptime)
+ 
+    {
+       size_t pos = 0;
+-      char number_buf[5]; /* enough for a four-digit year */
++      char number_buf[5] = {0, 0, 0, 0, 0}; /* enough for a four-digit year */
+ 
+ #     define APPEND_STRING(string) pos = png_safecat(out, 29, pos, (string))
+ #     define APPEND_NUMBER(format, value)\
+@@ -815,8 +794,8 @@ png_get_copyright(png_const_structrp png_ptr)
+    return PNG_STRING_COPYRIGHT
+ #else
+    return PNG_STRING_NEWLINE \
+-      "libpng version 1.6.37" PNG_STRING_NEWLINE \
+-      "Copyright (c) 2018-2019 Cosmin Truta" PNG_STRING_NEWLINE \
++      "libpng version 1.6.41" PNG_STRING_NEWLINE \
++      "Copyright (c) 2018-2024 Cosmin Truta" PNG_STRING_NEWLINE \
+       "Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson" \
+       PNG_STRING_NEWLINE \
+       "Copyright (c) 1996-1997 Andreas Dilger" PNG_STRING_NEWLINE \
+@@ -977,7 +956,7 @@ png_reset_zstream(png_structrp png_ptr)
+       return Z_STREAM_ERROR;
+ 
+    /* WARNING: this resets the window bits to the maximum! */
+-   return (inflateReset(&png_ptr->zstream));
++   return inflateReset(&png_ptr->zstream);
+ }
+ #endif /* READ */
+ 
+@@ -986,7 +965,7 @@ png_uint_32 PNGAPI
+ png_access_version_number(void)
+ {
+    /* Version of *.c files used when building libpng */
+-   return((png_uint_32)PNG_LIBPNG_VER);
++   return (png_uint_32)PNG_LIBPNG_VER;
+ }
+ 
+ #if defined(PNG_READ_SUPPORTED) || defined(PNG_WRITE_SUPPORTED)
+@@ -1843,12 +1822,12 @@ png_icc_profile_error(png_const_structrp png_ptr, png_colorspacerp colorspace,
+ #  ifdef PNG_WARNINGS_SUPPORTED
+    else
+       {
+-         char number[PNG_NUMBER_BUFFER_SIZE]; /* +24 = 114*/
++         char number[PNG_NUMBER_BUFFER_SIZE]; /* +24 = 114 */
+ 
+          pos = png_safecat(message, (sizeof message), pos,
+              png_format_number(number, number+(sizeof number),
+              PNG_NUMBER_FORMAT_x, value));
+-         pos = png_safecat(message, (sizeof message), pos, "h: "); /*+2 = 116*/
++         pos = png_safecat(message, (sizeof message), pos, "h: "); /* +2 = 116 */
+       }
+ #  endif
+    /* The 'reason' is an arbitrary message, allow +79 maximum 195 */
+@@ -2710,7 +2689,7 @@ png_check_IHDR(png_const_structrp png_ptr,
+ 
+ int /* PRIVATE */
+ png_check_fp_number(png_const_charp string, size_t size, int *statep,
+-    png_size_tp whereami)
++    size_t *whereami)
+ {
+    int state = *statep;
+    size_t i = *whereami;
+@@ -2891,14 +2870,6 @@ png_pow10(int power)
+ /* Function to format a floating point value in ASCII with a given
+  * precision.
+  */
+-#if GCC_STRICT_OVERFLOW
+-#pragma GCC diagnostic push
+-/* The problem arises below with exp_b10, which can never overflow because it
+- * comes, originally, from frexp and is therefore limited to a range which is
+- * typically +/-710 (log2(DBL_MAX)/log2(DBL_MIN)).
+- */
+-#pragma GCC diagnostic warning "-Wstrict-overflow=2"
+-#endif /* GCC_STRICT_OVERFLOW */
+ void /* PRIVATE */
+ png_ascii_from_fp(png_const_structrp png_ptr, png_charp ascii, size_t size,
+     double fp, unsigned int precision)
+@@ -3220,10 +3191,6 @@ png_ascii_from_fp(png_const_structrp png_ptr, png_charp ascii, size_t size,
+    /* Here on buffer too small. */
+    png_error(png_ptr, "ASCII conversion buffer too small");
+ }
+-#if GCC_STRICT_OVERFLOW
+-#pragma GCC diagnostic pop
+-#endif /* GCC_STRICT_OVERFLOW */
+-
+ #  endif /* FLOATING_POINT */
+ 
+ #  ifdef PNG_FIXED_POINT_SUPPORTED
+@@ -3251,7 +3218,7 @@ png_ascii_from_fixed(png_const_structrp png_ptr, png_charp ascii,
+       if (num <= 0x80000000) /* else overflowed */
+       {
+          unsigned int ndigits = 0, first = 16 /* flag value */;
+-         char digits[10];
++         char digits[10] = {0};
+ 
+          while (num)
+          {
+@@ -3336,15 +3303,6 @@ png_fixed(png_const_structrp png_ptr, double fp, png_const_charp text)
+  * the nearest .00001).  Overflow and divide by zero are signalled in
+  * the result, a boolean - true on success, false on overflow.
+  */
+-#if GCC_STRICT_OVERFLOW /* from above */
+-/* It is not obvious which comparison below gets optimized in such a way that
+- * signed overflow would change the result; looking through the code does not
+- * reveal any tests which have the form GCC complains about, so presumably the
+- * optimizer is moving an add or subtract into the 'if' somewhere.
+- */
+-#pragma GCC diagnostic push
+-#pragma GCC diagnostic warning "-Wstrict-overflow=2"
+-#endif /* GCC_STRICT_OVERFLOW */
+ int
+ png_muldiv(png_fixed_point_p res, png_fixed_point a, png_int_32 times,
+     png_int_32 divisor)
+@@ -3459,9 +3417,6 @@ png_muldiv(png_fixed_point_p res, png_fixed_point a, png_int_32 times,
+ 
+    return 0;
+ }
+-#if GCC_STRICT_OVERFLOW
+-#pragma GCC diagnostic pop
+-#endif /* GCC_STRICT_OVERFLOW */
+ #endif /* READ_GAMMA || INCH_CONVERSIONS */
+ 
+ #if defined(PNG_READ_GAMMA_SUPPORTED) || defined(PNG_INCH_CONVERSIONS_SUPPORTED)
+diff --git old/qtbase/src/3rdparty/libpng/png.h new/qtbase/src/3rdparty/libpng/png.h
+index 139eb0dc0f3..d78c7799341 100644
+--- old/qtbase/src/3rdparty/libpng/png.h
++++ new/qtbase/src/3rdparty/libpng/png.h
+@@ -1,9 +1,9 @@
+ 
+ /* png.h - header file for PNG reference library
+  *
+- * libpng version 1.6.37 - April 14, 2019
++ * libpng version 1.6.41
+  *
+- * Copyright (c) 2018-2019 Cosmin Truta
++ * Copyright (c) 2018-2024 Cosmin Truta
+  * Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson
+  * Copyright (c) 1996-1997 Andreas Dilger
+  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
+@@ -15,7 +15,7 @@
+  *   libpng versions 0.89, June 1996, through 0.96, May 1997: Andreas Dilger
+  *   libpng versions 0.97, January 1998, through 1.6.35, July 2018:
+  *     Glenn Randers-Pehrson
+- *   libpng versions 1.6.36, December 2018, through 1.6.37, April 2019:
++ *   libpng versions 1.6.36, December 2018, through 1.6.41, January 2024:
+  *     Cosmin Truta
+  *   See also "Contributing Authors", below.
+  */
+@@ -27,8 +27,8 @@
+  * PNG Reference Library License version 2
+  * ---------------------------------------
+  *
+- *  * Copyright (c) 1995-2019 The PNG Reference Library Authors.
+- *  * Copyright (c) 2018-2019 Cosmin Truta.
++ *  * Copyright (c) 1995-2024 The PNG Reference Library Authors.
++ *  * Copyright (c) 2018-2024 Cosmin Truta.
+  *  * Copyright (c) 2000-2002, 2004, 2006-2018 Glenn Randers-Pehrson.
+  *  * Copyright (c) 1996-1997 Andreas Dilger.
+  *  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
+@@ -239,7 +239,7 @@
+  *    ...
+  *    1.5.30                  15    10530  15.so.15.30[.0]
+  *    ...
+- *    1.6.37                  16    10637  16.so.16.37[.0]
++ *    1.6.41                  16    10641  16.so.16.41[.0]
+  *
+  *    Henceforth the source version will match the shared-library major and
+  *    minor numbers; the shared-library major version number will be used for
+@@ -278,8 +278,8 @@
+  */
+ 
+ /* Version information for png.h - this should match the version in png.c */
+-#define PNG_LIBPNG_VER_STRING "1.6.37"
+-#define PNG_HEADER_VERSION_STRING " libpng version 1.6.37 - April 14, 2019\n"
++#define PNG_LIBPNG_VER_STRING "1.6.41"
++#define PNG_HEADER_VERSION_STRING " libpng version " PNG_LIBPNG_VER_STRING "\n"
+ 
+ #define PNG_LIBPNG_VER_SONUM   16
+ #define PNG_LIBPNG_VER_DLLNUM  16
+@@ -287,7 +287,7 @@
+ /* These should match the first 3 components of PNG_LIBPNG_VER_STRING: */
+ #define PNG_LIBPNG_VER_MAJOR   1
+ #define PNG_LIBPNG_VER_MINOR   6
+-#define PNG_LIBPNG_VER_RELEASE 37
++#define PNG_LIBPNG_VER_RELEASE 41
+ 
+ /* This should be zero for a public release, or non-zero for a
+  * development version.  [Deprecated]
+@@ -318,7 +318,7 @@
+  * From version 1.0.1 it is:
+  * XXYYZZ, where XX=major, YY=minor, ZZ=release
+  */
+-#define PNG_LIBPNG_VER 10637 /* 1.6.37 */
++#define PNG_LIBPNG_VER 10641 /* 1.6.41 */
+ 
+ /* Library configuration: these options cannot be changed after
+  * the library has been built.
+@@ -428,7 +428,7 @@ extern "C" {
+ /* This triggers a compiler error in png.c, if png.c and png.h
+  * do not agree upon the version number.
+  */
+-typedef char* png_libpng_version_1_6_37;
++typedef char* png_libpng_version_1_6_41;
+ 
+ /* Basic control structions.  Read libpng-manual.txt or libpng.3 for more info.
+  *
+@@ -849,7 +849,7 @@ PNG_FUNCTION(void, (PNGCAPI *png_longjmp_ptr), PNGARG((jmp_buf, int)), typedef);
+ #define PNG_TRANSFORM_GRAY_TO_RGB   0x2000      /* read only */
+ /* Added to libpng-1.5.4 */
+ #define PNG_TRANSFORM_EXPAND_16     0x4000      /* read only */
+-#if INT_MAX >= 0x8000 /* else this might break */
++#if ~0U > 0xffffU /* or else this might break on a 16-bit machine */
+ #define PNG_TRANSFORM_SCALE_16      0x8000      /* read only */
+ #endif
+ 
+@@ -908,15 +908,15 @@ PNG_EXPORT(2, void, png_set_sig_bytes, (png_structrp png_ptr, int num_bytes));
+ /* Check sig[start] through sig[start + num_to_check - 1] to see if it's a
+  * PNG file.  Returns zero if the supplied bytes match the 8-byte PNG
+  * signature, and non-zero otherwise.  Having num_to_check == 0 or
+- * start > 7 will always fail (ie return non-zero).
++ * start > 7 will always fail (i.e. return non-zero).
+  */
+ PNG_EXPORT(3, int, png_sig_cmp, (png_const_bytep sig, size_t start,
+     size_t num_to_check));
+ 
+ /* Simple signature checking function.  This is the same as calling
+- * png_check_sig(sig, n) := !png_sig_cmp(sig, 0, n).
++ * png_check_sig(sig, n) := (png_sig_cmp(sig, 0, n) != 0).
+  */
+-#define png_check_sig(sig, n) !png_sig_cmp((sig), 0, (n))
++#define png_check_sig(sig, n) (png_sig_cmp((sig), 0, (n)) != 0)
+ 
+ /* Allocate and initialize png_ptr struct for reading, and any other memory. */
+ PNG_EXPORTA(4, png_structp, png_create_read_struct,
+@@ -1446,7 +1446,7 @@ PNG_EXPORT(66, void, png_set_crc_action, (png_structrp png_ptr, int crit_action,
+  * mainly useful for testing, as the defaults should work with most users.
+  * Those users who are tight on memory or want faster performance at the
+  * expense of compression can modify them.  See the compression library
+- * header file (zlib.h) for an explination of the compression functions.
++ * header file (zlib.h) for an explanation of the compression functions.
+  */
+ 
+ /* Set the filtering method(s) used by libpng.  Currently, the only valid
+@@ -1501,7 +1501,7 @@ PNG_FIXED_EXPORT(209, void, png_set_filter_heuristics_fixed,
+  * 0 - 9, corresponding directly to the zlib compression levels 0 - 9
+  * (0 - no compression, 9 - "maximal" compression).  Note that tests have
+  * shown that zlib compression levels 3-6 usually perform as well as level 9
+- * for PNG images, and do considerably fewer caclulations.  In the future,
++ * for PNG images, and do considerably fewer calculations.  In the future,
+  * these values may not correspond directly to the zlib compression levels.
+  */
+ #ifdef PNG_WRITE_CUSTOMIZE_COMPRESSION_SUPPORTED
+@@ -1730,12 +1730,9 @@ PNG_EXPORT(97, void, png_free, (png_const_structrp png_ptr, png_voidp ptr));
+ PNG_EXPORT(98, void, png_free_data, (png_const_structrp png_ptr,
+     png_inforp info_ptr, png_uint_32 free_me, int num));
+ 
+-/* Reassign responsibility for freeing existing data, whether allocated
++/* Reassign the responsibility for freeing existing data, whether allocated
+  * by libpng or by the application; this works on the png_info structure passed
+- * in, it does not change the state for other png_info structures.
+- *
+- * It is unlikely that this function works correctly as of 1.6.0 and using it
+- * may result either in memory leaks or double free of allocated data.
++ * in, without changing the state for other png_info structures.
+  */
+ PNG_EXPORT(99, void, png_data_freer, (png_const_structrp png_ptr,
+     png_inforp info_ptr, int freer, png_uint_32 mask));
+@@ -3207,11 +3204,18 @@ PNG_EXPORT(245, int, png_image_write_to_memory, (png_imagep image, void *memory,
+ #ifdef PNG_MIPS_MSA_API_SUPPORTED
+ #  define PNG_MIPS_MSA   6 /* HARDWARE: MIPS Msa SIMD instructions supported */
+ #endif
+-#define PNG_IGNORE_ADLER32 8
++#ifdef PNG_DISABLE_ADLER32_CHECK_SUPPORTED
++#  define PNG_IGNORE_ADLER32 8 /* SOFTWARE: disable Adler32 check on IDAT */
++#endif
+ #ifdef PNG_POWERPC_VSX_API_SUPPORTED
+-#  define PNG_POWERPC_VSX   10 /* HARDWARE: PowerPC VSX SIMD instructions supported */
++#  define PNG_POWERPC_VSX   10 /* HARDWARE: PowerPC VSX SIMD instructions
++                                * supported */
+ #endif
+-#define PNG_OPTION_NEXT  12 /* Next option - numbers must be even */
++#ifdef PNG_MIPS_MMI_API_SUPPORTED
++#  define PNG_MIPS_MMI   12 /* HARDWARE: MIPS MMI SIMD instructions supported */
++#endif
++
++#define PNG_OPTION_NEXT  14 /* Next option - numbers must be even */
+ 
+ /* Return values: NOTE: there are four values and 'off' is *not* zero */
+ #define PNG_OPTION_UNSET   0 /* Unset - defaults to off */
+diff --git old/qtbase/src/3rdparty/libpng/pngconf.h new/qtbase/src/3rdparty/libpng/pngconf.h
+index 927a769dbee..30c1aad52d7 100644
+--- old/qtbase/src/3rdparty/libpng/pngconf.h
++++ new/qtbase/src/3rdparty/libpng/pngconf.h
+@@ -1,9 +1,9 @@
+ 
+ /* pngconf.h - machine-configurable file for libpng
+  *
+- * libpng version 1.6.37
++ * libpng version 1.6.41
+  *
+- * Copyright (c) 2018-2019 Cosmin Truta
++ * Copyright (c) 2018-2024 Cosmin Truta
+  * Copyright (c) 1998-2002,2004,2006-2016,2018 Glenn Randers-Pehrson
+  * Copyright (c) 1996-1997 Andreas Dilger
+  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
+@@ -180,8 +180,8 @@
+  * compiler-specific macros to the values required to change the calling
+  * conventions of the various functions.
+  */
+-#if defined(_Windows) || defined(_WINDOWS) || defined(WIN32) ||\
+-    defined(_WIN32) || defined(__WIN32__) || defined(__CYGWIN__)
++#if defined(_WIN32) || defined(__WIN32__) || defined(__NT__) || \
++    defined(__CYGWIN__)
+   /* Windows system (DOS doesn't support DLLs).  Includes builds under Cygwin or
+    * MinGW on any architecture currently supported by Windows.  Also includes
+    * Watcom builds but these need special treatment because they are not
+diff --git old/qtbase/src/3rdparty/libpng/pngerror.c new/qtbase/src/3rdparty/libpng/pngerror.c
+index ec3a709b9d2..29ebda79437 100644
+--- old/qtbase/src/3rdparty/libpng/pngerror.c
++++ new/qtbase/src/3rdparty/libpng/pngerror.c
+@@ -1,7 +1,7 @@
+ 
+ /* pngerror.c - stub functions for i/o and memory allocation
+  *
+- * Copyright (c) 2018 Cosmin Truta
++ * Copyright (c) 2018-2024 Cosmin Truta
+  * Copyright (c) 1998-2002,2004,2006-2017 Glenn Randers-Pehrson
+  * Copyright (c) 1996-1997 Andreas Dilger
+  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
+@@ -255,7 +255,7 @@ void
+ png_warning_parameter_unsigned(png_warning_parameters p, int number, int format,
+     png_alloc_size_t value)
+ {
+-   char buffer[PNG_NUMBER_BUFFER_SIZE];
++   char buffer[PNG_NUMBER_BUFFER_SIZE] = {0};
+    png_warning_parameter(p, number, PNG_FORMAT_NUMBER(buffer, format, value));
+ }
+ 
+@@ -265,7 +265,7 @@ png_warning_parameter_signed(png_warning_parameters p, int number, int format,
+ {
+    png_alloc_size_t u;
+    png_charp str;
+-   char buffer[PNG_NUMBER_BUFFER_SIZE];
++   char buffer[PNG_NUMBER_BUFFER_SIZE] = {0};
+ 
+    /* Avoid overflow by doing the negate in a png_alloc_size_t: */
+    u = (png_alloc_size_t)value;
+@@ -858,7 +858,7 @@ png_get_error_ptr(png_const_structrp png_ptr)
+    if (png_ptr == NULL)
+       return NULL;
+ 
+-   return ((png_voidp)png_ptr->error_ptr);
++   return (png_voidp)png_ptr->error_ptr;
+ }
+ 
+ 
+@@ -933,31 +933,25 @@ png_safe_warning(png_structp png_nonconst_ptr, png_const_charp warning_message)
+ #endif
+ 
+ int /* PRIVATE */
+-png_safe_execute(png_imagep image_in, int (*function)(png_voidp), png_voidp arg)
++png_safe_execute(png_imagep image, int (*function)(png_voidp), png_voidp arg)
+ {
+-   volatile png_imagep image = image_in;
+-   volatile int result;
+-   volatile png_voidp saved_error_buf;
++   png_voidp saved_error_buf = image->opaque->error_buf;
+    jmp_buf safe_jmpbuf;
++   int result;
+ 
+-   /* Safely execute function(arg) with png_error returning to this function. */
+-   saved_error_buf = image->opaque->error_buf;
+-   result = setjmp(safe_jmpbuf) == 0;
+-
+-   if (result != 0)
++   /* Safely execute function(arg), with png_error returning back here. */
++   if (setjmp(safe_jmpbuf) == 0)
+    {
+-
+       image->opaque->error_buf = safe_jmpbuf;
+       result = function(arg);
++      image->opaque->error_buf = saved_error_buf;
++      return result;
+    }
+ 
++   /* On png_error, return via longjmp, pop the jmpbuf, and free the image. */
+    image->opaque->error_buf = saved_error_buf;
+-
+-   /* And do the cleanup prior to any failure return. */
+-   if (result == 0)
+-      png_image_free(image);
+-
+-   return result;
++   png_image_free(image);
++   return 0;
+ }
+ #endif /* SIMPLIFIED READ || SIMPLIFIED_WRITE */
+ #endif /* READ || WRITE */
+diff --git old/qtbase/src/3rdparty/libpng/pngget.c new/qtbase/src/3rdparty/libpng/pngget.c
+index 5abf1efd9f7..1084b268ff9 100644
+--- old/qtbase/src/3rdparty/libpng/pngget.c
++++ new/qtbase/src/3rdparty/libpng/pngget.c
+@@ -1,7 +1,7 @@
+ 
+ /* pngget.c - retrieval of values from info struct
+  *
+- * Copyright (c) 2018 Cosmin Truta
++ * Copyright (c) 2018-2024 Cosmin Truta
+  * Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson
+  * Copyright (c) 1996-1997 Andreas Dilger
+  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
+@@ -21,18 +21,29 @@ png_get_valid(png_const_structrp png_ptr, png_const_inforp info_ptr,
+     png_uint_32 flag)
+ {
+    if (png_ptr != NULL && info_ptr != NULL)
+-      return(info_ptr->valid & flag);
++   {
++#ifdef PNG_READ_tRNS_SUPPORTED
++      /* png_handle_PLTE() may have canceled a valid tRNS chunk but left the
++       * 'valid' flag for the detection of duplicate chunks. Do not report a
++       * valid tRNS chunk in this case.
++       */
++      if (flag == PNG_INFO_tRNS && png_ptr->num_trans == 0)
++         return 0;
++#endif
+ 
+-   return(0);
++      return info_ptr->valid & flag;
++   }
++
++   return 0;
+ }
+ 
+ size_t PNGAPI
+ png_get_rowbytes(png_const_structrp png_ptr, png_const_inforp info_ptr)
+ {
+    if (png_ptr != NULL && info_ptr != NULL)
+-      return(info_ptr->rowbytes);
++      return info_ptr->rowbytes;
+ 
+-   return(0);
++   return 0;
+ }
+ 
+ #ifdef PNG_INFO_IMAGE_SUPPORTED
+@@ -40,9 +51,9 @@ png_bytepp PNGAPI
+ png_get_rows(png_const_structrp png_ptr, png_const_inforp info_ptr)
+ {
+    if (png_ptr != NULL && info_ptr != NULL)
+-      return(info_ptr->row_pointers);
++      return info_ptr->row_pointers;
+ 
+-   return(0);
++   return 0;
+ }
+ #endif
+ 
+@@ -54,7 +65,7 @@ png_get_image_width(png_const_structrp png_ptr, png_const_inforp info_ptr)
+    if (png_ptr != NULL && info_ptr != NULL)
+       return info_ptr->width;
+ 
+-   return (0);
++   return 0;
+ }
+ 
+ png_uint_32 PNGAPI
+@@ -63,7 +74,7 @@ png_get_image_height(png_const_structrp png_ptr, png_const_inforp info_ptr)
+    if (png_ptr != NULL && info_ptr != NULL)
+       return info_ptr->height;
+ 
+-   return (0);
++   return 0;
+ }
+ 
+ png_byte PNGAPI
+@@ -72,7 +83,7 @@ png_get_bit_depth(png_const_structrp png_ptr, png_const_inforp info_ptr)
+    if (png_ptr != NULL && info_ptr != NULL)
+       return info_ptr->bit_depth;
+ 
+-   return (0);
++   return 0;
+ }
+ 
+ png_byte PNGAPI
+@@ -81,7 +92,7 @@ png_get_color_type(png_const_structrp png_ptr, png_const_inforp info_ptr)
+    if (png_ptr != NULL && info_ptr != NULL)
+       return info_ptr->color_type;
+ 
+-   return (0);
++   return 0;
+ }
+ 
+ png_byte PNGAPI
+@@ -90,7 +101,7 @@ png_get_filter_type(png_const_structrp png_ptr, png_const_inforp info_ptr)
+    if (png_ptr != NULL && info_ptr != NULL)
+       return info_ptr->filter_type;
+ 
+-   return (0);
++   return 0;
+ }
+ 
+ png_byte PNGAPI
+@@ -99,7 +110,7 @@ png_get_interlace_type(png_const_structrp png_ptr, png_const_inforp info_ptr)
+    if (png_ptr != NULL && info_ptr != NULL)
+       return info_ptr->interlace_type;
+ 
+-   return (0);
++   return 0;
+ }
+ 
+ png_byte PNGAPI
+@@ -108,7 +119,7 @@ png_get_compression_type(png_const_structrp png_ptr, png_const_inforp info_ptr)
+    if (png_ptr != NULL && info_ptr != NULL)
+       return info_ptr->compression_type;
+ 
+-   return (0);
++   return 0;
+ }
+ 
+ png_uint_32 PNGAPI
+@@ -116,21 +127,20 @@ png_get_x_pixels_per_meter(png_const_structrp png_ptr, png_const_inforp
+    info_ptr)
+ {
+ #ifdef PNG_pHYs_SUPPORTED
++   png_debug(1, "in png_get_x_pixels_per_meter");
++
+    if (png_ptr != NULL && info_ptr != NULL &&
+        (info_ptr->valid & PNG_INFO_pHYs) != 0)
+-      {
+-         png_debug1(1, "in %s retrieval function",
+-             "png_get_x_pixels_per_meter");
+-
+-         if (info_ptr->phys_unit_type == PNG_RESOLUTION_METER)
+-            return (info_ptr->x_pixels_per_unit);
+-      }
++   {
++      if (info_ptr->phys_unit_type == PNG_RESOLUTION_METER)
++         return info_ptr->x_pixels_per_unit;
++   }
+ #else
+    PNG_UNUSED(png_ptr)
+    PNG_UNUSED(info_ptr)
+ #endif
+ 
+-   return (0);
++   return 0;
+ }
+ 
+ png_uint_32 PNGAPI
+@@ -138,42 +148,41 @@ png_get_y_pixels_per_meter(png_const_structrp png_ptr, png_const_inforp
+     info_ptr)
+ {
+ #ifdef PNG_pHYs_SUPPORTED
++   png_debug(1, "in png_get_y_pixels_per_meter");
++
+    if (png_ptr != NULL && info_ptr != NULL &&
+        (info_ptr->valid & PNG_INFO_pHYs) != 0)
+    {
+-      png_debug1(1, "in %s retrieval function",
+-          "png_get_y_pixels_per_meter");
+-
+       if (info_ptr->phys_unit_type == PNG_RESOLUTION_METER)
+-         return (info_ptr->y_pixels_per_unit);
++         return info_ptr->y_pixels_per_unit;
+    }
+ #else
+    PNG_UNUSED(png_ptr)
+    PNG_UNUSED(info_ptr)
+ #endif
+ 
+-   return (0);
++   return 0;
+ }
+ 
+ png_uint_32 PNGAPI
+ png_get_pixels_per_meter(png_const_structrp png_ptr, png_const_inforp info_ptr)
+ {
+ #ifdef PNG_pHYs_SUPPORTED
++   png_debug(1, "in png_get_pixels_per_meter");
++
+    if (png_ptr != NULL && info_ptr != NULL &&
+        (info_ptr->valid & PNG_INFO_pHYs) != 0)
+    {
+-      png_debug1(1, "in %s retrieval function", "png_get_pixels_per_meter");
+-
+       if (info_ptr->phys_unit_type == PNG_RESOLUTION_METER &&
+           info_ptr->x_pixels_per_unit == info_ptr->y_pixels_per_unit)
+-         return (info_ptr->x_pixels_per_unit);
++         return info_ptr->x_pixels_per_unit;
+    }
+ #else
+    PNG_UNUSED(png_ptr)
+    PNG_UNUSED(info_ptr)
+ #endif
+ 
+-   return (0);
++   return 0;
+ }
+ 
+ #ifdef PNG_FLOATING_POINT_SUPPORTED
+@@ -182,21 +191,21 @@ png_get_pixel_aspect_ratio(png_const_structrp png_ptr, png_const_inforp
+    info_ptr)
+ {
+ #ifdef PNG_READ_pHYs_SUPPORTED
++   png_debug(1, "in png_get_pixel_aspect_ratio");
++
+    if (png_ptr != NULL && info_ptr != NULL &&
+        (info_ptr->valid & PNG_INFO_pHYs) != 0)
+    {
+-      png_debug1(1, "in %s retrieval function", "png_get_aspect_ratio");
+-
+       if (info_ptr->x_pixels_per_unit != 0)
+-         return ((float)((float)info_ptr->y_pixels_per_unit
+-             /(float)info_ptr->x_pixels_per_unit));
++         return (float)info_ptr->y_pixels_per_unit
++              / (float)info_ptr->x_pixels_per_unit;
+    }
+ #else
+    PNG_UNUSED(png_ptr)
+    PNG_UNUSED(info_ptr)
+ #endif
+ 
+-   return ((float)0.0);
++   return (float)0.0;
+ }
+ #endif
+ 
+@@ -206,6 +215,8 @@ png_get_pixel_aspect_ratio_fixed(png_const_structrp png_ptr,
+     png_const_inforp info_ptr)
+ {
+ #ifdef PNG_READ_pHYs_SUPPORTED
++   png_debug(1, "in png_get_pixel_aspect_ratio_fixed");
++
+    if (png_ptr != NULL && info_ptr != NULL &&
+        (info_ptr->valid & PNG_INFO_pHYs) != 0 &&
+        info_ptr->x_pixels_per_unit > 0 && info_ptr->y_pixels_per_unit > 0 &&
+@@ -214,8 +225,6 @@ png_get_pixel_aspect_ratio_fixed(png_const_structrp png_ptr,
+    {
+       png_fixed_point res;
+ 
+-      png_debug1(1, "in %s retrieval function", "png_get_aspect_ratio_fixed");
+-
+       /* The following casts work because a PNG 4 byte integer only has a valid
+        * range of 0..2^31-1; otherwise the cast might overflow.
+        */
+@@ -236,80 +245,80 @@ png_int_32 PNGAPI
+ png_get_x_offset_microns(png_const_structrp png_ptr, png_const_inforp info_ptr)
+ {
+ #ifdef PNG_oFFs_SUPPORTED
++   png_debug(1, "in png_get_x_offset_microns");
++
+    if (png_ptr != NULL && info_ptr != NULL &&
+        (info_ptr->valid & PNG_INFO_oFFs) != 0)
+    {
+-      png_debug1(1, "in %s retrieval function", "png_get_x_offset_microns");
+-
+       if (info_ptr->offset_unit_type == PNG_OFFSET_MICROMETER)
+-         return (info_ptr->x_offset);
++         return info_ptr->x_offset;
+    }
+ #else
+    PNG_UNUSED(png_ptr)
+    PNG_UNUSED(info_ptr)
+ #endif
+ 
+-   return (0);
++   return 0;
+ }
+ 
+ png_int_32 PNGAPI
+ png_get_y_offset_microns(png_const_structrp png_ptr, png_const_inforp info_ptr)
+ {
+ #ifdef PNG_oFFs_SUPPORTED
++   png_debug(1, "in png_get_y_offset_microns");
++
+    if (png_ptr != NULL && info_ptr != NULL &&
+        (info_ptr->valid & PNG_INFO_oFFs) != 0)
+    {
+-      png_debug1(1, "in %s retrieval function", "png_get_y_offset_microns");
+-
+       if (info_ptr->offset_unit_type == PNG_OFFSET_MICROMETER)
+-         return (info_ptr->y_offset);
++         return info_ptr->y_offset;
+    }
+ #else
+    PNG_UNUSED(png_ptr)
+    PNG_UNUSED(info_ptr)
+ #endif
+ 
+-   return (0);
++   return 0;
+ }
+ 
+ png_int_32 PNGAPI
+ png_get_x_offset_pixels(png_const_structrp png_ptr, png_const_inforp info_ptr)
+ {
+ #ifdef PNG_oFFs_SUPPORTED
++   png_debug(1, "in png_get_x_offset_pixels");
++
+    if (png_ptr != NULL && info_ptr != NULL &&
+        (info_ptr->valid & PNG_INFO_oFFs) != 0)
+    {
+-      png_debug1(1, "in %s retrieval function", "png_get_x_offset_pixels");
+-
+       if (info_ptr->offset_unit_type == PNG_OFFSET_PIXEL)
+-         return (info_ptr->x_offset);
++         return info_ptr->x_offset;
+    }
+ #else
+    PNG_UNUSED(png_ptr)
+    PNG_UNUSED(info_ptr)
+ #endif
+ 
+-   return (0);
++   return 0;
+ }
+ 
+ png_int_32 PNGAPI
+ png_get_y_offset_pixels(png_const_structrp png_ptr, png_const_inforp info_ptr)
+ {
+ #ifdef PNG_oFFs_SUPPORTED
++   png_debug(1, "in png_get_y_offset_pixels");
++
+    if (png_ptr != NULL && info_ptr != NULL &&
+        (info_ptr->valid & PNG_INFO_oFFs) != 0)
+    {
+-      png_debug1(1, "in %s retrieval function", "png_get_y_offset_pixels");
+-
+       if (info_ptr->offset_unit_type == PNG_OFFSET_PIXEL)
+-         return (info_ptr->y_offset);
++         return info_ptr->y_offset;
+    }
+ #else
+    PNG_UNUSED(png_ptr)
+    PNG_UNUSED(info_ptr)
+ #endif
+ 
+-   return (0);
++   return 0;
+ }
+ 
+ #ifdef PNG_INCH_CONVERSIONS_SUPPORTED
+@@ -423,11 +432,11 @@ png_get_pHYs_dpi(png_const_structrp png_ptr, png_const_inforp info_ptr,
+ {
+    png_uint_32 retval = 0;
+ 
++   png_debug1(1, "in %s retrieval function", "pHYs");
++
+    if (png_ptr != NULL && info_ptr != NULL &&
+        (info_ptr->valid & PNG_INFO_pHYs) != 0)
+    {
+-      png_debug1(1, "in %s retrieval function", "pHYs");
+-
+       if (res_x != NULL)
+       {
+          *res_x = info_ptr->x_pixels_per_unit;
+@@ -453,7 +462,7 @@ png_get_pHYs_dpi(png_const_structrp png_ptr, png_const_inforp info_ptr,
+       }
+    }
+ 
+-   return (retval);
++   return retval;
+ }
+ #endif /* pHYs */
+ #endif /* INCH_CONVERSIONS */
+@@ -467,9 +476,9 @@ png_byte PNGAPI
+ png_get_channels(png_const_structrp png_ptr, png_const_inforp info_ptr)
+ {
+    if (png_ptr != NULL && info_ptr != NULL)
+-      return(info_ptr->channels);
++      return info_ptr->channels;
+ 
+-   return (0);
++   return 0;
+ }
+ 
+ #ifdef PNG_READ_SUPPORTED
+@@ -477,9 +486,9 @@ png_const_bytep PNGAPI
+ png_get_signature(png_const_structrp png_ptr, png_const_inforp info_ptr)
+ {
+    if (png_ptr != NULL && info_ptr != NULL)
+-      return(info_ptr->signature);
++      return info_ptr->signature;
+ 
+-   return (NULL);
++   return NULL;
+ }
+ #endif
+ 
+@@ -488,17 +497,17 @@ png_uint_32 PNGAPI
+ png_get_bKGD(png_const_structrp png_ptr, png_inforp info_ptr,
+     png_color_16p *background)
+ {
++   png_debug1(1, "in %s retrieval function", "bKGD");
++
+    if (png_ptr != NULL && info_ptr != NULL &&
+        (info_ptr->valid & PNG_INFO_bKGD) != 0 &&
+        background != NULL)
+    {
+-      png_debug1(1, "in %s retrieval function", "bKGD");
+-
+       *background = &(info_ptr->background);
+-      return (PNG_INFO_bKGD);
++      return PNG_INFO_bKGD;
+    }
+ 
+-   return (0);
++   return 0;
+ }
+ #endif
+ 
+@@ -513,6 +522,8 @@ png_get_cHRM(png_const_structrp png_ptr, png_const_inforp info_ptr,
+     double *white_x, double *white_y, double *red_x, double *red_y,
+     double *green_x, double *green_y, double *blue_x, double *blue_y)
+ {
++   png_debug1(1, "in %s retrieval function", "cHRM");
++
+    /* Quiet API change: this code used to only return the end points if a cHRM
+     * chunk was present, but the end points can also come from iCCP or sRGB
+     * chunks, so in 1.6.0 the png_get_ APIs return the end points regardless and
+@@ -522,8 +533,6 @@ png_get_cHRM(png_const_structrp png_ptr, png_const_inforp info_ptr,
+    if (png_ptr != NULL && info_ptr != NULL &&
+       (info_ptr->colorspace.flags & PNG_COLORSPACE_HAVE_ENDPOINTS) != 0)
+    {
+-      png_debug1(1, "in %s retrieval function", "cHRM");
+-
+       if (white_x != NULL)
+          *white_x = png_float(png_ptr,
+              info_ptr->colorspace.end_points_xy.whitex, "cHRM white X");
+@@ -548,10 +557,10 @@ png_get_cHRM(png_const_structrp png_ptr, png_const_inforp info_ptr,
+       if (blue_y != NULL)
+          *blue_y = png_float(png_ptr, info_ptr->colorspace.end_points_xy.bluey,
+              "cHRM blue Y");
+-      return (PNG_INFO_cHRM);
++      return PNG_INFO_cHRM;
+    }
+ 
+-   return (0);
++   return 0;
+ }
+ 
+ png_uint_32 PNGAPI
+@@ -560,11 +569,11 @@ png_get_cHRM_XYZ(png_const_structrp png_ptr, png_const_inforp info_ptr,
+     double *green_Y, double *green_Z, double *blue_X, double *blue_Y,
+     double *blue_Z)
+ {
++   png_debug1(1, "in %s retrieval function", "cHRM_XYZ(float)");
++
+    if (png_ptr != NULL && info_ptr != NULL &&
+        (info_ptr->colorspace.flags & PNG_COLORSPACE_HAVE_ENDPOINTS) != 0)
+    {
+-      png_debug1(1, "in %s retrieval function", "cHRM_XYZ(float)");
+-
+       if (red_X != NULL)
+          *red_X = png_float(png_ptr, info_ptr->colorspace.end_points_XYZ.red_X,
+              "cHRM red X");
+@@ -592,10 +601,10 @@ png_get_cHRM_XYZ(png_const_structrp png_ptr, png_const_inforp info_ptr,
+       if (blue_Z != NULL)
+          *blue_Z = png_float(png_ptr,
+              info_ptr->colorspace.end_points_XYZ.blue_Z, "cHRM blue Z");
+-      return (PNG_INFO_cHRM);
++      return PNG_INFO_cHRM;
+    }
+ 
+-   return (0);
++   return 0;
+ }
+ #  endif
+ 
+@@ -608,11 +617,11 @@ png_get_cHRM_XYZ_fixed(png_const_structrp png_ptr, png_const_inforp info_ptr,
+     png_fixed_point *int_blue_X, png_fixed_point *int_blue_Y,
+     png_fixed_point *int_blue_Z)
+ {
++   png_debug1(1, "in %s retrieval function", "cHRM_XYZ");
++
+    if (png_ptr != NULL && info_ptr != NULL &&
+       (info_ptr->colorspace.flags & PNG_COLORSPACE_HAVE_ENDPOINTS) != 0)
+    {
+-      png_debug1(1, "in %s retrieval function", "cHRM_XYZ");
+-
+       if (int_red_X != NULL)
+          *int_red_X = info_ptr->colorspace.end_points_XYZ.red_X;
+       if (int_red_Y != NULL)
+@@ -631,10 +640,10 @@ png_get_cHRM_XYZ_fixed(png_const_structrp png_ptr, png_const_inforp info_ptr,
+          *int_blue_Y = info_ptr->colorspace.end_points_XYZ.blue_Y;
+       if (int_blue_Z != NULL)
+          *int_blue_Z = info_ptr->colorspace.end_points_XYZ.blue_Z;
+-      return (PNG_INFO_cHRM);
++      return PNG_INFO_cHRM;
+    }
+ 
+-   return (0);
++   return 0;
+ }
+ 
+ png_uint_32 PNGAPI
+@@ -664,10 +673,10 @@ png_get_cHRM_fixed(png_const_structrp png_ptr, png_const_inforp info_ptr,
+          *blue_x = info_ptr->colorspace.end_points_xy.bluex;
+       if (blue_y != NULL)
+          *blue_y = info_ptr->colorspace.end_points_xy.bluey;
+-      return (PNG_INFO_cHRM);
++      return PNG_INFO_cHRM;
+    }
+ 
+-   return (0);
++   return 0;
+ }
+ #  endif
+ #endif
+@@ -685,10 +694,10 @@ png_get_gAMA_fixed(png_const_structrp png_ptr, png_const_inforp info_ptr,
+        file_gamma != NULL)
+    {
+       *file_gamma = info_ptr->colorspace.gamma;
+-      return (PNG_INFO_gAMA);
++      return PNG_INFO_gAMA;
+    }
+ 
+-   return (0);
++   return 0;
+ }
+ #  endif
+ 
+@@ -705,10 +714,10 @@ png_get_gAMA(png_const_structrp png_ptr, png_const_inforp info_ptr,
+    {
+       *file_gamma = png_float(png_ptr, info_ptr->colorspace.gamma,
+           "png_get_gAMA");
+-      return (PNG_INFO_gAMA);
++      return PNG_INFO_gAMA;
+    }
+ 
+-   return (0);
++   return 0;
+ }
+ #  endif
+ #endif
+@@ -724,10 +733,10 @@ png_get_sRGB(png_const_structrp png_ptr, png_const_inforp info_ptr,
+       (info_ptr->valid & PNG_INFO_sRGB) != 0 && file_srgb_intent != NULL)
+    {
+       *file_srgb_intent = info_ptr->colorspace.rendering_intent;
+-      return (PNG_INFO_sRGB);
++      return PNG_INFO_sRGB;
+    }
+ 
+-   return (0);
++   return 0;
+ }
+ #endif
+ 
+@@ -751,10 +760,10 @@ png_get_iCCP(png_const_structrp png_ptr, png_inforp info_ptr,
+        */
+       if (compression_type != NULL)
+          *compression_type = PNG_COMPRESSION_TYPE_BASE;
+-      return (PNG_INFO_iCCP);
++      return PNG_INFO_iCCP;
+    }
+ 
+-   return (0);
++   return 0;
+ 
+ }
+ #endif
+@@ -764,13 +773,15 @@ int PNGAPI
+ png_get_sPLT(png_const_structrp png_ptr, png_inforp info_ptr,
+     png_sPLT_tpp spalettes)
+ {
++   png_debug1(1, "in %s retrieval function", "sPLT");
++
+    if (png_ptr != NULL && info_ptr != NULL && spalettes != NULL)
+    {
+       *spalettes = info_ptr->splt_palettes;
+       return info_ptr->splt_palettes_num;
+    }
+ 
+-   return (0);
++   return 0;
+ }
+ #endif
+ 
+@@ -796,10 +807,10 @@ png_get_eXIf_1(png_const_structrp png_ptr, png_const_inforp info_ptr,
+    {
+       *num_exif = info_ptr->num_exif;
+       *exif = info_ptr->exif;
+-      return (PNG_INFO_eXIf);
++      return PNG_INFO_eXIf;
+    }
+ 
+-   return (0);
++   return 0;
+ }
+ #endif
+ 
+@@ -814,10 +825,10 @@ png_get_hIST(png_const_structrp png_ptr, png_inforp info_ptr,
+        (info_ptr->valid & PNG_INFO_hIST) != 0 && hist != NULL)
+    {
+       *hist = info_ptr->hist;
+-      return (PNG_INFO_hIST);
++      return PNG_INFO_hIST;
+    }
+ 
+-   return (0);
++   return 0;
+ }
+ #endif
+ 
+@@ -830,7 +841,7 @@ png_get_IHDR(png_const_structrp png_ptr, png_const_inforp info_ptr,
+    png_debug1(1, "in %s retrieval function", "IHDR");
+ 
+    if (png_ptr == NULL || info_ptr == NULL)
+-      return (0);
++      return 0;
+ 
+    if (width != NULL)
+        *width = info_ptr->width;
+@@ -862,7 +873,7 @@ png_get_IHDR(png_const_structrp png_ptr, png_const_inforp info_ptr,
+        info_ptr->bit_depth, info_ptr->color_type, info_ptr->interlace_type,
+        info_ptr->compression_type, info_ptr->filter_type);
+ 
+-   return (1);
++   return 1;
+ }
+ 
+ #ifdef PNG_oFFs_SUPPORTED
+@@ -879,10 +890,10 @@ png_get_oFFs(png_const_structrp png_ptr, png_const_inforp info_ptr,
+       *offset_x = info_ptr->x_offset;
+       *offset_y = info_ptr->y_offset;
+       *unit_type = (int)info_ptr->offset_unit_type;
+-      return (PNG_INFO_oFFs);
++      return PNG_INFO_oFFs;
+    }
+ 
+-   return (0);
++   return 0;
+ }
+ #endif
+ 
+@@ -906,10 +917,10 @@ png_get_pCAL(png_const_structrp png_ptr, png_inforp info_ptr,
+       *nparams = (int)info_ptr->pcal_nparams;
+       *units = info_ptr->pcal_units;
+       *params = info_ptr->pcal_params;
+-      return (PNG_INFO_pCAL);
++      return PNG_INFO_pCAL;
+    }
+ 
+-   return (0);
++   return 0;
+ }
+ #endif
+ 
+@@ -921,6 +932,8 @@ png_uint_32 PNGAPI
+ png_get_sCAL_fixed(png_const_structrp png_ptr, png_const_inforp info_ptr,
+     int *unit, png_fixed_point *width, png_fixed_point *height)
+ {
++   png_debug1(1, "in %s retrieval function", "sCAL");
++
+    if (png_ptr != NULL && info_ptr != NULL &&
+        (info_ptr->valid & PNG_INFO_sCAL) != 0)
+    {
+@@ -932,10 +945,10 @@ png_get_sCAL_fixed(png_const_structrp png_ptr, png_const_inforp info_ptr,
+       *width = png_fixed(png_ptr, atof(info_ptr->scal_s_width), "sCAL width");
+       *height = png_fixed(png_ptr, atof(info_ptr->scal_s_height),
+           "sCAL height");
+-      return (PNG_INFO_sCAL);
++      return PNG_INFO_sCAL;
+    }
+ 
+-   return(0);
++   return 0;
+ }
+ #    endif /* FLOATING_ARITHMETIC */
+ #  endif /* FIXED_POINT */
+@@ -944,32 +957,36 @@ png_uint_32 PNGAPI
+ png_get_sCAL(png_const_structrp png_ptr, png_const_inforp info_ptr,
+     int *unit, double *width, double *height)
+ {
++   png_debug1(1, "in %s retrieval function", "sCAL(float)");
++
+    if (png_ptr != NULL && info_ptr != NULL &&
+        (info_ptr->valid & PNG_INFO_sCAL) != 0)
+    {
+       *unit = info_ptr->scal_unit;
+       *width = atof(info_ptr->scal_s_width);
+       *height = atof(info_ptr->scal_s_height);
+-      return (PNG_INFO_sCAL);
++      return PNG_INFO_sCAL;
+    }
+ 
+-   return(0);
++   return 0;
+ }
+ #  endif /* FLOATING POINT */
+ png_uint_32 PNGAPI
+ png_get_sCAL_s(png_const_structrp png_ptr, png_const_inforp info_ptr,
+     int *unit, png_charpp width, png_charpp height)
+ {
++   png_debug1(1, "in %s retrieval function", "sCAL(str)");
++
+    if (png_ptr != NULL && info_ptr != NULL &&
+        (info_ptr->valid & PNG_INFO_sCAL) != 0)
+    {
+       *unit = info_ptr->scal_unit;
+       *width = info_ptr->scal_s_width;
+       *height = info_ptr->scal_s_height;
+-      return (PNG_INFO_sCAL);
++      return PNG_INFO_sCAL;
+    }
+ 
+-   return(0);
++   return 0;
+ }
+ #endif /* sCAL */
+ 
+@@ -1004,7 +1021,7 @@ png_get_pHYs(png_const_structrp png_ptr, png_const_inforp info_ptr,
+       }
+    }
+ 
+-   return (retval);
++   return retval;
+ }
+ #endif /* pHYs */
+ 
+@@ -1020,10 +1037,10 @@ png_get_PLTE(png_const_structrp png_ptr, png_inforp info_ptr,
+       *palette = info_ptr->palette;
+       *num_palette = info_ptr->num_palette;
+       png_debug1(3, "num_palette = %d", *num_palette);
+-      return (PNG_INFO_PLTE);
++      return PNG_INFO_PLTE;
+    }
+ 
+-   return (0);
++   return 0;
+ }
+ 
+ #ifdef PNG_sBIT_SUPPORTED
+@@ -1037,10 +1054,10 @@ png_get_sBIT(png_const_structrp png_ptr, png_inforp info_ptr,
+        (info_ptr->valid & PNG_INFO_sBIT) != 0 && sig_bit != NULL)
+    {
+       *sig_bit = &(info_ptr->sig_bit);
+-      return (PNG_INFO_sBIT);
++      return PNG_INFO_sBIT;
+    }
+ 
+-   return (0);
++   return 0;
+ }
+ #endif
+ 
+@@ -1051,7 +1068,7 @@ png_get_text(png_const_structrp png_ptr, png_inforp info_ptr,
+ {
+    if (png_ptr != NULL && info_ptr != NULL && info_ptr->num_text > 0)
+    {
+-      png_debug1(1, "in 0x%lx retrieval function",
++      png_debug1(1, "in text retrieval function, chunk typeid = 0x%lx",
+          (unsigned long)png_ptr->chunk_name);
+ 
+       if (text_ptr != NULL)
+@@ -1066,7 +1083,7 @@ png_get_text(png_const_structrp png_ptr, png_inforp info_ptr,
+    if (num_text != NULL)
+       *num_text = 0;
+ 
+-   return(0);
++   return 0;
+ }
+ #endif
+ 
+@@ -1081,10 +1098,10 @@ png_get_tIME(png_const_structrp png_ptr, png_inforp info_ptr,
+        (info_ptr->valid & PNG_INFO_tIME) != 0 && mod_time != NULL)
+    {
+       *mod_time = &(info_ptr->mod_time);
+-      return (PNG_INFO_tIME);
++      return PNG_INFO_tIME;
+    }
+ 
+-   return (0);
++   return 0;
+ }
+ #endif
+ 
+@@ -1094,11 +1111,12 @@ png_get_tRNS(png_const_structrp png_ptr, png_inforp info_ptr,
+     png_bytep *trans_alpha, int *num_trans, png_color_16p *trans_color)
+ {
+    png_uint_32 retval = 0;
++
++   png_debug1(1, "in %s retrieval function", "tRNS");
++
+    if (png_ptr != NULL && info_ptr != NULL &&
+        (info_ptr->valid & PNG_INFO_tRNS) != 0)
+    {
+-      png_debug1(1, "in %s retrieval function", "tRNS");
+-
+       if (info_ptr->color_type == PNG_COLOR_TYPE_PALETTE)
+       {
+          if (trans_alpha != NULL)
+@@ -1130,7 +1148,7 @@ png_get_tRNS(png_const_structrp png_ptr, png_inforp info_ptr,
+       }
+    }
+ 
+-   return (retval);
++   return retval;
+ }
+ #endif
+ 
+@@ -1145,13 +1163,13 @@ png_get_unknown_chunks(png_const_structrp png_ptr, png_inforp info_ptr,
+       return info_ptr->unknown_chunks_num;
+    }
+ 
+-   return (0);
++   return 0;
+ }
+ #endif
+ 
+ #ifdef PNG_READ_RGB_TO_GRAY_SUPPORTED
+ png_byte PNGAPI
+-png_get_rgb_to_gray_status (png_const_structrp png_ptr)
++png_get_rgb_to_gray_status(png_const_structrp png_ptr)
+ {
+    return (png_byte)(png_ptr ? png_ptr->rgb_to_gray_status : 0);
+ }
+@@ -1192,27 +1210,27 @@ png_get_compression_buffer_size(png_const_structrp png_ptr)
+ /* These functions were added to libpng 1.2.6 and were enabled
+  * by default in libpng-1.4.0 */
+ png_uint_32 PNGAPI
+-png_get_user_width_max (png_const_structrp png_ptr)
++png_get_user_width_max(png_const_structrp png_ptr)
+ {
+    return (png_ptr ? png_ptr->user_width_max : 0);
+ }
+ 
+ png_uint_32 PNGAPI
+-png_get_user_height_max (png_const_structrp png_ptr)
++png_get_user_height_max(png_const_structrp png_ptr)
+ {
+    return (png_ptr ? png_ptr->user_height_max : 0);
+ }
+ 
+ /* This function was added to libpng 1.4.0 */
+ png_uint_32 PNGAPI
+-png_get_chunk_cache_max (png_const_structrp png_ptr)
++png_get_chunk_cache_max(png_const_structrp png_ptr)
+ {
+    return (png_ptr ? png_ptr->user_chunk_cache_max : 0);
+ }
+ 
+ /* This function was added to libpng 1.4.1 */
+ png_alloc_size_t PNGAPI
+-png_get_chunk_malloc_max (png_const_structrp png_ptr)
++png_get_chunk_malloc_max(png_const_structrp png_ptr)
+ {
+    return (png_ptr ? png_ptr->user_chunk_malloc_max : 0);
+ }
+@@ -1221,13 +1239,13 @@ png_get_chunk_malloc_max (png_const_structrp png_ptr)
+ /* These functions were added to libpng 1.4.0 */
+ #ifdef PNG_IO_STATE_SUPPORTED
+ png_uint_32 PNGAPI
+-png_get_io_state (png_const_structrp png_ptr)
++png_get_io_state(png_const_structrp png_ptr)
+ {
+    return png_ptr->io_state;
+ }
+ 
+ png_uint_32 PNGAPI
+-png_get_io_chunk_type (png_const_structrp png_ptr)
++png_get_io_chunk_type(png_const_structrp png_ptr)
+ {
+    return png_ptr->chunk_name;
+ }
+@@ -1241,7 +1259,7 @@ png_get_palette_max(png_const_structp png_ptr, png_const_infop info_ptr)
+    if (png_ptr != NULL && info_ptr != NULL)
+       return png_ptr->num_palette_max;
+ 
+-   return (-1);
++   return -1;
+ }
+ #  endif
+ #endif
+diff --git old/qtbase/src/3rdparty/libpng/pnglibconf.h new/qtbase/src/3rdparty/libpng/pnglibconf.h
+index e1e27e957ea..d768a8ef087 100644
+--- old/qtbase/src/3rdparty/libpng/pnglibconf.h
++++ new/qtbase/src/3rdparty/libpng/pnglibconf.h
+@@ -1,8 +1,8 @@
+ /* pnglibconf.h - library build configuration */
+ 
+-/* libpng version 1.6.37 */
++/* libpng version 1.6.41 */
+ 
+-/* Copyright (c) 2018-2019 Cosmin Truta */
++/* Copyright (c) 2018-2024 Cosmin Truta */
+ /* Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson */
+ 
+ /* This code is released under the libpng license. */
+@@ -27,6 +27,7 @@
+ #define PNG_COLORSPACE_SUPPORTED
+ #define PNG_CONSOLE_IO_SUPPORTED
+ #define PNG_CONVERT_tIME_SUPPORTED
++/*#undef PNG_DISABLE_ADLER32_CHECK_SUPPORTED*/
+ #define PNG_EASY_ACCESS_SUPPORTED
+ /*#undef PNG_ERROR_NUMBERS_SUPPORTED*/
+ #define PNG_ERROR_TEXT_SUPPORTED
+@@ -41,6 +42,10 @@
+ #define PNG_INCH_CONVERSIONS_SUPPORTED
+ #define PNG_INFO_IMAGE_SUPPORTED
+ #define PNG_IO_STATE_SUPPORTED
++/*#undef PNG_MIPS_MMI_API_SUPPORTED*/
++/*#undef PNG_MIPS_MMI_CHECK_SUPPORTED*/
++/*#undef PNG_MIPS_MSA_API_SUPPORTED*/
++/*#undef PNG_MIPS_MSA_CHECK_SUPPORTED*/
+ #define PNG_MNG_FEATURES_SUPPORTED
+ #define PNG_POINTER_INDEXING_SUPPORTED
+ /*#undef PNG_POWERPC_VSX_API_SUPPORTED*/
+diff --git old/qtbase/src/3rdparty/libpng/pngpread.c new/qtbase/src/3rdparty/libpng/pngpread.c
+index e283627b77c..be640f77a9b 100644
+--- old/qtbase/src/3rdparty/libpng/pngpread.c
++++ new/qtbase/src/3rdparty/libpng/pngpread.c
+@@ -1,7 +1,7 @@
+ 
+ /* pngpread.c - read a png file in push mode
+  *
+- * Copyright (c) 2018 Cosmin Truta
++ * Copyright (c) 2018-2024 Cosmin Truta
+  * Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson
+  * Copyright (c) 1996-1997 Andreas Dilger
+  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
+@@ -145,10 +145,10 @@ png_push_read_sig(png_structrp png_ptr, png_inforp info_ptr)
+        num_to_check);
+    png_ptr->sig_bytes = (png_byte)(png_ptr->sig_bytes + num_to_check);
+ 
+-   if (png_sig_cmp(info_ptr->signature, num_checked, num_to_check))
++   if (png_sig_cmp(info_ptr->signature, num_checked, num_to_check) != 0)
+    {
+       if (num_checked < 4 &&
+-          png_sig_cmp(info_ptr->signature, num_checked, num_to_check - 4))
++          png_sig_cmp(info_ptr->signature, num_checked, num_to_check - 4) != 0)
+          png_error(png_ptr, "Not a PNG file");
+ 
+       else
+@@ -1089,7 +1089,7 @@ png_voidp PNGAPI
+ png_get_progressive_ptr(png_const_structrp png_ptr)
+ {
+    if (png_ptr == NULL)
+-      return (NULL);
++      return NULL;
+ 
+    return png_ptr->io_ptr;
+ }
+diff --git old/qtbase/src/3rdparty/libpng/pngpriv.h new/qtbase/src/3rdparty/libpng/pngpriv.h
+index 2ab9b70d736..3a3e9d3564d 100644
+--- old/qtbase/src/3rdparty/libpng/pngpriv.h
++++ new/qtbase/src/3rdparty/libpng/pngpriv.h
+@@ -1,7 +1,7 @@
+ 
+ /* pngpriv.h - private declarations for use inside libpng
+  *
+- * Copyright (c) 2018-2019 Cosmin Truta
++ * Copyright (c) 2018-2024 Cosmin Truta
+  * Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson
+  * Copyright (c) 1996-1997 Andreas Dilger
+  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
+@@ -23,12 +23,6 @@
+ #ifndef PNGPRIV_H
+ #define PNGPRIV_H
+ 
+-#ifdef _MSC_VER
+-#  ifndef _CRT_SECURE_NO_DEPRECATE
+-#    define _CRT_SECURE_NO_DEPRECATE
+-#  endif
+-#endif
+-
+ /* Feature Test Macros.  The following are defined here to ensure that correctly
+  * implemented libraries reveal the APIs libpng needs to build and hide those
+  * that are not needed and potentially damaging to the compilation.
+@@ -180,7 +174,7 @@
+ #     else /* !defined __ARM_NEON__ */
+          /* The 'intrinsics' code simply won't compile without this -mfpu=neon:
+           */
+-#        if !defined(__aarch64__)
++#        if !defined(__aarch64__) && !defined(_M_ARM64)
+             /* The assembler code currently does not work on ARM64 */
+ #          define PNG_ARM_NEON_IMPLEMENTATION 2
+ #        endif /* __aarch64__ */
+@@ -191,6 +185,8 @@
+       /* Use the intrinsics code by default. */
+ #     define PNG_ARM_NEON_IMPLEMENTATION 1
+ #  endif
++#else /* PNG_ARM_NEON_OPT == 0 */
++#     define PNG_ARM_NEON_IMPLEMENTATION 0
+ #endif /* PNG_ARM_NEON_OPT > 0 */
+ 
+ #ifndef PNG_MIPS_MSA_OPT
+@@ -201,6 +197,18 @@
+ #  endif
+ #endif
+ 
++#ifndef PNG_MIPS_MMI_OPT
++#  ifdef PNG_MIPS_MMI
++#    if defined(__mips_loongson_mmi) && (_MIPS_SIM == _ABI64) && defined(PNG_ALIGNED_MEMORY_SUPPORTED)
++#       define PNG_MIPS_MMI_OPT 1
++#    else
++#       define PNG_MIPS_MMI_OPT 0
++#    endif
++#  else
++#    define PNG_MIPS_MMI_OPT 0
++#  endif
++#endif
++
+ #ifndef PNG_POWERPC_VSX_OPT
+ #  if defined(__PPC64__) && defined(__ALTIVEC__) && defined(__VSX__)
+ #     define PNG_POWERPC_VSX_OPT 2
+@@ -209,6 +217,14 @@
+ #  endif
+ #endif
+ 
++#ifndef PNG_LOONGARCH_LSX_OPT
++#  if defined(__loongarch_sx)
++#     define PNG_LOONGARCH_LSX_OPT 1
++#  else
++#     define PNG_LOONGARCH_LSX_OPT 0
++#  endif
++#endif
++
+ #ifndef PNG_INTEL_SSE_OPT
+ #   ifdef PNG_INTEL_SSE
+       /* Only check for SSE if the build configuration has been modified to
+@@ -252,7 +268,6 @@
+ #endif
+ 
+ #if PNG_MIPS_MSA_OPT > 0
+-#  define PNG_FILTER_OPTIMIZATIONS png_init_filter_functions_msa
+ #  ifndef PNG_MIPS_MSA_IMPLEMENTATION
+ #     if defined(__mips_msa)
+ #        if defined(__clang__)
+@@ -268,14 +283,41 @@
+ 
+ #  ifndef PNG_MIPS_MSA_IMPLEMENTATION
+ #     define PNG_MIPS_MSA_IMPLEMENTATION 1
++#     define PNG_FILTER_OPTIMIZATIONS png_init_filter_functions_mips
+ #  endif
++#else
++#  define PNG_MIPS_MSA_IMPLEMENTATION 0
+ #endif /* PNG_MIPS_MSA_OPT > 0 */
+ 
++#if PNG_MIPS_MMI_OPT > 0
++#  ifndef PNG_MIPS_MMI_IMPLEMENTATION
++#     if defined(__mips_loongson_mmi) && (_MIPS_SIM == _ABI64)
++#        define PNG_MIPS_MMI_IMPLEMENTATION 2
++#     else /* !defined __mips_loongson_mmi  || _MIPS_SIM != _ABI64 */
++#        define PNG_MIPS_MMI_IMPLEMENTATION 0
++#     endif /* __mips_loongson_mmi  && _MIPS_SIM == _ABI64 */
++#  endif /* !PNG_MIPS_MMI_IMPLEMENTATION */
++
++#   if PNG_MIPS_MMI_IMPLEMENTATION > 0
++#      define PNG_FILTER_OPTIMIZATIONS png_init_filter_functions_mips
++#   endif
++#else
++#   define PNG_MIPS_MMI_IMPLEMENTATION 0
++#endif /* PNG_MIPS_MMI_OPT > 0 */
++
+ #if PNG_POWERPC_VSX_OPT > 0
+ #  define PNG_FILTER_OPTIMIZATIONS png_init_filter_functions_vsx
+ #  define PNG_POWERPC_VSX_IMPLEMENTATION 1
++#else
++#  define PNG_POWERPC_VSX_IMPLEMENTATION 0
+ #endif
+ 
++#if PNG_LOONGARCH_LSX_OPT > 0
++#   define PNG_FILTER_OPTIMIZATIONS png_init_filter_functions_lsx
++#   define PNG_LOONGARCH_LSX_IMPLEMENTATION 1
++#else
++#   define PNG_LOONGARCH_LSX_IMPLEMENTATION 0
++#endif
+ 
+ /* Is this a build of a DLL where compilation of the object modules requires
+  * different preprocessor settings to those required for a simple library?  If
+@@ -314,11 +356,6 @@
+ #  endif
+ #endif /* Setting PNG_BUILD_DLL if required */
+ 
+-/* Modfied for usage in Qt: Do not export the libpng APIs */
+-#ifdef PNG_BUILD_DLL
+-#undef PNG_BUILD_DLL
+-#endif
+-
+ /* See pngconf.h for more details: the builder of the library may set this on
+  * the command line to the right thing for the specific compilation system or it
+  * may be automagically set above (at present we know of no system where it does
+@@ -503,16 +540,7 @@
+    static_cast<type>(static_cast<const void*>(value))
+ #else
+ #  define png_voidcast(type, value) (value)
+-#  ifdef _WIN64
+-#     ifdef __GNUC__
+-         typedef unsigned long long png_ptruint;
+-#     else
+-         typedef unsigned __int64 png_ptruint;
+-#     endif
+-#  else
+-      typedef unsigned long png_ptruint;
+-#  endif
+-#  define png_constcast(type, value) ((type)(png_ptruint)(const void*)(value))
++#  define png_constcast(type, value) ((type)(void*)(const void*)(value))
+ #  define png_aligncast(type, value) ((void*)(value))
+ #  define png_aligncastconst(type, value) ((const void*)(value))
+ #endif /* __cplusplus */
+@@ -528,18 +556,8 @@
+     */
+ #  include <float.h>
+ 
+-#  if (defined(__MWERKS__) && defined(macintosh)) || defined(applec) || \
+-    defined(THINK_C) || defined(__SC__) || defined(TARGET_OS_MAC)
+-   /* We need to check that <math.h> hasn't already been included earlier
+-    * as it seems it doesn't agree with <fp.h>, yet we should really use
+-    * <fp.h> if possible.
+-    */
+-#    if !defined(__MATH_H__) && !defined(__MATH_H) && !defined(__cmath__)
+-#      include <fp.h>
+-#    endif
+-#  else
+-#    include <math.h>
+-#  endif
++#  include <math.h>
++
+ #  if defined(_AMIGA) && defined(__SASC) && defined(_M68881)
+    /* Amiga SAS/C: We must include builtin FPU functions when compiling using
+     * MATH=68881
+@@ -554,12 +572,8 @@
+ #  include <alloc.h>
+ #endif
+ 
+-#if defined(WIN32) || defined(_Windows) || defined(_WINDOWS) || \
+-    defined(_WIN32) || defined(__WIN32__)
+-#  include <windows.h>  /* defines _WINDOWS_ macro */
+-#  if defined(WINAPI_FAMILY) && (WINAPI_FAMILY==WINAPI_FAMILY_APP || WINAPI_FAMILY==WINAPI_FAMILY_PHONE_APP)
+-#    define _WINRT_ /* Define a macro for Windows Runtime builds */
+-#  endif
++#if defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
++#  include <windows.h>
+ #endif
+ #endif /* PNG_VERSION_INFO_ONLY */
+ 
+@@ -568,24 +582,20 @@
+  * functions that are passed far data must be model-independent.
+  */
+ 
+-/* Memory model/platform independent fns */
++/* Platform-independent functions */
+ #ifndef PNG_ABORT
+-#  if (defined(_WINDOWS_) || defined(_WIN32_WCE)) && !defined(_WINRT_)
+-#    define PNG_ABORT() ExitProcess(0)
+-#  else
+-#    define PNG_ABORT() abort()
+-#  endif
++#  define PNG_ABORT() abort()
+ #endif
+ 
+ /* These macros may need to be architecture dependent. */
+-#define PNG_ALIGN_NONE   0 /* do not use data alignment */
+-#define PNG_ALIGN_ALWAYS 1 /* assume unaligned accesses are OK */
++#define PNG_ALIGN_NONE      0 /* do not use data alignment */
++#define PNG_ALIGN_ALWAYS    1 /* assume unaligned accesses are OK */
+ #ifdef offsetof
+-#  define PNG_ALIGN_OFFSET 2 /* use offsetof to determine alignment */
++#  define PNG_ALIGN_OFFSET  2 /* use offsetof to determine alignment */
+ #else
+ #  define PNG_ALIGN_OFFSET -1 /* prevent the use of this */
+ #endif
+-#define PNG_ALIGN_SIZE   3 /* use sizeof to determine alignment */
++#define PNG_ALIGN_SIZE      3 /* use sizeof to determine alignment */
+ 
+ #ifndef PNG_ALIGN_TYPE
+    /* Default to using aligned access optimizations and requiring alignment to a
+@@ -599,26 +609,25 @@
+    /* This is used because in some compiler implementations non-aligned
+     * structure members are supported, so the offsetof approach below fails.
+     * Set PNG_ALIGN_SIZE=0 for compiler combinations where unaligned access
+-    * is good for performance.  Do not do this unless you have tested the result
+-    * and understand it.
++    * is good for performance.  Do not do this unless you have tested the
++    * result and understand it.
+     */
+-#  define png_alignof(type) (sizeof (type))
++#  define png_alignof(type) (sizeof(type))
+ #else
+ #  if PNG_ALIGN_TYPE == PNG_ALIGN_OFFSET
+-#     define png_alignof(type) offsetof(struct{char c; type t;}, t)
++#    define png_alignof(type) offsetof(struct{char c; type t;}, t)
+ #  else
+-#     if PNG_ALIGN_TYPE == PNG_ALIGN_ALWAYS
+-#        define png_alignof(type) (1)
+-#     endif
+-      /* Else leave png_alignof undefined to prevent use thereof */
++#    if PNG_ALIGN_TYPE == PNG_ALIGN_ALWAYS
++#      define png_alignof(type) 1
++#    endif
++     /* Else leave png_alignof undefined to prevent use thereof */
+ #  endif
+ #endif
+ 
+-/* This implicitly assumes alignment is always to a power of 2. */
++/* This implicitly assumes alignment is always a multiple of 2. */
+ #ifdef png_alignof
+-#  define png_isaligned(ptr, type)\
+-   (((type)((const char*)ptr-(const char*)0) & \
+-   (type)(png_alignof(type)-1)) == 0)
++#  define png_isaligned(ptr, type) \
++   (((type)(size_t)((const void*)(ptr)) & (type)(png_alignof(type)-1)) == 0)
+ #else
+ #  define png_isaligned(ptr, type) 0
+ #endif
+@@ -649,7 +658,7 @@
+ #define PNG_BACKGROUND_IS_GRAY     0x800U
+ #define PNG_HAVE_PNG_SIGNATURE    0x1000U
+ #define PNG_HAVE_CHUNK_AFTER_IDAT 0x2000U /* Have another chunk after IDAT */
+-                   /*             0x4000U (unused) */
++#define PNG_WROTE_eXIf            0x4000U
+ #define PNG_IS_READ_STRUCT        0x8000U /* Else is a write struct */
+ 
+ /* Flags for the transformations the PNG library does on the image data */
+@@ -1329,7 +1338,7 @@ PNG_INTERNAL_FUNCTION(void,png_read_filter_row_paeth4_neon,(png_row_infop
+     row_info, png_bytep row, png_const_bytep prev_row),PNG_EMPTY);
+ #endif
+ 
+-#if PNG_MIPS_MSA_OPT > 0
++#if PNG_MIPS_MSA_IMPLEMENTATION == 1
+ PNG_INTERNAL_FUNCTION(void,png_read_filter_row_up_msa,(png_row_infop row_info,
+     png_bytep row, png_const_bytep prev_row),PNG_EMPTY);
+ PNG_INTERNAL_FUNCTION(void,png_read_filter_row_sub3_msa,(png_row_infop
+@@ -1346,6 +1355,23 @@ PNG_INTERNAL_FUNCTION(void,png_read_filter_row_paeth4_msa,(png_row_infop
+     row_info, png_bytep row, png_const_bytep prev_row),PNG_EMPTY);
+ #endif
+ 
++#if PNG_MIPS_MMI_IMPLEMENTATION > 0
++PNG_INTERNAL_FUNCTION(void,png_read_filter_row_up_mmi,(png_row_infop row_info,
++    png_bytep row, png_const_bytep prev_row),PNG_EMPTY);
++PNG_INTERNAL_FUNCTION(void,png_read_filter_row_sub3_mmi,(png_row_infop
++    row_info, png_bytep row, png_const_bytep prev_row),PNG_EMPTY);
++PNG_INTERNAL_FUNCTION(void,png_read_filter_row_sub4_mmi,(png_row_infop
++    row_info, png_bytep row, png_const_bytep prev_row),PNG_EMPTY);
++PNG_INTERNAL_FUNCTION(void,png_read_filter_row_avg3_mmi,(png_row_infop
++    row_info, png_bytep row, png_const_bytep prev_row),PNG_EMPTY);
++PNG_INTERNAL_FUNCTION(void,png_read_filter_row_avg4_mmi,(png_row_infop
++    row_info, png_bytep row, png_const_bytep prev_row),PNG_EMPTY);
++PNG_INTERNAL_FUNCTION(void,png_read_filter_row_paeth3_mmi,(png_row_infop
++    row_info, png_bytep row, png_const_bytep prev_row),PNG_EMPTY);
++PNG_INTERNAL_FUNCTION(void,png_read_filter_row_paeth4_mmi,(png_row_infop
++    row_info, png_bytep row, png_const_bytep prev_row),PNG_EMPTY);
++#endif
++
+ #if PNG_POWERPC_VSX_OPT > 0
+ PNG_INTERNAL_FUNCTION(void,png_read_filter_row_up_vsx,(png_row_infop row_info,
+     png_bytep row, png_const_bytep prev_row),PNG_EMPTY);
+@@ -1378,6 +1404,23 @@ PNG_INTERNAL_FUNCTION(void,png_read_filter_row_paeth4_sse2,(png_row_infop
+     row_info, png_bytep row, png_const_bytep prev_row),PNG_EMPTY);
+ #endif
+ 
++#if PNG_LOONGARCH_LSX_IMPLEMENTATION == 1
++PNG_INTERNAL_FUNCTION(void,png_read_filter_row_up_lsx,(png_row_infop
++    row_info, png_bytep row, png_const_bytep prev_row),PNG_EMPTY);
++PNG_INTERNAL_FUNCTION(void,png_read_filter_row_sub3_lsx,(png_row_infop
++    row_info, png_bytep row, png_const_bytep prev_row),PNG_EMPTY);
++PNG_INTERNAL_FUNCTION(void,png_read_filter_row_sub4_lsx,(png_row_infop
++    row_info, png_bytep row, png_const_bytep prev_row),PNG_EMPTY);
++PNG_INTERNAL_FUNCTION(void,png_read_filter_row_avg3_lsx,(png_row_infop
++    row_info, png_bytep row, png_const_bytep prev_row),PNG_EMPTY);
++PNG_INTERNAL_FUNCTION(void,png_read_filter_row_avg4_lsx,(png_row_infop
++    row_info, png_bytep row, png_const_bytep prev_row),PNG_EMPTY);
++PNG_INTERNAL_FUNCTION(void,png_read_filter_row_paeth3_lsx,(png_row_infop
++    row_info, png_bytep row, png_const_bytep prev_row),PNG_EMPTY);
++PNG_INTERNAL_FUNCTION(void,png_read_filter_row_paeth4_lsx,(png_row_infop
++    row_info, png_bytep row, png_const_bytep prev_row),PNG_EMPTY);
++#endif
++
+ /* Choose the best filter to use and filter the row data */
+ PNG_INTERNAL_FUNCTION(void,png_write_find_filter,(png_structrp png_ptr,
+     png_row_infop row_info),PNG_EMPTY);
+@@ -1933,7 +1976,7 @@ PNG_INTERNAL_FUNCTION(void,png_ascii_from_fixed,(png_const_structrp png_ptr,
+  */
+ #define PNG_FP_INVALID  512  /* Available for callers as a distinct value */
+ 
+-/* Result codes for the parser (boolean - true meants ok, false means
++/* Result codes for the parser (boolean - true means ok, false means
+  * not ok yet.)
+  */
+ #define PNG_FP_MAYBE      0  /* The number may be valid in the future */
+@@ -1969,7 +2012,7 @@ PNG_INTERNAL_FUNCTION(void,png_ascii_from_fixed,(png_const_structrp png_ptr,
+  * the problem character.)  This has not been tested within libpng.
+  */
+ PNG_INTERNAL_FUNCTION(int,png_check_fp_number,(png_const_charp string,
+-   size_t size, int *statep, png_size_tp whereami),PNG_EMPTY);
++   size_t size, int *statep, size_t *whereami),PNG_EMPTY);
+ 
+ /* This is the same but it checks a complete string and returns true
+  * only if it just contains a floating point number.  As of 1.5.4 this
+@@ -2117,17 +2160,27 @@ PNG_INTERNAL_FUNCTION(void, png_init_filter_functions_neon,
+    (png_structp png_ptr, unsigned int bpp), PNG_EMPTY);
+ #endif
+ 
+-#if PNG_MIPS_MSA_OPT > 0
+-PNG_INTERNAL_FUNCTION(void, png_init_filter_functions_msa,
++#if PNG_MIPS_MSA_IMPLEMENTATION == 1
++PNG_INTERNAL_FUNCTION(void, png_init_filter_functions_mips,
+    (png_structp png_ptr, unsigned int bpp), PNG_EMPTY);
+ #endif
+ 
++#  if PNG_MIPS_MMI_IMPLEMENTATION > 0
++PNG_INTERNAL_FUNCTION(void, png_init_filter_functions_mips,
++   (png_structp png_ptr, unsigned int bpp), PNG_EMPTY);
++#  endif
++
+ #  if PNG_INTEL_SSE_IMPLEMENTATION > 0
+ PNG_INTERNAL_FUNCTION(void, png_init_filter_functions_sse2,
+    (png_structp png_ptr, unsigned int bpp), PNG_EMPTY);
+ #  endif
+ #endif
+ 
++#if PNG_LOONGARCH_LSX_OPT > 0
++PNG_INTERNAL_FUNCTION(void, png_init_filter_functions_lsx,
++    (png_structp png_ptr, unsigned int bpp), PNG_EMPTY);
++#endif
++
+ PNG_INTERNAL_FUNCTION(png_uint_32, png_check_keyword, (png_structrp png_ptr,
+    png_const_charp key, png_bytep new_key), PNG_EMPTY);
+ 
+diff --git old/qtbase/src/3rdparty/libpng/pngread.c new/qtbase/src/3rdparty/libpng/pngread.c
+index 8fa7d9f1628..008a41856b6 100644
+--- old/qtbase/src/3rdparty/libpng/pngread.c
++++ new/qtbase/src/3rdparty/libpng/pngread.c
+@@ -1,7 +1,7 @@
+ 
+ /* pngread.c - read a PNG file
+  *
+- * Copyright (c) 2018-2019 Cosmin Truta
++ * Copyright (c) 2018-2024 Cosmin Truta
+  * Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson
+  * Copyright (c) 1996-1997 Andreas Dilger
+  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
+@@ -568,7 +568,7 @@ png_read_row(png_structrp png_ptr, png_bytep row, png_bytep dsp_row)
+ #endif
+ 
+ #ifdef PNG_READ_TRANSFORMS_SUPPORTED
+-   if (png_ptr->transformations)
++   if (png_ptr->transformations || png_ptr->num_palette_max >= 0)
+       png_do_read_transformations(png_ptr, &row_info);
+ #endif
+ 
+@@ -785,7 +785,7 @@ png_read_end(png_structrp png_ptr, png_inforp info_ptr)
+ #ifdef PNG_READ_CHECK_FOR_INVALID_INDEX_SUPPORTED
+    /* Report invalid palette index; added at libng-1.5.10 */
+    if (png_ptr->color_type == PNG_COLOR_TYPE_PALETTE &&
+-       png_ptr->num_palette_max > png_ptr->num_palette)
++       png_ptr->num_palette_max >= png_ptr->num_palette)
+       png_benign_error(png_ptr, "Read palette index exceeding num_palette");
+ #endif
+ 
+@@ -1049,6 +1049,8 @@ void PNGAPI
+ png_read_png(png_structrp png_ptr, png_inforp info_ptr,
+     int transforms, voidp params)
+ {
++   png_debug(1, "in png_read_png");
++
+    if (png_ptr == NULL || info_ptr == NULL)
+       return;
+ 
+@@ -3452,7 +3454,6 @@ png_image_read_background(png_voidp argument)
+ 
+             for (pass = 0; pass < passes; ++pass)
+             {
+-               png_bytep row = png_voidcast(png_bytep, display->first_row);
+                unsigned int     startx, stepx, stepy;
+                png_uint_32      y;
+ 
+@@ -3557,8 +3558,6 @@ png_image_read_background(png_voidp argument)
+ 
+                         inrow += 2; /* gray and alpha channel */
+                      }
+-
+-                     row += display->row_bytes;
+                   }
+                }
+             }
+@@ -3765,13 +3764,13 @@ png_image_read_direct(png_voidp argument)
+          mode = PNG_ALPHA_PNG;
+          output_gamma = PNG_DEFAULT_sRGB;
+       }
+-      
++
+       if ((change & PNG_FORMAT_FLAG_ASSOCIATED_ALPHA) != 0)
+       {
+          mode = PNG_ALPHA_OPTIMIZED;
+          change &= ~PNG_FORMAT_FLAG_ASSOCIATED_ALPHA;
+       }
+-      
++
+       /* If 'do_local_background' is set check for the presence of gamma
+        * correction; this is part of the work-round for the libpng bug
+        * described above.
+diff --git old/qtbase/src/3rdparty/libpng/pngrtran.c new/qtbase/src/3rdparty/libpng/pngrtran.c
+index 9a8fad9f4aa..16474741aac 100644
+--- old/qtbase/src/3rdparty/libpng/pngrtran.c
++++ new/qtbase/src/3rdparty/libpng/pngrtran.c
+@@ -1,7 +1,7 @@
+ 
+ /* pngrtran.c - transforms the data in a row for PNG readers
+  *
+- * Copyright (c) 2018-2019 Cosmin Truta
++ * Copyright (c) 2018-2024 Cosmin Truta
+  * Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson
+  * Copyright (c) 1996-1997 Andreas Dilger
+  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
+@@ -21,7 +21,7 @@
+ #ifdef PNG_ARM_NEON_IMPLEMENTATION
+ #  if PNG_ARM_NEON_IMPLEMENTATION == 1
+ #    define PNG_ARM_NEON_INTRINSICS_AVAILABLE
+-#    if defined(_MSC_VER) && defined(_M_ARM64)
++#    if defined(_MSC_VER) && !defined(__clang__) && defined(_M_ARM64)
+ #      include <arm64_neon.h>
+ #    else
+ #      include <arm_neon.h>
+@@ -290,7 +290,7 @@ png_set_alpha_mode_fixed(png_structrp png_ptr, int mode,
+    int compose = 0;
+    png_fixed_point file_gamma;
+ 
+-   png_debug(1, "in png_set_alpha_mode");
++   png_debug(1, "in png_set_alpha_mode_fixed");
+ 
+    if (png_rtran_ok(png_ptr, 0) == 0)
+       return;
+@@ -970,7 +970,7 @@ void PNGFAPI
+ png_set_rgb_to_gray_fixed(png_structrp png_ptr, int error_action,
+     png_fixed_point red, png_fixed_point green)
+ {
+-   png_debug(1, "in png_set_rgb_to_gray");
++   png_debug(1, "in png_set_rgb_to_gray_fixed");
+ 
+    /* Need the IHDR here because of the check on color_type below. */
+    /* TODO: fix this */
+diff --git old/qtbase/src/3rdparty/libpng/pngrutil.c new/qtbase/src/3rdparty/libpng/pngrutil.c
+index 4db3de990bd..d31dc21dae8 100644
+--- old/qtbase/src/3rdparty/libpng/pngrutil.c
++++ new/qtbase/src/3rdparty/libpng/pngrutil.c
+@@ -1,7 +1,7 @@
+ 
+ /* pngrutil.c - utilities to read a PNG file
+  *
+- * Copyright (c) 2018 Cosmin Truta
++ * Copyright (c) 2018-2024 Cosmin Truta
+  * Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson
+  * Copyright (c) 1996-1997 Andreas Dilger
+  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
+@@ -26,7 +26,7 @@ png_get_uint_31(png_const_structrp png_ptr, png_const_bytep buf)
+    if (uval > PNG_UINT_31_MAX)
+       png_error(png_ptr, "PNG unsigned integer out of range");
+ 
+-   return (uval);
++   return uval;
+ }
+ 
+ #if defined(PNG_READ_gAMA_SUPPORTED) || defined(PNG_READ_cHRM_SUPPORTED)
+@@ -140,7 +140,7 @@ png_read_sig(png_structrp png_ptr, png_inforp info_ptr)
+    if (png_sig_cmp(info_ptr->signature, num_checked, num_to_check) != 0)
+    {
+       if (num_checked < 4 &&
+-          png_sig_cmp(info_ptr->signature, num_checked, num_to_check - 4))
++          png_sig_cmp(info_ptr->signature, num_checked, num_to_check - 4) != 0)
+          png_error(png_ptr, "Not a PNG file");
+       else
+          png_error(png_ptr, "PNG file corrupted by ASCII conversion");
+@@ -171,7 +171,7 @@ png_read_chunk_header(png_structrp png_ptr)
+    /* Put the chunk name into png_ptr->chunk_name. */
+    png_ptr->chunk_name = PNG_CHUNK_FROM_STRING(buf+4);
+ 
+-   png_debug2(0, "Reading %lx chunk, length = %lu",
++   png_debug2(0, "Reading chunk typeid = 0x%lx, length = %lu",
+        (unsigned long)png_ptr->chunk_name, (unsigned long)length);
+ 
+    /* Reset the crc and run it over the chunk name. */
+@@ -238,10 +238,10 @@ png_crc_finish(png_structrp png_ptr, png_uint_32 skip)
+       else
+          png_chunk_error(png_ptr, "CRC error");
+ 
+-      return (1);
++      return 1;
+    }
+ 
+-   return (0);
++   return 0;
+ }
+ 
+ /* Compare the CRC stored in the PNG file with that calculated by libpng from
+@@ -277,11 +277,11 @@ png_crc_error(png_structrp png_ptr)
+    if (need_crc != 0)
+    {
+       crc = png_get_uint_32(crc_bytes);
+-      return ((int)(crc != png_ptr->crc));
++      return crc != png_ptr->crc;
+    }
+ 
+    else
+-      return (0);
++      return 0;
+ }
+ 
+ #if defined(PNG_READ_iCCP_SUPPORTED) || defined(PNG_READ_iTXt_SUPPORTED) ||\
+@@ -301,7 +301,6 @@ png_read_buffer(png_structrp png_ptr, png_alloc_size_t new_size, int warn)
+ 
+    if (buffer != NULL && new_size > png_ptr->read_buffer_size)
+    {
+-      png_ptr->read_buffer = NULL;
+       png_ptr->read_buffer = NULL;
+       png_ptr->read_buffer_size = 0;
+       png_free(png_ptr, buffer);
+@@ -422,8 +421,7 @@ png_inflate_claim(png_structrp png_ptr, png_uint_32 owner)
+             png_ptr->flags |= PNG_FLAG_ZSTREAM_INITIALIZED;
+       }
+ 
+-#if ZLIB_VERNUM >= 0x1290 && \
+-   defined(PNG_SET_OPTION_SUPPORTED) && defined(PNG_IGNORE_ADLER32)
++#ifdef PNG_DISABLE_ADLER32_CHECK_SUPPORTED
+       if (((png_ptr->options >> PNG_IGNORE_ADLER32) & 3) == PNG_OPTION_ON)
+          /* Turn off validation of the ADLER32 checksum in IDAT chunks */
+          ret = inflateValidate(&png_ptr->zstream, 0);
+@@ -2076,14 +2074,17 @@ png_handle_eXIf(png_structrp png_ptr, png_inforp info_ptr, png_uint_32 length)
+       png_byte buf[1];
+       png_crc_read(png_ptr, buf, 1);
+       info_ptr->eXIf_buf[i] = buf[0];
+-      if (i == 1 && buf[0] != 'M' && buf[0] != 'I'
+-                 && info_ptr->eXIf_buf[0] != buf[0])
++      if (i == 1)
+       {
+-         png_crc_finish(png_ptr, length);
+-         png_chunk_benign_error(png_ptr, "incorrect byte-order specifier");
+-         png_free(png_ptr, info_ptr->eXIf_buf);
+-         info_ptr->eXIf_buf = NULL;
+-         return;
++         if ((buf[0] != 'M' && buf[0] != 'I') ||
++             (info_ptr->eXIf_buf[0] != buf[0]))
++         {
++            png_crc_finish(png_ptr, length - 2);
++            png_chunk_benign_error(png_ptr, "incorrect byte-order specifier");
++            png_free(png_ptr, info_ptr->eXIf_buf);
++            info_ptr->eXIf_buf = NULL;
++            return;
++         }
+       }
+    }
+ 
+@@ -2124,8 +2125,9 @@ png_handle_hIST(png_structrp png_ptr, png_inforp info_ptr, png_uint_32 length)
+ 
+    num = length / 2 ;
+ 
+-   if (num != (unsigned int) png_ptr->num_palette ||
+-       num > (unsigned int) PNG_MAX_PALETTE_LENGTH)
++   if (length != num * 2 ||
++       num != (unsigned int)png_ptr->num_palette ||
++       num > (unsigned int)PNG_MAX_PALETTE_LENGTH)
+    {
+       png_crc_finish(png_ptr, length);
+       png_chunk_benign_error(png_ptr, "invalid");
+@@ -3183,7 +3185,7 @@ png_check_chunk_length(png_const_structrp png_ptr, png_uint_32 length)
+    {
+       png_debug2(0," length = %lu, limit = %lu",
+          (unsigned long)length,(unsigned long)limit);
+-      png_chunk_error(png_ptr, "chunk data is too large");
++      png_benign_error(png_ptr, "chunk data is too large");
+    }
+ }
+ 
+@@ -4619,14 +4621,13 @@ defined(PNG_USER_TRANSFORM_PTR_SUPPORTED)
+        */
+       {
+          png_bytep temp = png_ptr->big_row_buf + 32;
+-         int extra = (int)((temp - (png_bytep)0) & 0x0f);
++         size_t extra = (size_t)temp & 0x0f;
+          png_ptr->row_buf = temp - extra - 1/*filter byte*/;
+ 
+          temp = png_ptr->big_prev_row + 32;
+-         extra = (int)((temp - (png_bytep)0) & 0x0f);
++         extra = (size_t)temp & 0x0f;
+          png_ptr->prev_row = temp - extra - 1/*filter byte*/;
+       }
+-
+ #else
+       /* Use 31 bytes of padding before and 17 bytes after row_buf. */
+       png_ptr->row_buf = png_ptr->big_row_buf + 31;
+diff --git old/qtbase/src/3rdparty/libpng/pngset.c new/qtbase/src/3rdparty/libpng/pngset.c
+index ec75dbe3690..eb1c8c7a35a 100644
+--- old/qtbase/src/3rdparty/libpng/pngset.c
++++ new/qtbase/src/3rdparty/libpng/pngset.c
+@@ -1,7 +1,7 @@
+ 
+ /* pngset.c - storage of image information into info struct
+  *
+- * Copyright (c) 2018 Cosmin Truta
++ * Copyright (c) 2018-2024 Cosmin Truta
+  * Copyright (c) 1998-2018 Glenn Randers-Pehrson
+  * Copyright (c) 1996-1997 Andreas Dilger
+  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
+@@ -137,46 +137,40 @@ png_set_cHRM_XYZ(png_const_structrp png_ptr, png_inforp info_ptr, double red_X,
+ #ifdef PNG_eXIf_SUPPORTED
+ void PNGAPI
+ png_set_eXIf(png_const_structrp png_ptr, png_inforp info_ptr,
+-    png_bytep eXIf_buf)
++    png_bytep exif)
+ {
+   png_warning(png_ptr, "png_set_eXIf does not work; use png_set_eXIf_1");
+   PNG_UNUSED(info_ptr)
+-  PNG_UNUSED(eXIf_buf)
++  PNG_UNUSED(exif)
+ }
+ 
+ void PNGAPI
+ png_set_eXIf_1(png_const_structrp png_ptr, png_inforp info_ptr,
+-    png_uint_32 num_exif, png_bytep eXIf_buf)
++    png_uint_32 num_exif, png_bytep exif)
+ {
+-   int i;
++   png_bytep new_exif;
+ 
+    png_debug1(1, "in %s storage function", "eXIf");
+ 
+-   if (png_ptr == NULL || info_ptr == NULL)
++   if (png_ptr == NULL || info_ptr == NULL ||
++       (png_ptr->mode & PNG_WROTE_eXIf) != 0)
+       return;
+ 
+-   if (info_ptr->exif)
+-   {
+-      png_free(png_ptr, info_ptr->exif);
+-      info_ptr->exif = NULL;
+-   }
+-
+-   info_ptr->num_exif = num_exif;
+-
+-   info_ptr->exif = png_voidcast(png_bytep, png_malloc_warn(png_ptr,
+-       info_ptr->num_exif));
++   new_exif = png_voidcast(png_bytep, png_malloc_warn(png_ptr, num_exif));
+ 
+-   if (info_ptr->exif == NULL)
++   if (new_exif == NULL)
+    {
+       png_warning(png_ptr, "Insufficient memory for eXIf chunk data");
+       return;
+    }
+ 
+-   info_ptr->free_me |= PNG_FREE_EXIF;
++   memcpy(new_exif, exif, (size_t)num_exif);
+ 
+-   for (i = 0; i < (int) info_ptr->num_exif; i++)
+-      info_ptr->exif[i] = eXIf_buf[i];
++   png_free_data(png_ptr, info_ptr, PNG_FREE_EXIF, 0);
+ 
++   info_ptr->num_exif = num_exif;
++   info_ptr->exif = new_exif;
++   info_ptr->free_me |= PNG_FREE_EXIF;
+    info_ptr->valid |= PNG_INFO_eXIf;
+ }
+ #endif /* eXIf */
+@@ -237,15 +231,13 @@ png_set_hIST(png_const_structrp png_ptr, png_inforp info_ptr,
+    if (info_ptr->hist == NULL)
+    {
+       png_warning(png_ptr, "Insufficient memory for hIST chunk data");
+-
+       return;
+    }
+ 
+-   info_ptr->free_me |= PNG_FREE_HIST;
+-
+    for (i = 0; i < info_ptr->num_palette; i++)
+       info_ptr->hist[i] = hist[i];
+ 
++   info_ptr->free_me |= PNG_FREE_HIST;
+    info_ptr->valid |= PNG_INFO_hIST;
+ }
+ #endif
+@@ -367,6 +359,8 @@ png_set_pCAL(png_const_structrp png_ptr, png_inforp info_ptr,
+ 
+    memcpy(info_ptr->pcal_purpose, purpose, length);
+ 
++   info_ptr->free_me |= PNG_FREE_PCAL;
++
+    png_debug(3, "storing X0, X1, type, and nparams in info");
+    info_ptr->pcal_X0 = X0;
+    info_ptr->pcal_X1 = X1;
+@@ -383,7 +377,6 @@ png_set_pCAL(png_const_structrp png_ptr, png_inforp info_ptr,
+    if (info_ptr->pcal_units == NULL)
+    {
+       png_warning(png_ptr, "Insufficient memory for pCAL units");
+-
+       return;
+    }
+ 
+@@ -395,7 +388,6 @@ png_set_pCAL(png_const_structrp png_ptr, png_inforp info_ptr,
+    if (info_ptr->pcal_params == NULL)
+    {
+       png_warning(png_ptr, "Insufficient memory for pCAL params");
+-
+       return;
+    }
+ 
+@@ -413,7 +405,6 @@ png_set_pCAL(png_const_structrp png_ptr, png_inforp info_ptr,
+       if (info_ptr->pcal_params[i] == NULL)
+       {
+          png_warning(png_ptr, "Insufficient memory for pCAL parameter");
+-
+          return;
+       }
+ 
+@@ -421,7 +412,6 @@ png_set_pCAL(png_const_structrp png_ptr, png_inforp info_ptr,
+    }
+ 
+    info_ptr->valid |= PNG_INFO_pCAL;
+-   info_ptr->free_me |= PNG_FREE_PCAL;
+ }
+ #endif
+ 
+@@ -478,18 +468,17 @@ png_set_sCAL_s(png_const_structrp png_ptr, png_inforp info_ptr,
+ 
+    if (info_ptr->scal_s_height == NULL)
+    {
+-      png_free (png_ptr, info_ptr->scal_s_width);
++      png_free(png_ptr, info_ptr->scal_s_width);
+       info_ptr->scal_s_width = NULL;
+ 
+       png_warning(png_ptr, "Memory allocation failed while processing sCAL");
+-
+       return;
+    }
+ 
+    memcpy(info_ptr->scal_s_height, sheight, lengthh);
+ 
+-   info_ptr->valid |= PNG_INFO_sCAL;
+    info_ptr->free_me |= PNG_FREE_SCAL;
++   info_ptr->valid |= PNG_INFO_sCAL;
+ }
+ 
+ #  ifdef PNG_FLOATING_POINT_SUPPORTED
+@@ -625,11 +614,10 @@ png_set_PLTE(png_structrp png_ptr, png_inforp info_ptr,
+    if (num_palette > 0)
+       memcpy(png_ptr->palette, palette, (unsigned int)num_palette *
+           (sizeof (png_color)));
++
+    info_ptr->palette = png_ptr->palette;
+    info_ptr->num_palette = png_ptr->num_palette = (png_uint_16)num_palette;
+-
+    info_ptr->free_me |= PNG_FREE_PLTE;
+-
+    info_ptr->valid |= PNG_INFO_PLTE;
+ }
+ 
+@@ -775,11 +763,11 @@ png_set_text_2(png_const_structrp png_ptr, png_inforp info_ptr,
+ {
+    int i;
+ 
+-   png_debug1(1, "in %lx storage function", png_ptr == NULL ? 0xabadca11U :
+-      (unsigned long)png_ptr->chunk_name);
++   png_debug1(1, "in text storage function, chunk typeid = 0x%lx",
++      png_ptr == NULL ? 0xabadca11UL : (unsigned long)png_ptr->chunk_name);
+ 
+    if (png_ptr == NULL || info_ptr == NULL || num_text <= 0 || text_ptr == NULL)
+-      return(0);
++      return 0;
+ 
+    /* Make sure we have enough space in the "text" array in info_struct
+     * to hold all of the incoming text_ptr objects.  This compare can't overflow
+@@ -959,7 +947,7 @@ png_set_text_2(png_const_structrp png_ptr, png_inforp info_ptr,
+       png_debug1(3, "transferred text chunk %d", info_ptr->num_text);
+    }
+ 
+-   return(0);
++   return 0;
+ }
+ #endif
+ 
+@@ -1019,6 +1007,9 @@ png_set_tRNS(png_structrp png_ptr, png_inforp info_ptr,
+           info_ptr->trans_alpha = png_voidcast(png_bytep,
+               png_malloc(png_ptr, PNG_MAX_PALETTE_LENGTH));
+           memcpy(info_ptr->trans_alpha, trans_alpha, (size_t)num_trans);
++
++          info_ptr->free_me |= PNG_FREE_TRNS;
++          info_ptr->valid |= PNG_INFO_tRNS;
+        }
+        png_ptr->trans_alpha = info_ptr->trans_alpha;
+    }
+@@ -1051,8 +1042,8 @@ png_set_tRNS(png_structrp png_ptr, png_inforp info_ptr,
+ 
+    if (num_trans != 0)
+    {
+-      info_ptr->valid |= PNG_INFO_tRNS;
+       info_ptr->free_me |= PNG_FREE_TRNS;
++      info_ptr->valid |= PNG_INFO_tRNS;
+    }
+ }
+ #endif
+@@ -1072,6 +1063,8 @@ png_set_sPLT(png_const_structrp png_ptr,
+ {
+    png_sPLT_tp np;
+ 
++   png_debug1(1, "in %s storage function", "sPLT");
++
+    if (png_ptr == NULL || info_ptr == NULL || nentries <= 0 || entries == NULL)
+       return;
+ 
+@@ -1086,11 +1079,11 @@ png_set_sPLT(png_const_structrp png_ptr,
+    {
+       /* Out of memory or too many chunks */
+       png_chunk_report(png_ptr, "too many sPLT chunks", PNG_CHUNK_WRITE_ERROR);
+-
+       return;
+    }
+ 
+    png_free(png_ptr, info_ptr->splt_palettes);
++
+    info_ptr->splt_palettes = np;
+    info_ptr->free_me |= PNG_FREE_SPLT;
+ 
+@@ -1244,11 +1237,11 @@ png_set_unknown_chunks(png_const_structrp png_ptr,
+    {
+       png_chunk_report(png_ptr, "too many unknown chunks",
+           PNG_CHUNK_WRITE_ERROR);
+-
+       return;
+    }
+ 
+    png_free(png_ptr, info_ptr->unknown_chunks);
++
+    info_ptr->unknown_chunks = np; /* safe because it is initialized */
+    info_ptr->free_me |= PNG_FREE_UNKN;
+ 
+@@ -1326,7 +1319,7 @@ png_set_unknown_chunk_location(png_const_structrp png_ptr, png_inforp info_ptr,
+ 
+ #ifdef PNG_MNG_FEATURES_SUPPORTED
+ png_uint_32 PNGAPI
+-png_permit_mng_features (png_structrp png_ptr, png_uint_32 mng_features)
++png_permit_mng_features(png_structrp png_ptr, png_uint_32 mng_features)
+ {
+    png_debug(1, "in png_permit_mng_features");
+ 
+@@ -1546,7 +1539,7 @@ void PNGAPI
+ png_set_rows(png_const_structrp png_ptr, png_inforp info_ptr,
+     png_bytepp row_pointers)
+ {
+-   png_debug1(1, "in %s storage function", "rows");
++   png_debug(1, "in png_set_rows");
+ 
+    if (png_ptr == NULL || info_ptr == NULL)
+       return;
+@@ -1565,6 +1558,8 @@ png_set_rows(png_const_structrp png_ptr, png_inforp info_ptr,
+ void PNGAPI
+ png_set_compression_buffer_size(png_structrp png_ptr, size_t size)
+ {
++   png_debug(1, "in png_set_compression_buffer_size");
++
+    if (png_ptr == NULL)
+       return;
+ 
+@@ -1633,9 +1628,11 @@ png_set_invalid(png_const_structrp png_ptr, png_inforp info_ptr, int mask)
+ #ifdef PNG_SET_USER_LIMITS_SUPPORTED
+ /* This function was added to libpng 1.2.6 */
+ void PNGAPI
+-png_set_user_limits (png_structrp png_ptr, png_uint_32 user_width_max,
++png_set_user_limits(png_structrp png_ptr, png_uint_32 user_width_max,
+     png_uint_32 user_height_max)
+ {
++   png_debug(1, "in png_set_user_limits");
++
+    /* Images with dimensions larger than these limits will be
+     * rejected by png_set_IHDR().  To accept any PNG datastream
+     * regardless of dimensions, set both limits to 0x7fffffff.
+@@ -1649,17 +1646,21 @@ png_set_user_limits (png_structrp png_ptr, png_uint_32 user_width_max,
+ 
+ /* This function was added to libpng 1.4.0 */
+ void PNGAPI
+-png_set_chunk_cache_max (png_structrp png_ptr, png_uint_32 user_chunk_cache_max)
++png_set_chunk_cache_max(png_structrp png_ptr, png_uint_32 user_chunk_cache_max)
+ {
++   png_debug(1, "in png_set_chunk_cache_max");
++
+    if (png_ptr != NULL)
+       png_ptr->user_chunk_cache_max = user_chunk_cache_max;
+ }
+ 
+ /* This function was added to libpng 1.4.1 */
+ void PNGAPI
+-png_set_chunk_malloc_max (png_structrp png_ptr,
++png_set_chunk_malloc_max(png_structrp png_ptr,
+     png_alloc_size_t user_chunk_malloc_max)
+ {
++   png_debug(1, "in png_set_chunk_malloc_max");
++
+    if (png_ptr != NULL)
+       png_ptr->user_chunk_malloc_max = user_chunk_malloc_max;
+ }
+diff --git old/qtbase/src/3rdparty/libpng/pngstruct.h new/qtbase/src/3rdparty/libpng/pngstruct.h
+index 8bdc7ce46db..e591d94d587 100644
+--- old/qtbase/src/3rdparty/libpng/pngstruct.h
++++ new/qtbase/src/3rdparty/libpng/pngstruct.h
+@@ -1,7 +1,7 @@
+ 
+ /* pngstruct.h - header file for PNG reference library
+  *
+- * Copyright (c) 2018-2019 Cosmin Truta
++ * Copyright (c) 2018-2022 Cosmin Truta
+  * Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson
+  * Copyright (c) 1996-1997 Andreas Dilger
+  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
+@@ -334,18 +334,8 @@ struct png_struct_def
+    size_t current_buffer_size;       /* amount of data now in current_buffer */
+    int process_mode;                 /* what push library is currently doing */
+    int cur_palette;                  /* current push library palette index */
+-
+ #endif /* PROGRESSIVE_READ */
+ 
+-#if defined(__TURBOC__) && !defined(_Windows) && !defined(__FLAT__)
+-/* For the Borland special 64K segment handler */
+-   png_bytepp offset_table_ptr;
+-   png_bytep offset_table;
+-   png_uint_16 offset_table_number;
+-   png_uint_16 offset_table_count;
+-   png_uint_16 offset_table_count_free;
+-#endif
+-
+ #ifdef PNG_READ_QUANTIZE_SUPPORTED
+    png_bytep palette_lookup; /* lookup table for quantizing */
+    png_bytep quantize_index; /* index translation for palette files */
+diff --git old/qtbase/src/3rdparty/libpng/pngtrans.c new/qtbase/src/3rdparty/libpng/pngtrans.c
+index 1100f46ebec..62cb21edf1f 100644
+--- old/qtbase/src/3rdparty/libpng/pngtrans.c
++++ new/qtbase/src/3rdparty/libpng/pngtrans.c
+@@ -1,7 +1,7 @@
+ 
+ /* pngtrans.c - transforms the data in a row (used by both readers and writers)
+  *
+- * Copyright (c) 2018 Cosmin Truta
++ * Copyright (c) 2018-2024 Cosmin Truta
+  * Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson
+  * Copyright (c) 1996-1997 Andreas Dilger
+  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
+@@ -103,10 +103,10 @@ png_set_interlace_handling(png_structrp png_ptr)
+    if (png_ptr != 0 && png_ptr->interlaced != 0)
+    {
+       png_ptr->transformations |= PNG_INTERLACE;
+-      return (7);
++      return 7;
+    }
+ 
+-   return (1);
++   return 1;
+ }
+ #endif
+ 
+@@ -498,6 +498,8 @@ png_do_strip_channel(png_row_infop row_info, png_bytep row, int at_start)
+    png_bytep dp = row; /* destination pointer */
+    png_bytep ep = row + row_info->rowbytes; /* One beyond end of row */
+ 
++   png_debug(1, "in png_do_strip_channel");
++
+    /* At the start sp will point to the first byte to copy and dp to where
+     * it is copied to.  ep always points just beyond the end of the row, so
+     * the loop simply copies (channels-1) channels until sp reaches ep.
+@@ -698,6 +700,8 @@ png_do_bgr(png_row_infop row_info, png_bytep row)
+ void /* PRIVATE */
+ png_do_check_palette_indexes(png_structrp png_ptr, png_row_infop row_info)
+ {
++   png_debug(1, "in png_do_check_palette_indexes");
++
+    if (png_ptr->num_palette < (1 << row_info->bit_depth) &&
+       png_ptr->num_palette > 0) /* num_palette can be 0 in MNG files */
+    {
+@@ -708,7 +712,7 @@ png_do_check_palette_indexes(png_structrp png_ptr, png_row_infop row_info)
+        * forms produced on either GCC or MSVC.
+        */
+       int padding = PNG_PADBITS(row_info->pixel_depth, row_info->width);
+-      png_bytep rp = png_ptr->row_buf + row_info->rowbytes - 1;
++      png_bytep rp = png_ptr->row_buf + row_info->rowbytes;
+ 
+       switch (row_info->bit_depth)
+       {
+@@ -833,7 +837,7 @@ png_voidp PNGAPI
+ png_get_user_transform_ptr(png_const_structrp png_ptr)
+ {
+    if (png_ptr == NULL)
+-      return (NULL);
++      return NULL;
+ 
+    return png_ptr->user_transform_ptr;
+ }
+diff --git old/qtbase/src/3rdparty/libpng/pngwrite.c new/qtbase/src/3rdparty/libpng/pngwrite.c
+index 59377a4ddea..77e412f43d5 100644
+--- old/qtbase/src/3rdparty/libpng/pngwrite.c
++++ new/qtbase/src/3rdparty/libpng/pngwrite.c
+@@ -1,7 +1,7 @@
+ 
+ /* pngwrite.c - general routines to write a PNG file
+  *
+- * Copyright (c) 2018-2019 Cosmin Truta
++ * Copyright (c) 2018-2024 Cosmin Truta
+  * Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson
+  * Copyright (c) 1996-1997 Andreas Dilger
+  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
+@@ -75,10 +75,10 @@ write_unknown_chunks(png_structrp png_ptr, png_const_inforp info_ptr,
+  * library.  If you have a new chunk to add, make a function to write it,
+  * and put it in the correct location here.  If you want the chunk written
+  * after the image data, put it in png_write_end().  I strongly encourage
+- * you to supply a PNG_INFO_ flag, and check info_ptr->valid before writing
+- * the chunk, as that will keep the code from breaking if you want to just
+- * write a plain PNG file.  If you have long comments, I suggest writing
+- * them in png_write_end(), and compressing them.
++ * you to supply a PNG_INFO_<chunk> flag, and check info_ptr->valid before
++ * writing the chunk, as that will keep the code from breaking if you want
++ * to just write a plain PNG file.  If you have long comments, I suggest
++ * writing them in png_write_end(), and compressing them.
+  */
+ void PNGAPI
+ png_write_info_before_PLTE(png_structrp png_ptr, png_const_inforp info_ptr)
+@@ -239,7 +239,10 @@ png_write_info(png_structrp png_ptr, png_const_inforp info_ptr)
+ 
+ #ifdef PNG_WRITE_eXIf_SUPPORTED
+    if ((info_ptr->valid & PNG_INFO_eXIf) != 0)
++   {
+       png_write_eXIf(png_ptr, info_ptr->exif, info_ptr->num_exif);
++      png_ptr->mode |= PNG_WROTE_eXIf;
++   }
+ #endif
+ 
+ #ifdef PNG_WRITE_hIST_SUPPORTED
+@@ -366,7 +369,8 @@ png_write_end(png_structrp png_ptr, png_inforp info_ptr)
+       png_error(png_ptr, "No IDATs written into file");
+ 
+ #ifdef PNG_WRITE_CHECK_FOR_INVALID_INDEX_SUPPORTED
+-   if (png_ptr->num_palette_max > png_ptr->num_palette)
++   if (png_ptr->color_type == PNG_COLOR_TYPE_PALETTE &&
++       png_ptr->num_palette_max >= png_ptr->num_palette)
+       png_benign_error(png_ptr, "Wrote palette index exceeding num_palette");
+ #endif
+ 
+@@ -439,8 +443,9 @@ png_write_end(png_structrp png_ptr, png_inforp info_ptr)
+ #endif
+ 
+ #ifdef PNG_WRITE_eXIf_SUPPORTED
+-   if ((info_ptr->valid & PNG_INFO_eXIf) != 0)
+-      png_write_eXIf(png_ptr, info_ptr->exif, info_ptr->num_exif);
++      if ((info_ptr->valid & PNG_INFO_eXIf) != 0 &&
++          (png_ptr->mode & PNG_WROTE_eXIf) == 0)
++         png_write_eXIf(png_ptr, info_ptr->exif, info_ptr->num_exif);
+ #endif
+ 
+ #ifdef PNG_WRITE_UNKNOWN_CHUNKS_SUPPORTED
+@@ -489,6 +494,16 @@ png_convert_from_time_t(png_timep ptime, time_t ttime)
+    png_debug(1, "in png_convert_from_time_t");
+ 
+    tbuf = gmtime(&ttime);
++   if (tbuf == NULL)
++   {
++      /* TODO: add a safe function which takes a png_ptr argument and raises
++       * a png_error if the ttime argument is invalid and the call to gmtime
++       * fails as a consequence.
++       */
++      memset(ptime, 0, sizeof(*ptime));
++      return;
++   }
++
+    png_convert_from_struct_tm(ptime, tbuf);
+ }
+ #endif
+@@ -700,12 +715,12 @@ png_write_row(png_structrp png_ptr, png_const_bytep row)
+    /* 1.5.6: moved from png_struct to be a local structure: */
+    png_row_info row_info;
+ 
+-   if (png_ptr == NULL)
+-      return;
+-
+    png_debug2(1, "in png_write_row (row %u, pass %d)",
+        png_ptr->row_number, png_ptr->pass);
+ 
++   if (png_ptr == NULL)
++      return;
++
+    /* Initialize transformations and other stuff if first time */
+    if (png_ptr->row_number == 0 && png_ptr->pass == 0)
+    {
+@@ -1196,6 +1211,8 @@ png_set_compression_strategy(png_structrp png_ptr, int strategy)
+ void PNGAPI
+ png_set_compression_window_bits(png_structrp png_ptr, int window_bits)
+ {
++   png_debug(1, "in png_set_compression_window_bits");
++
+    if (png_ptr == NULL)
+       return;
+ 
+@@ -1279,6 +1296,8 @@ png_set_text_compression_strategy(png_structrp png_ptr, int strategy)
+ void PNGAPI
+ png_set_text_compression_window_bits(png_structrp png_ptr, int window_bits)
+ {
++   png_debug(1, "in png_set_text_compression_window_bits");
++
+    if (png_ptr == NULL)
+       return;
+ 
+@@ -1316,6 +1335,8 @@ png_set_text_compression_method(png_structrp png_ptr, int method)
+ void PNGAPI
+ png_set_write_status_fn(png_structrp png_ptr, png_write_status_ptr write_row_fn)
+ {
++   png_debug(1, "in png_set_write_status_fn");
++
+    if (png_ptr == NULL)
+       return;
+ 
+@@ -1343,6 +1364,8 @@ void PNGAPI
+ png_write_png(png_structrp png_ptr, png_inforp info_ptr,
+     int transforms, voidp params)
+ {
++   png_debug(1, "in png_write_png");
++
+    if (png_ptr == NULL || info_ptr == NULL)
+       return;
+ 
+diff --git old/qtbase/src/3rdparty/libpng/pngwutil.c new/qtbase/src/3rdparty/libpng/pngwutil.c
+index 16345e4c0ba..14cc4ce367f 100644
+--- old/qtbase/src/3rdparty/libpng/pngwutil.c
++++ new/qtbase/src/3rdparty/libpng/pngwutil.c
+@@ -1,7 +1,7 @@
+ 
+ /* pngwutil.c - utilities to write a PNG file
+  *
+- * Copyright (c) 2018 Cosmin Truta
++ * Copyright (c) 2018-2024 Cosmin Truta
+  * Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson
+  * Copyright (c) 1996-1997 Andreas Dilger
+  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
+@@ -1747,7 +1747,7 @@ png_write_pCAL(png_structrp png_ptr, png_charp purpose, png_int_32 X0,
+ {
+    png_uint_32 purpose_len;
+    size_t units_len, total_len;
+-   png_size_tp params_len;
++   size_t *params_len;
+    png_byte buf[10];
+    png_byte new_purpose[80];
+    int i;
+@@ -1769,7 +1769,7 @@ png_write_pCAL(png_structrp png_ptr, png_charp purpose, png_int_32 X0,
+    png_debug1(3, "pCAL units length = %d", (int)units_len);
+    total_len = purpose_len + units_len + 10;
+ 
+-   params_len = (png_size_tp)png_malloc(png_ptr,
++   params_len = (size_t *)png_malloc(png_ptr,
+        (png_alloc_size_t)((png_alloc_size_t)nparams * (sizeof (size_t))));
+ 
+    /* Find the length of each parameter, making sure we don't count the
+@@ -2311,7 +2311,7 @@ png_setup_sub_row(png_structrp png_ptr, png_uint_32 bpp,
+         break;
+    }
+ 
+-   return (sum);
++   return sum;
+ }
+ 
+ static void /* PRIVATE */
+@@ -2361,7 +2361,7 @@ png_setup_up_row(png_structrp png_ptr, size_t row_bytes, size_t lmins)
+         break;
+    }
+ 
+-   return (sum);
++   return sum;
+ }
+ static void /* PRIVATE */
+ png_setup_up_row_only(png_structrp png_ptr, size_t row_bytes)
+@@ -2417,7 +2417,7 @@ png_setup_avg_row(png_structrp png_ptr, png_uint_32 bpp,
+         break;
+    }
+ 
+-   return (sum);
++   return sum;
+ }
+ static void /* PRIVATE */
+ png_setup_avg_row_only(png_structrp png_ptr, png_uint_32 bpp,
+@@ -2500,7 +2500,7 @@ png_setup_paeth_row(png_structrp png_ptr, png_uint_32 bpp,
+         break;
+    }
+ 
+-   return (sum);
++   return sum;
+ }
+ static void /* PRIVATE */
+ png_setup_paeth_row_only(png_structrp png_ptr, png_uint_32 bpp,
+diff --git old/qtbase/src/3rdparty/libpng/qt_attribution.json new/qtbase/src/3rdparty/libpng/qt_attribution.json
+index 612aa67791f..3d0df998833 100644
+--- old/qtbase/src/3rdparty/libpng/qt_attribution.json
++++ new/qtbase/src/3rdparty/libpng/qt_attribution.json
+@@ -6,21 +6,24 @@
+ 
+     "Description": "libpng is the official PNG reference library.",
+     "Homepage": "http://www.libpng.org/pub/png/libpng.html",
+-    "Version": "1.6.37",
++    "Version": "1.6.41",
++    "DownloadLocation": "https://download.sourceforge.net/libpng/libpng-1.6.41.tar.xz",
+     "License": "libpng License and PNG Reference Library version 2",
+     "LicenseId": "Libpng AND libpng-2.0",
+     "LicenseFile": "LICENSE",
+-    "Copyright": "Copyright (c) 1998-2018 Glenn Randers-Pehrson
++    "Copyright": "Copyright (c) 1995-2024 The PNG Reference Library Authors
++Copyright (c) 2000-2024 Cosmin Truta
++Copyright (c) 1998-2018 Glenn Randers-Pehrson
++Copyright (c) 1996-1997 Andreas Dilger
++Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
+ Copyright (c) 2000-2017 Simon-Pierre Cadieux
+ Copyright (c) 2000-2017 Eric S. Raymond
+ Copyright (c) 2000-2017 Mans Rullgard
+-Copyright (c) 2000-2019 Cosmin Truta
+ Copyright (c) 2000-2017 Gilles Vollant
+ Copyright (c) 2000-2017 James Yu
+ Copyright (c) 2000-2017 Mandar Sahastrabuddhe
+ Copyright (c) 1998-2000 Tom Lane
+ Copyright (c) 1998-2000 Willem van Schaik
+-Copyright (c) 1996-1997 Andreas Dilger
+ Copyright (c) 1996-1997 John Bowler
+ Copyright (c) 1996-1997 Kevin Bracey
+ Copyright (c) 1996-1997 Sam Bushell
+@@ -29,6 +32,5 @@ Copyright (c) 1996-1997 Greg Roelofs
+ Copyright (c) 1996-1997 Tom Tanner
+ Copyright (c) 1995-1996 Dave Martindale
+ Copyright (c) 1995-1996 Paul Schmidt
+-Copyright (c) 1995-1996 Tim Wegner
+-Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc."
++Copyright (c) 1995-1996 Tim Wegner"
+ }
+diff --git old/qtbase/src/3rdparty/libpng/qtpatches.diff new/qtbase/src/3rdparty/libpng/qtpatches.diff
+deleted file mode 100644
+index 272532cdd86..00000000000
+--- old/qtbase/src/3rdparty/libpng/qtpatches.diff
++++ /dev/null
+@@ -1,65 +0,0 @@
+-diff --git a/src/3rdparty/libpng/pngpriv.h b/src/3rdparty/libpng/pngpriv.h
+-index 583c26f9bd..2ab9b70d73 100644
+---- a/src/3rdparty/libpng/pngpriv.h
+-+++ b/src/3rdparty/libpng/pngpriv.h
+-@@ -23,6 +23,12 @@
+- #ifndef PNGPRIV_H
+- #define PNGPRIV_H
+- 
+-+#ifdef _MSC_VER
+-+#  ifndef _CRT_SECURE_NO_DEPRECATE
+-+#    define _CRT_SECURE_NO_DEPRECATE
+-+#  endif
+-+#endif
+-+
+- /* Feature Test Macros.  The following are defined here to ensure that correctly
+-  * implemented libraries reveal the APIs libpng needs to build and hide those
+-  * that are not needed and potentially damaging to the compilation.
+-@@ -308,6 +314,11 @@
+- #  endif
+- #endif /* Setting PNG_BUILD_DLL if required */
+- 
+-+/* Modfied for usage in Qt: Do not export the libpng APIs */
+-+#ifdef PNG_BUILD_DLL
+-+#undef PNG_BUILD_DLL
+-+#endif
+-+
+- /* See pngconf.h for more details: the builder of the library may set this on
+-  * the command line to the right thing for the specific compilation system or it
+-  * may be automagically set above (at present we know of no system where it does
+-@@ -546,6 +557,9 @@
+- #if defined(WIN32) || defined(_Windows) || defined(_WINDOWS) || \
+-     defined(_WIN32) || defined(__WIN32__)
+- #  include <windows.h>  /* defines _WINDOWS_ macro */
+-+#  if defined(WINAPI_FAMILY) && (WINAPI_FAMILY==WINAPI_FAMILY_APP || WINAPI_FAMILY==WINAPI_FAMILY_PHONE_APP)
+-+#    define _WINRT_ /* Define a macro for Windows Runtime builds */
+-+#  endif
+- #endif
+- #endif /* PNG_VERSION_INFO_ONLY */
+- 
+-@@ -556,7 +570,7 @@
+- 
+- /* Memory model/platform independent fns */
+- #ifndef PNG_ABORT
+--#  ifdef _WINDOWS_
+-+#  if (defined(_WINDOWS_) || defined(_WIN32_WCE)) && !defined(_WINRT_)
+- #    define PNG_ABORT() ExitProcess(0)
+- #  else
+- #    define PNG_ABORT() abort()
+-diff --git a/src/3rdparty/libpng/pngrutil.c b/src/3rdparty/libpng/pngrutil.c
+-index d5fa08c397..4db3de990b 100644
+---- a/src/3rdparty/libpng/pngrutil.c
+-+++ b/src/3rdparty/libpng/pngrutil.c
+-@@ -2087,10 +2087,8 @@ png_handle_eXIf(png_structrp png_ptr, png_inforp info_ptr, png_uint_32 length)
+-       }
+-    }
+- 
+--   if (png_crc_finish(png_ptr, 0) != 0)
+--      return;
+--
+--   png_set_eXIf_1(png_ptr, info_ptr, length, info_ptr->eXIf_buf);
+-+   if (png_crc_finish(png_ptr, 0) == 0)
+-+      png_set_eXIf_1(png_ptr, info_ptr, length, info_ptr->eXIf_buf);
+- 
+-    png_free(png_ptr, info_ptr->eXIf_buf);
+-    info_ptr->eXIf_buf = NULL;

--- a/src/fixed.h
+++ b/src/fixed.h
@@ -57,6 +57,7 @@ namespace detail {
 		static const bool           is_specialized = true;
 		static const std::size_t    size = 128;
 		typedef __int128            value_type;
+		typedef unsigned __int128   unsigned_type;
 		typedef type_from_size<128> next_size;
 	};
 #endif
@@ -67,6 +68,7 @@ namespace detail {
 		static const bool           is_specialized = true;
 		static const std::size_t    size = 64;
 		typedef int64_t             value_type;
+		typedef uint64_t            unsigned_type;
 		typedef type_from_size<128> next_size;
 	};
 
@@ -75,6 +77,7 @@ namespace detail {
 		static const bool          is_specialized = true;
 		static const std::size_t   size = 32;
 		typedef int32_t            value_type;
+		typedef uint32_t		   unsigned_type;
 		typedef type_from_size<64> next_size;
 	};
 
@@ -83,6 +86,7 @@ namespace detail {
 		static const bool          is_specialized = true;
 		static const std::size_t   size = 16;
 		typedef int16_t            value_type;
+		typedef uint16_t          unsigned_type;
 		typedef type_from_size<32> next_size;
 	};
 
@@ -91,6 +95,7 @@ namespace detail {
 		static const bool          is_specialized = true;
 		static const std::size_t   size = 8;
 		typedef int8_t             value_type;
+		typedef uint8_t            unsigned_type;
 		typedef type_from_size<16> next_size;
 	};
 
@@ -250,7 +255,7 @@ public:
 
 public:
 	static const std::size_t base_size     = base_type_info::size;
-	static const base_type fractional_mask = ~((~base_type(0)) << fractional_bits);
+	static const base_type fractional_mask = ~(static_cast<typename base_type_info::unsigned_type>(~base_type(0)) << fractional_bits);
 	static const base_type integer_mask    = ~fractional_mask;
 
 public:


### PR DESCRIPTION
## PR intention
Fixed compilation issues on the most recent Sequoia 15.5

## Code changes brief
Updated `libpng` version in `qt` dependency, fixed compilation error in `fixed.h` file
