### PR TITLE
Fix: restore Spark name button visibility after request payment

### DIFF
--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -138,7 +138,7 @@ void ReceiveCoinsDialog::clear()
     ui->reqLabel->setText("");
     ui->reqMessage->setText("");
     ui->reuseAddress->setChecked(false);
-    ui->createSparkNameButton->setVisible(false);
+    displayCheckBox(ui->addressTypeCombobox->currentIndex());
     updateDisplayUnit();
 }
 


### PR DESCRIPTION
fix #1537