### PR TITLE
Fix crashes when anonymizing Spark

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -416,7 +416,7 @@ void SendCoinsDialog::on_sendButton_clicked()
     QString warningMessage;
 
     for(int i = 0; i < recipients.size(); ++i) {
-        warningMessage = entry->generateWarningText(recipients[i].address, fAnonymousMode);
+        warningMessage = SendCoinsEntry::generateWarningText(recipients[i].address, fAnonymousMode);
         if ((model->validateSparkAddress(recipients[i].address)) || (recipients[i].address.startsWith("EX"))) {
             break;
         }
@@ -688,8 +688,16 @@ void SendCoinsDialog::on_sendButton_clicked()
 void SendCoinsDialog::on_switchFundButton_clicked()
 {
     setAnonymizeMode(!fAnonymousMode);
-    entry->setfAnonymousMode(fAnonymousMode);
-    entry->setWarning(fAnonymousMode);
+    // Update all entries with the new anonymous mode setting
+    for(int i = 0; i < ui->entries->count(); ++i)
+    {
+        SendCoinsEntry *entryWidget = qobject_cast<SendCoinsEntry*>(ui->entries->itemAt(i)->widget());
+        if(entryWidget)
+        {
+            entryWidget->setfAnonymousMode(fAnonymousMode);
+            entryWidget->setWarning(fAnonymousMode);
+        }
+    }
     coinControlUpdateLabels();
 }
 

--- a/src/qt/sparkmodel.cpp
+++ b/src/qt/sparkmodel.cpp
@@ -103,7 +103,7 @@ CAmount SparkModel::mintSparkAll()
             } catch (std::invalid_argument&) {
                 ok = false;
             }
