### PR TITLE
fix segfault caused by wrong locking

### DIFF
--- a/src/qt/automintdialog.cpp
+++ b/src/qt/automintdialog.cpp
@@ -105,8 +105,6 @@ void AutoMintSparkDialog::reject()
 
 void AutoMintSparkDialog::setModel(WalletModel *model)
 {
-    LOCK(sparkModel->cs);
-
     this->model = model;
     if (!this->model) {
         return;
@@ -117,7 +115,7 @@ void AutoMintSparkDialog::setModel(WalletModel *model)
         return;
     }
 
-    CCriticalSectionLocker criticalLocker(sparkModel->cs);
+    ENTER_CRITICAL_SECTION(sparkModel->cs);
 
     if (this->model->getEncryptionStatus() != WalletModel::Locked) {
         ui->passLabel->setVisible(false);

--- a/src/qt/automintdialog.h
+++ b/src/qt/automintdialog.h
@@ -11,17 +11,6 @@ namespace Ui {
     class AutoMintDialog;
 }
 
-class CCriticalSectionLocker {
-public:
-    explicit CCriticalSectionLocker(CCriticalSection& mutex) : m_mutex(mutex) { ENTER_CRITICAL_SECTION(m_mutex); }
-    ~CCriticalSectionLocker()   { LEAVE_CRITICAL_SECTION(m_mutex); }
-    CCriticalSectionLocker(const CCriticalSectionLocker&) = delete;
-    CCriticalSectionLocker& operator=(const CCriticalSectionLocker&) = delete;
-
-private:
-    CCriticalSection& m_mutex;
-};
-
 enum class AutoMintSparkMode : uint8_t {
     MintAll, // come from overview page
     AutoMintAll // come from notification


### PR DESCRIPTION
## PR intention
Fix the seg fault caused by locking. 

This bug was unintentionally added to the repo via https://github.com/firoorg/firo/pull/1618 

This is where the code has been added:

<img width="2100" height="1917" alt="image" src="https://github.com/user-attachments/assets/e81e8382-1e50-4c52-b398-95ed2c284e48" />

The unlocking happens in the destructor:

<img width="1595" height="884" alt="image" src="https://github.com/user-attachments/assets/a6e9d7dc-a84a-427b-910f-195594799953" />

I am reverting this to the original ( to https://github.com/firoorg/firo/blob/a187afa8e1044932c5b69a174bc35a65b101e4c4/src/qt/automintdialog.cpp#L106 ): 

<img width="1645" height="1279" alt="image" src="https://github.com/user-attachments/assets/da537a8b-75ba-45fb-8fcb-d37f64c3e538" />

