### PR TITLE
prevent tor linking to cap and seccomp

### DIFF
--- a/depends/packages/tor.mk
+++ b/depends/packages/tor.mk
@@ -50,7 +50,7 @@ $(package)_lib_files = \
     src/ext/keccak-tiny/libkeccak-tiny.a
 
 define $(package)_set_vars
-  $(package)_config_opts+=--disable-system-torrc --disable-systemd --disable-lzma --disable-asciidoc --disable-libscrypt --disable-gcc-hardening --enable-pic --disable-unittests --disable-tool-name-check
+  $(package)_config_opts+=--disable-system-torrc --disable-systemd --disable-lzma --disable-asciidoc --disable-libscrypt --disable-gcc-hardening --enable-pic --disable-unittests --disable-tool-name-check --disable-seccomp ac_cv_header_sys_capability_h=no ac_cv_lib_cap_cap_init=no ac_cv_func_cap_set_proc=no
   $(package)_cflags+=-std=gnu11 -fPIC
 endef
 


### PR DESCRIPTION
## PR intention
In some distros, tor automatically founds `seccomp` and `cap` libraries from system libraries. That breaks our sandbox when building. 