-            if (ok) {
+            if (ok && pwalletMain && pwalletMain->sparkWallet) {
                 CSparkMintMeta mintMeta;
                 coin.setSerialContext(spark::getSerialContext(* wtx.first.tx));
                 if (pwalletMain->sparkWallet->getMintMeta(coin, mintMeta)) {

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -182,7 +182,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
                     } catch (std::invalid_argument&) {
                         ok = false;
                     }
-                    if (ok) {
+                    if (ok && pwalletMain && pwalletMain->sparkWallet) {
                         coin.setSerialContext(spark::getSerialContext(*wtx.tx));
                         spark::Address addr = pwalletMain->sparkWallet->getMyCoinAddress(coin);
                         unsigned char network = spark::GetNetworkType();

--- a/src/qt/walletmodeltransaction.cpp
+++ b/src/qt/walletmodeltransaction.cpp
@@ -65,7 +65,7 @@ void WalletModelTransaction::reassignAmounts(int nChangePosRet)
                     ok = false;
                 }
 
-                if (ok) {
+                if (ok && pwalletMain && pwalletMain->sparkWallet) {
                     CSparkMintMeta mintMeta;
                     coin.setSerialContext(spark::getSerialContext(* walletTransaction->tx));
                     if (pwalletMain->sparkWallet->getMintMeta(coin, mintMeta)) {

--- a/src/spark/sparkwallet.cpp
+++ b/src/spark/sparkwallet.cpp
@@ -1203,7 +1203,10 @@ bool CSparkWallet::CreateSparkMintTransactions(
 
                 {
                     CValidationState state;
-                    if (!mempool.IsTransactionAllowed(*wtx.tx, state)) {
+                    // Use txNewConst (the actual signed transaction) instead of wtx.tx
+                    // which still points to an empty/uninitialized transaction at this point.
+                    // Using wtx.tx here would cause EXCEPTION_ACCESS_VIOLATION crash.
+                    if (!mempool.IsTransactionAllowed(txNewConst, state)) {
                         strFailReason = _("Signing transaction failed");
                         return false;
                     }


### PR DESCRIPTION
Wallet crashes at times when clicking on Anonymize All or when sending transparent balance to a Spark Address that you own.

## PR intention
DeleteMe: Mandatory: What this PR is intended to do, what change it introduces, what issue it solves.

## Complete Summary of All Bugs Fixed

Critical Bug (from PR #1734): Uninitialized Transaction in sparkwallet.cpp
**Location:** src/spark/sparkwallet.cpp, line 1206
**Problem:** The code was calling mempool.IsTransactionAllowed(*wtx.tx, state) where wtx.tx was still pointing to an empty/uninitialized transaction. The actual signed transaction (txNewConst) was created at line 1186, but wtx.tx is only set at line 1212 (AFTER the mempool check).
Root Cause: When mempool.IsTransactionAllowed() tried to access fields of the empty transaction, it caused EXCEPTION_ACCESS_VIOLATION.
Fix: Changed to use txNewConst (the actual signed transaction) instead of *wtx.tx.

<!--StartFragment--><section id="markdown-section-99780ea9-f8c0-4f90-b1d2-034a60f2ccc3-2" class="markdown-section chat-fade-in" data-markdown-raw="

### **Critical Null Pointer Bugs in `wallet.cpp`:**" data-section-index="2" style="border-radius: 4px; line-height: 19.5px; margin: 6px 0px; position: relative; scroll-margin-bottom: 40px; scroll-margin-top: 40px; color: rgba(228, 228, 228, 0.92); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h3 style="animation: 0.25s ease 0s 1 normal none running fade-in; font-weight: 600 !important; font-size: 1.15em; line-height: 1.25; margin-bottom: 8px; margin-top: 18px;"><span class="markdown-bold-text" style="animation: 0.25s ease 0s 1 normal none running fade-in; font-weight: 600;"><span style="animation: 0.25s ease 0s 1 normal none running fade-in;">Critical</span><span style="animation: 0.25s ease 0s 1 normal none running fade-in;"><span> </span>Null</span><span style="animation: 0.25s ease 0s 1 normal none running fade-in;"><span> </span>Pointer Bugs in</span><span style="animation: 0.25s ease 0s 1 normal none running fade-in;"><span> </span></span><span class="markdown-inline-code leading-[1.4]" style="animation: 0.25s ease 0s 1 normal none running fade-in; line-height: 1.4; background-color: color(srgb 0.199297 0.199297 0.199297 / 0.393725); border-radius: 4px; color: inherit; font-family: Consolas, &quot;Courier New&quot;, monospace, Menlo, Monaco, &quot;Courier New&quot;, monospace; font-size: 0.9em; padding: 1.5px 3px; transition: 0.1s; word-break: break-all; cursor: default;"><span style="animation: 0.25s ease 0s 1 normal none running fade-in;">wallet</span><span style="animation: 0.25s ease 0s 1 normal none running fade-in;">.cpp</span></span><span style="animation: 0.25s ease 0s 1 normal none running fade-in;">:</span></span></h3></section><div class="monaco-scrollable-element markdown-table-container is-scrollable-right" role="presentation" style="scrollbar-width: none; overflow: hidden; color: rgba(228, 228, 228, 0.92); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; position: relative; margin: 1em 0px; width: fit-content; max-width: 100%; border-color: color(srgb 0.894118 0.894118 0.894118 / 0.0737255); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; border-radius: 6px;"><div class="markdown-table-wrapper" style="--fade-start: rgba(0,0,0,.25); --fade-end: #000; --markdown-table-fade-width: 10px; mask-image: linear-gradient(to right, rgb(0, 0, 0) calc(100% - 10px), rgba(0, 0, 0, 0.25) 100%); --mask: linear-gradient(to right,#000 calc(100% - 10px),rgba(0,0,0,.25) 100%); overflow: hidden;">
Location | Issue | Fix
-- | -- | --
Line 7168 | CWallet::CreateSparkMintTransactions accessed sparkWallet-> without null check | Added null check with error return
Lines 4886, 4902 | CreateSparkSpendTransaction and CreateSparkNameTransaction called EnsureMintWalletAvailable() instead of EnsureSparkWalletAvailable() | Changed to call the correct function
Line 1839 | GetChange() accessed sparkWallet->getMyCoinV() without null check | Added null check
Line 1496 | AbandonSpends() called on potentially null sparkWallet | Added null check
Line 1520 | AbandonSparkMints() called on potentially null sparkWallet | Added null check
Line 2718 | getMyCoinIsChange() called on potentially null sparkWallet | Added null check

</div><div role="presentation" aria-hidden="true" class="invisible scrollbar horizontal fade" style="opacity: 0; pointer-events: none; transition: opacity 0.8s linear; position: absolute; width: 800px; height: 10px; left: 0px; bottom: 0px;"><div class="slider" style="background: none 0% 0% / auto repeat scroll padding-box border-box rgba(228, 228, 228, 0.07); position: absolute; top: 0px; left: 0px; height: 10px; transform: translate3d(0px, 0px, 0px); contain: strict; width: 507px;"></div></div><div role="presentation" aria-hidden="true" class="invisible scrollbar vertical" style="opacity: 0; pointer-events: none; position: absolute; width: 0px; height: 217px; right: 0px; top: 0px;"><div class="slider" style="background: none 0% 0% / auto repeat scroll padding-box border-box rgba(228, 228, 228, 0.07); position: absolute; top: 0px; left: 0px; width: 10px; transform: translate3d(0px, 0px, 0px); contain: strict; height: 217px;"></div></div></div><section id="markdown-section-99780ea9-f8c0-4f90-b1d2-034a60f2ccc3-4" class="markdown-section chat-fade-in" data-markdown-raw="

| Location | Issue | Fix |
|----------|-------|-----|
| Line 7168 | `CWallet::CreateSparkMintTransactions` accessed `sparkWallet->` without null check | Added null check with error return |
| Lines 4886, 4902 | `CreateSparkSpendTransaction` and `CreateSparkNameTransaction` called `EnsureMintWalletAvailable()` instead of `EnsureSparkWalletAvailable()` | Changed to call the correct function |
| Line 1839 | `GetChange()` accessed `sparkWallet->getMyCoinV()` without null check | Added null check |
| Line 1496 | `AbandonSpends()` called on potentially null `sparkWallet` | Added null check |
| Line 1520 | `AbandonSparkMints()` called on potentially null `sparkWallet` | Added null check |
| Line 2718 | `getMyCoinIsChange()` called on potentially null `sparkWallet` | Added null check |

### **Other Fixed Bugs:**" data-section-index="4" style="border-radius: 4px; line-height: 19.5px; margin: 6px 0px; position: relative; scroll-margin-bottom: 40px; scroll-margin-top: 40px; color: rgba(228, 228, 228, 0.92); font-family: &quot;Segoe WPC&quot;, &quot;Segoe UI&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h3 style="animation: 0.25s ease 0s 1 normal none running fade-in; font-weight: 600 !important; font-size: 1.15em; line-height: 1.25; margin-bottom: 8px; margin-top: 18px;"><span class="markdown-bold-text" style="animation: 0.25s ease 0s 1 normal none running fade-in; font-weight: 600;"><span style="animation: 0.25s ease 0s 1 normal none running fade-in;">Previously</span><span style="animation: 0.25s ease 0s 1 normal none running fade-in;"><span> </span>Fixe</span><span style="animation: 0.25s ease 0s 1 normal none running fade-in;">d Bugs:</span></span></h3></section><!--EndFragment-->

<!--StartFragment-->
File | Issue | Fix
-- | -- | --
sparkwallet.cpp (line 1206) | PR #1734 bug - using uninitialized wtx.tx instead of txNewConst | Changed to use txNewConst
sendcoinsdialog.cpp (line 419) | Dangling entry pointer | Use static method call
sendcoinsdialog.cpp (lines 691-692) | Only updated one entry instead of all | Iterate over all entries
sparkmodel.cpp (line 109) | Null pointer on sparkWallet | Added null check
walletmodeltransaction.cpp (line 71) | Null pointer on sparkWallet | Added null check
transactionrecord.cpp (lines 187, 190) | Null pointer on sparkWallet | Added null check

<!--EndFragment-->
</body>
</html>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Resolves crashes when sending/minting Spark by hardening wallet/Qt code and fixing a critical mempool check.
> 
> - Use the actual signed transaction (`txNewConst`) for `mempool.IsTransactionAllowed` in `sparkwallet.cpp` to avoid accessing an uninitialized `wtx.tx`
> - Add null checks for `pwalletMain->sparkWallet` before accessing Spark data in `wallet.cpp`, `transactionrecord.cpp`, `walletmodeltransaction.cpp`, and `sparkmodel.cpp`
> - Replace `EnsureMintWalletAvailable()` with `EnsureSparkWalletAvailable()` in Spark spend/name creation; add early null check in `CreateSparkMintTransactions`
> - In `sendcoinsdialog.cpp`, call `SendCoinsEntry::generateWarningText` statically and update all `SendCoinsEntry` widgets when toggling anonymize mode
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f31778a6fc242a2bb829f57654b3b434be7eb140. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->