### PR TITLE
docs: update copyright year in LICENSE

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2016-2025 The Firo Core developers
-Copyright (c) 2009-2025 The Bitcoin Core developers
+Copyright (c) 2016-2026 The Firo Core developers
+Copyright (c) 2009-2026 The Bitcoin Core developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updates the copyright year from 2025 to 2026.

Keeping license files current for the new year.