### PR TITLE
refactor: replace NULL with nullptr in mirrored SetCompact signature

### DIFF
--- a/src/crypto/MerkleTreeProof/arith_uint256.h
+++ b/src/crypto/MerkleTreeProof/arith_uint256.h
@@ -288,7 +288,7 @@ public:
      * complexities of the sign bit and using base 256 are probably an
      * implementation accident.
      */
-    arith_uint256& SetCompact(uint32_t nCompact, bool* pfNegative = nullptr, bool* pfOverflow = nullptr
+    arith_uint256& SetCompact(uint32_t nCompact, bool* pfNegative = nullptr, bool* pfOverflow = nullptr);
     uint32_t GetCompact(bool fNegative = false) const;
 
     friend uint256 ArithToUint256(const arith_uint256 &);

--- a/src/crypto/MerkleTreeProof/arith_uint256.h
+++ b/src/crypto/MerkleTreeProof/arith_uint256.h
@@ -288,7 +288,7 @@ public:
      * complexities of the sign bit and using base 256 are probably an
      * implementation accident.
      */
-    arith_uint256& SetCompact(uint32_t nCompact, bool *pfNegative = NULL, bool *pfOverflow = NULL);
+    arith_uint256& SetCompact(uint32_t nCompact, bool* pfNegative = nullptr, bool* pfOverflow = nullptr
     uint32_t GetCompact(bool fNegative = false) const;
 
     friend uint256 ArithToUint256(const arith_uint256 &);


### PR DESCRIPTION
Replace NULL with nullptr in mirrored SetCompact declaration for consistency with src/arith_uint256.h.