### PR TITLE
Change dumpfiroviewkey to use a hex string

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -592,8 +592,17 @@ UniValue dumpsparkviewkey(const JSONRPCRequest& request) {
         throw std::runtime_error("wallet not available");
     }
 
-    if (request.fHelp || request.params.size() != 0)
-        throw std::runtime_error("dumpviewkey\n\nDisplay our Spark View Key.\n");
+    if (request.fHelp || request.params.size() != 0)  {
+        throw std::runtime_error(
+            "dumpsparkviewkey\n"
+            "\nDisplay our Spark View Key.\n"
+            "\nResult:\n"
+            "\"key\"                (string) The Spark view key\n"
+            "\nExamples:\n"
+            + HelpExampleCli("dumpsparkviewkey", "")
+            + HelpExampleRpc("dumpsparkviewkey", "")
+        );
+    }
 
   return {pwallet->GetSparkViewKeyStr()};
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -6888,16 +6888,9 @@ std::string CWallet::GetSparkViewKeyStr() {
   std::ostringstream keydata;
   ::Serialize(keydata, key);
 
-  std::string keydata_s = keydata.str();
-  assert(keydata_s.size() % 4 == 0);
+  std::string keydata_hex = HexStr(keydata.str());
 
-  SecureVector seckeydata(keydata_s.begin(), keydata_s.end());
-
-  SecureString mnemonicsecstr = Mnemonic::mnemonic_from_data(seckeydata, seckeydata.size());
-  std::string mnemonicstr(mnemonicsecstr.begin(), mnemonicsecstr.end());
-  assert(!mnemonicstr.empty());
-
-  return mnemonicstr;
+  return keydata_hex;
 }
 
 bool CWallet::UpdatedTransaction(const uint256 &hashTx)


### PR DESCRIPTION
Stack Wallet uses hex strings for their other view keys, so this is changed here to give consistency with that. There is nowhere that accepts the old format so it shouldn't break anything.