### PR TITLE
CI: migrate workflows to checkout v5

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Install Required Packages
       run: |
         sudo apt-get update
@@ -56,7 +56,7 @@ jobs:
       with:
         python-version: '3.8'
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Install Required Packages
       run: |
         sudo apt-get update
@@ -239,7 +239,7 @@ jobs:
       ARTIFACT_DIR: windows-cmake-binaries
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Install Required Packages
       run: |
         sudo apt-get update
@@ -274,7 +274,7 @@ jobs:
       ARTIFACT_DIR: mac-cmake-binaries
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Use Xcode instead of Command Line Tools
       run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
     - name: Set NJOBS variable

--- a/.github/workflows/test-dockerfile.yml
+++ b/.github/workflows/test-dockerfile.yml
@@ -14,7 +14,7 @@ jobs:
    runs-on: ubuntu-latest
   
    steps:
-     - uses: actions/checkout@v4
+     - uses: actions/checkout@v5
      - name: Build Docker image 
        run: docker build -t firo .
 


### PR DESCRIPTION
Maintenance update to actions/checkout@v5 to align with the current runner stack (Node 24); nothing else modified.

Release notes: https://github.com/actions/checkout/releases/tag/v5.0.0