### PR TITLE
chore: Remove unused includes from aes.cpp

### DIFF
--- a/src/crypto/aes.cpp
+++ b/src/crypto/aes.cpp
@@ -3,9 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "aes.h"
-#include "crypto/common.h"
-
-#include <assert.h>
 #include <string.h>
 
 extern "C" {


### PR DESCRIPTION
Drop unnecessary includes crypto/common.h and assert.h from src/crypto/aes.cpp.