### PR TITLE
Subtract remaining amount after sigma and lelantus pull closed

### DIFF
--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -1941,6 +1941,52 @@ CAmount getzerocoinpoolbalance()
     return  nTotalAmount;
 }
 
+CAmount getsigmapoolbalance()
+{
+    CAmount nTotalAmount = 0;
+
+    // Iterate over all mints
+    std::vector<std::pair<CAddressIndexKey, CAmount> > addressIndex;
+    if (GetAddressIndex(uint160(), AddressType::sigmaMint, addressIndex)) {
+        for (auto& it : addressIndex) {
+            nTotalAmount += it.second;
+        }
+    }
+    addressIndex.clear();
+
+    // Iterate over all spends
+    if (GetAddressIndex(uint160(), AddressType::sigmaSpend, addressIndex)) {
+        for (auto& it : addressIndex) {
+            nTotalAmount += it.second;
+        }
+    }
+
+    return nTotalAmount;
+}
+
+CAmount getlelantuspoolbalance()
+{
+    CAmount nTotalAmount = 0;
+
+    // Iterate over all mints
+    std::vector<std::pair<CAddressIndexKey, CAmount> > addressIndex;
+    if (GetAddressIndex(uint160(), AddressType::lelantusMint, addressIndex)) {
+        for (auto& it : addressIndex) {
+            nTotalAmount += it.second;
+        }
+    }
+    addressIndex.clear();
+
+    // Iterate over all spends
+    if (GetAddressIndex(uint160(), AddressType::lelantusJSplit, addressIndex)) {
+        for (auto& it : addressIndex) {
+            nTotalAmount += it.second;
+        }
+    }
+
+    return nTotalAmount;
+}
+
 CAmount getCVE17144amount()
 {
     // CVE-2018-17144 was a critical bug that allowed double-spending of inputs
@@ -2090,6 +2136,7 @@ UniValue gettotalsupply(const JSONRPCRequest& request)
     total -= getzerocoinpoolbalance(); //498,397.00000000 The actual amount of coins forged during the Zerocoin attacks (the negative balance after the pool closed),
     total += getCVE17144amount(); //320,841.99803185 The cmount of forged coins during CVE-2018-17144 attacks,
     total -= 16810168037465;// burnt Coins sent to unrecoverable address https://explorer.firo.org/tx/0b53178c1b22bae4c04ef943ee6d6d30f2483327fe9beb54952951592e8ce368
+    total -= getsigmapoolbalance() + getlelantuspoolbalance(); // after closing sigma and lelantus pools, we have some amount of coins left in the pools. So we need to subtract them from the total supply.
     UniValue result(UniValue::VOBJ);
     result.push_back(Pair("total", total));
 
@@ -2113,6 +2160,44 @@ UniValue getzerocoinpoolbalance(const JSONRPCRequest& request)
         );
 
     return  getzerocoinpoolbalance();
+}
+
+UniValue getsigmapoolbalance(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() != 0)
+        throw std::runtime_error(
+                "getsigmapoolbalance\n"
+                "\nReturns the total coin amount, which remains after sigma pool closed.\n"
+                "\nArguments: none\n"
+                "\nResult:\n"
+                "{\n"
+                "  \"total\"  (string) The total balance\n"
+                "}\n"
+                "\nExamples:\n"
+                + HelpExampleCli("getsigmapoolbalance", "")
+                + HelpExampleRpc("getsigmapoolbalance", "")
+        );
+
+    return getsigmapoolbalance();
+}
+
+UniValue getlelantuspoolbalance(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() != 0)
+        throw std::runtime_error(
+                "getlelantuspoolbalance\n"
+                "\nReturns the total coin amount, which remains after lelantus pool closed.\n"
+                "\nArguments: none\n"
+                "\nResult:\n"
+                "{\n"
+                "  \"total\"  (string) The total balance\n"
+                "}\n"
+                "\nExamples:\n"
+                + HelpExampleCli("getlelantuspoolbalance", "")
+                + HelpExampleRpc("getlelantuspoolbalance", "")
+        );
+
+    return getlelantuspoolbalance();
 }
 
 UniValue getCVE17144amount(const JSONRPCRequest& request)
@@ -2262,6 +2347,8 @@ static const CRPCCommand commands[] =
     { "hidden",             "getinfoex",              &getinfoex,              false,         {} },
     { "addressindex",       "gettotalsupply",         &gettotalsupply,         false,         {} },
     { "addressindex",       "getzerocoinpoolbalance", &getzerocoinpoolbalance, false,         {} },
+    { "addressindex",       "getsigmapoolbalance",    &getsigmapoolbalance,    false,         {} },
+    { "addressindex",       "getlelantuspoolbalance", &getlelantuspoolbalance, false,         {} },
     { "addressindex",       "getCVE17144amount",      &getCVE17144amount,      false,         {} },
         /* Mobile related */
     { "mobile",             "getanonymityset",        &getanonymityset,        false,         {} },


### PR DESCRIPTION
Sigma and Lelantus pools have already been closed,
As we allowed to spend sigma coins by Lelantus spend transactions, so we need to take in account remaining numbers from 2 pools.
Sigma number [https://explorer.firo.org/address/Sigma](here) : 182463.94882676
Lelantus number [https://explorer.firo.org/address/Lelantus](here) : -86771.07491993
As we had some amount of forged coins and we added that figures into our total supply number, it would be fair to subtract the remainder from this 2 figures, which is 95692.8739068 .
This PR introduces all required changes to do it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `gettotalsupply` RPC calculation by subtracting additional pool balances, which can affect reported monetary supply used by explorers/analytics. Logic relies on `-addressindex` data and new address-type sums, so incorrect indexing or type selection could skew outputs.
> 
> **Overview**
> Adjusts the `gettotalsupply` RPC to also subtract the remaining balances in the **closed Sigma and Lelantus pools**, in addition to the existing Zerocoin/CVE/burn adjustments.
> 
> Introduces new addressindex-backed helpers and RPCs, `getsigmapoolbalance` and `getlelantuspoolbalance`, which compute pool remainders by summing `AddressType` index entries for the relevant mint/spend categories, and registers these commands in the RPC table.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5dcd7fced043479ed4385d63ad8ab8ea105cc6a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->