### PR TITLE
switch to glibc-2.31

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -102,7 +102,7 @@ chain for " target " development."))
                                        #:key
                                        (base-gcc-for-libc linux-base-gcc)
                                        (base-kernel-headers base-linux-kernel-headers)
-                                       (base-libc glibc-2.32)
+                                       (base-libc glibc-2.31)
                                        (base-gcc linux-base-gcc))
   "Convenience wrapper around MAKE-CROSS-TOOLCHAIN with default values
 desirable for building Bitcoin Core release binaries."
@@ -194,20 +194,20 @@ chain for " target " development."))
                  (("-rpath=") "-rpath-link="))
                #t))))))))
 
-(define-public glibc-2.32
-  (let ((commit "3de512be7ea6053255afed6154db9ee31d4e557a"))
+(define-public glibc-2.31
+  (let ((commit "7b27c450c34563a28e634cccb399cd415e71ebfe"))
   (package
-    (inherit glibc) ;; 2.32
-    (version "2.32")
+    (inherit glibc) ;; 2.35
+    (version "2.31")
     (source (origin
               (method git-fetch)
               (uri (git-reference
-                    (url "https://github.com/bminor/glibc")
+                    (url "https://sourceware.org/git/glibc.git")
                     (commit commit)))
               (file-name (git-file-name "glibc" commit))
               (sha256
                (base32
-                "1175qgpbmfh3hl435p4myamncnbvvv69r3xann823hrmrhc31bc0"))
+                "017qdpr5id7ddb4lpkzj2li1abvw916m3fc6n7nw28z4h5qbv2n0"))
               (patches (search-our-patches "glibc-guix-prefix.patch"))))
     (arguments
       (substitute-keyword-arguments (package-arguments glibc)
@@ -227,14 +227,13 @@ chain for " target " development."))
              (lambda* (#:key outputs #:allow-other-keys)
                ;; Install the rpc data base file under `$out/etc/rpc'.
                ;; Otherwise build will fail with "Permission denied."
-               ;; Can be removed when we are building 2.32 or later.
+               ;; Can be removed when we are building 2.31 or later.
                (let ((out (assoc-ref outputs "out")))
                  (substitute* "sunrpc/Makefile"
                    (("^\\$\\(inst_sysconfdir\\)/rpc(.*)$" _ suffix)
                     (string-append out "/etc/rpc" suffix "\n"))
                    (("^install-others =.*$")
                     (string-append "install-others = " out "/etc/rpc\n")))))))))))))
-
 
 (packages->manifest
  (append


### PR DESCRIPTION
## PR intention

This was the first reason to switch to glibc-2.32 [1]. But this appears this switch was a mistake. If you compile depends with the correct glibc (2.31), everything works. 

1. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100140

Tested on Ubuntu 20.04 and 24.04