### PR TITLE
Fix Spark Name list refresh for My own spark names

### DIFF
--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -213,14 +213,15 @@ void AddressBookPage::onCopyLabelAction()
 void AddressBookPage::onEditAction()
 {
     QModelIndexList indexes;
+    const int selectedType = ui->addressType->currentData().toInt();
 
-    if (ui->addressType->currentText() == AddressTableModel::SparkName)
+    if (selectedType == (int)SparkName || selectedType == (int)SparkNameMine)
         return;
 
     EditAddressDialog::Mode mode;
     AddressTableModel * pmodel;
     pmodel = model;
-    if (ui->addressType->currentText() == AddressTableModel::Transparent) {
+    if (selectedType == (int)Transparent) {
         mode = tab == SendingTab ? EditAddressDialog::EditSendingAddress : EditAddressDialog::EditReceivingAddress;
     } else {
         mode = tab == SendingTab ? EditAddressDialog::EditSparkSendingAddress : EditAddressDialog::EditSparkReceivingAddress;
@@ -246,7 +247,8 @@ void AddressBookPage::on_newAddress_clicked()
     if(!model)
         return;
 
-    if (ui->addressType->currentText() == AddressTableModel::SparkName) {
+    const int selectedType = ui->addressType->currentData().toInt();
+    if (selectedType == (int)SparkName || selectedType == (int)SparkNameMine) {
         CreateSparkNamePage *dialog = new CreateSparkNamePage(platformStyle, this);
         dialog->setAttribute(Qt::WA_DeleteOnClose);
         dialog->setModel(model->getWalletModel());
@@ -257,7 +259,7 @@ void AddressBookPage::on_newAddress_clicked()
     AddressTableModel *pmodel;
     EditAddressDialog::Mode mode;
     pmodel = model;
-    if (ui->addressType->currentText() == AddressTableModel::Spark) {
+    if (selectedType == (int)Spark) {
         mode = tab == SendingTab ? EditAddressDialog::NewSparkSendingAddress : EditAddressDialog::NewSparkReceivingAddress;
     } else {
         mode = tab == SendingTab ? EditAddressDialog::NewSendingAddress : EditAddressDialog::NewReceivingAddress;
@@ -275,8 +277,9 @@ void AddressBookPage::on_deleteAddress_clicked()
 {
     QTableView *table;
     table = ui->tableView;
+    const int selectedType = ui->addressType->currentData().toInt();
 
-    if(!table->selectionModel() || ui->addressType->currentText() == AddressTableModel::SparkName)
+    if(!table->selectionModel() || selectedType == (int)SparkName || selectedType == (int)SparkNameMine)
         return;
 
     QModelIndexList indexes = table->selectionModel()->selectedRows();
@@ -298,7 +301,8 @@ void AddressBookPage::selectionChanged()
 
     if(table->selectionModel()->hasSelection())
     {
-        bool fSparkNames = ui->addressType->currentText() == AddressTableModel::SparkName;
+        const int selectedType = ui->addressType->currentData().toInt();
+        bool fSparkNames = selectedType == (int)SparkName || selectedType == (int)SparkNameMine;
         switch(tab)
         {
         case SendingTab:
@@ -363,7 +367,8 @@ void AddressBookPage::on_exportButton_clicked()
 
     FIRO_UNUSED QTableView *table;
     writer.setModel(proxyModel);
-    if (ui->addressType->currentText() == AddressTableModel::Transparent) {
+    const int selectedType = ui->addressType->currentData().toInt();
+    if (selectedType == (int)Transparent) {
         writer.addColumn("Label", AddressTableModel::Label, Qt::EditRole);
         writer.addColumn("Transparent Address", AddressTableModel::Address, Qt::EditRole);
         writer.addColumn("Address Type", AddressTableModel::AddressType, Qt::EditRole);

--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -111,31 +111,46 @@ AddressBookPage::~AddressBookPage()
     delete ui;
 }
 
-void AddressBookPage::setModel(AddressTableModel *_model)
+void AddressBookPage::populateAddressTypes(bool sparkAllowed)
 {
-    this->model = _model;
-    if(!_model)
-        return;
-    bool spark = this->model->IsSparkAllowed();
+    ui->addressType->clear();
+    ui->addressType->show();
 
     if (tab == SendingTab) {
-        if (spark)
+        if (sparkAllowed)
             ui->addressType->addItem(tr("Spark"), Spark);
-        ui->addressType->addItem(tr("Transparent"), Transparent);     
-        if (spark) {
+        ui->addressType->addItem(tr("Transparent"), Transparent);
+        if (sparkAllowed) {
             ui->addressType->addItem(tr("Spark names"), SparkName);
             ui->addressType->addItem(tr("My own spark names"), SparkNameMine);
         }
-    } else if(tab == ReceivingTab && !this->isReused) {
-        if (spark) {
+    } else if (tab == ReceivingTab && !this->isReused) {
+        if (sparkAllowed)
             ui->addressType->addItem(tr("Spark"), Spark);
-        }
         ui->addressType->addItem(tr("Transparent"), Transparent);
     } else {
         ui->addressType->addItem(tr(""), Transparent);
         ui->addressType->addItem(tr("Transparent"), Transparent);
         ui->addressType->hide();
     }
+}
+
+int AddressBookPage::currentAddressType() const
+{
+    return ui->addressType->currentData().toInt();
+}
+
+bool AddressBookPage::isSparkNameType(int type)
+{
+    return type == (int)SparkName || type == (int)SparkNameMine;
+}
+
+void AddressBookPage::setModel(AddressTableModel *_model)
+{
+    this->model = _model;
+    if(!_model)
+        return;
+    populateAddressTypes(this->model->IsSparkAllowed());
 
     proxyModel = new QSortFilterProxyModel(this);
     fproxyModel = new AddressBookFilterProxy(this);
@@ -184,18 +199,7 @@ void AddressBookPage::setModel(AddressTableModel *_model)
 }
 
 void AddressBookPage::updateSpark() {
-    ui->addressType->clear();
-    if (tab == SendingTab) {
-        ui->addressType->addItem(tr("Spark"), Spark);
-        ui->addressType->addItem(tr("Transparent"), Transparent);
-    } else if(tab == ReceivingTab && !this->isReused) {
-        ui->addressType->addItem(tr("Spark"), Spark);
-        ui->addressType->addItem(tr("Transparent"), Transparent);
-    } else {
-        ui->addressType->addItem(tr(""), Transparent);
-        ui->addressType->addItem(tr("Transparent"), Transparent);
-        ui->addressType->hide();
-    }
+    populateAddressTypes(model && model->IsSparkAllowed());
 
     chooseAddressType(0);
 }
@@ -213,9 +217,9 @@ void AddressBookPage::onCopyLabelAction()
 void AddressBookPage::onEditAction()
 {
     QModelIndexList indexes;
-    const int selectedType = ui->addressType->currentData().toInt();
+    const int selectedType = currentAddressType();
 
-    if (selectedType == (int)SparkName || selectedType == (int)SparkNameMine)
+    if (isSparkNameType(selectedType))
         return;
 
     EditAddressDialog::Mode mode;
@@ -247,8 +251,8 @@ void AddressBookPage::on_newAddress_clicked()
     if(!model)
         return;
 
-    const int selectedType = ui->addressType->currentData().toInt();
-    if (selectedType == (int)SparkName || selectedType == (int)SparkNameMine) {
+    const int selectedType = currentAddressType();
+    if (isSparkNameType(selectedType)) {
         CreateSparkNamePage *dialog = new CreateSparkNamePage(platformStyle, this);
         dialog->setAttribute(Qt::WA_DeleteOnClose);
         dialog->setModel(model->getWalletModel());
@@ -277,9 +281,9 @@ void AddressBookPage::on_deleteAddress_clicked()
 {
     QTableView *table;
     table = ui->tableView;
-    const int selectedType = ui->addressType->currentData().toInt();
+    const int selectedType = currentAddressType();
 
-    if(!table->selectionModel() || selectedType == (int)SparkName || selectedType == (int)SparkNameMine)
+    if(!table->selectionModel() || isSparkNameType(selectedType))
         return;
 
     QModelIndexList indexes = table->selectionModel()->selectedRows();
@@ -301,8 +305,7 @@ void AddressBookPage::selectionChanged()
 
     if(table->selectionModel()->hasSelection())
     {
-        const int selectedType = ui->addressType->currentData().toInt();
-        bool fSparkNames = selectedType == (int)SparkName || selectedType == (int)SparkNameMine;
+        bool fSparkNames = isSparkNameType(currentAddressType());
         switch(tab)
         {
         case SendingTab:
@@ -367,7 +370,7 @@ void AddressBookPage::on_exportButton_clicked()
 
     FIRO_UNUSED QTableView *table;
     writer.setModel(proxyModel);
-    const int selectedType = ui->addressType->currentData().toInt();
+    const int selectedType = currentAddressType();
     if (selectedType == (int)Transparent) {
         writer.addColumn("Label", AddressTableModel::Label, Qt::EditRole);
         writer.addColumn("Transparent Address", AddressTableModel::Address, Qt::EditRole);
@@ -418,7 +421,7 @@ void AddressBookPage::chooseAddressType(int idx)
         return;
 
     const int selectedType = ui->addressType->itemData(idx).toInt();
-    if (selectedType == (int)SparkName || selectedType == (int)SparkNameMine) {
+    if (isSparkNameType(selectedType)) {
         model->ProcessPendingSparkNameChanges();
         ui->deleteAddress->setEnabled(false);
         deleteAction->setEnabled(false);

--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -412,7 +412,8 @@ void AddressBookPage::chooseAddressType(int idx)
     if(!proxyModel)
         return;
 
-    if (idx == 2) {
+    const int selectedType = ui->addressType->itemData(idx).toInt();
+    if (selectedType == (int)SparkName || selectedType == (int)SparkNameMine) {
         model->ProcessPendingSparkNameChanges();
         ui->deleteAddress->setEnabled(false);
         deleteAction->setEnabled(false);
@@ -421,8 +422,7 @@ void AddressBookPage::chooseAddressType(int idx)
         selectionChanged();
     }
     
-    fproxyModel->setTypeFilter(
-        ui->addressType->itemData(idx).toInt());
+    fproxyModel->setTypeFilter(selectedType);
 }
 
 AddressBookFilterProxy::AddressBookFilterProxy(QObject *parent) :

--- a/src/qt/addressbookpage.h
+++ b/src/qt/addressbookpage.h
@@ -75,6 +75,9 @@ private:
     QAction *deleteAction; // to be able to explicitly disable it
     QString newAddressToSelect;
     bool isReused;
+    void populateAddressTypes(bool sparkAllowed);
+    int currentAddressType() const;
+    static bool isSparkNameType(int type);
 
 private Q_SLOTS:
     /** Delete currently selected address entry */

--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -106,6 +106,8 @@ public:
 
 private:
     void queueProcessPendingSparkNameChanges() {
+        if (!parent->AutoProcessPendingSparkNameChanges())
+            return;
         QMetaObject::invokeMethod(parent, "ProcessPendingSparkNameChanges", Qt::QueuedConnection);
     }
 

--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -101,23 +101,32 @@ public:
         CSparkNameBlockIndexData sparkNameData;
     };
     QList<PendingSparkNameChange> pendingSparkNameChanges;
+    bool pendingSparkNameDrainScheduled = false;
 
     CCriticalSection cs_pendingSparkNameChanges;
 
 private:
     void queueProcessPendingSparkNameChanges() {
-        if (!parent->AutoProcessPendingSparkNameChanges())
+        // Caller must hold cs_pendingSparkNameChanges. Coalesce bursts into a
+        // single queued drain so a block full of spark-name mutations doesn't
+        // flood the Qt event loop.
+        if (pendingSparkNameDrainScheduled)
             return;
+        pendingSparkNameDrainScheduled = true;
         QMetaObject::invokeMethod(parent, "ProcessPendingSparkNameChanges", Qt::QueuedConnection);
     }
 
     void sparkNameAdded(const CSparkNameBlockIndexData &sparkNameData) {
+        if (!parent->AutoProcessPendingSparkNameChanges())
+            return;
         LOCK(cs_pendingSparkNameChanges);
         pendingSparkNameChanges.append(PendingSparkNameChange{CT_NEW, sparkNameData});
         queueProcessPendingSparkNameChanges();
     }
 
     void sparkNameRemoved(const CSparkNameBlockIndexData &sparkNameData) {
+        if (!parent->AutoProcessPendingSparkNameChanges())
+            return;
         LOCK(cs_pendingSparkNameChanges);
         pendingSparkNameChanges.append(PendingSparkNameChange{CT_DELETED, sparkNameData});
         queueProcessPendingSparkNameChanges();
@@ -330,6 +339,7 @@ public:
             LOCK(cs_pendingSparkNameChanges);
             pendingChanges = pendingSparkNameChanges;
             pendingSparkNameChanges.clear();
+            pendingSparkNameDrainScheduled = false;
         }
 
         LOCK(wallet->cs_wallet);

--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -18,6 +18,7 @@
 
 #include <QFont>
 #include <QDebug>
+#include <QMetaObject>
 
 const QString AddressTableModel::Send = "S";
 const QString AddressTableModel::Receive = "R";
@@ -104,14 +105,20 @@ public:
     CCriticalSection cs_pendingSparkNameChanges;
 
 private:
+    void queueProcessPendingSparkNameChanges() {
+        QMetaObject::invokeMethod(parent, "ProcessPendingSparkNameChanges", Qt::QueuedConnection);
+    }
+
     void sparkNameAdded(const CSparkNameBlockIndexData &sparkNameData) {
         LOCK(cs_pendingSparkNameChanges);
         pendingSparkNameChanges.append(PendingSparkNameChange{CT_NEW, sparkNameData});
+        queueProcessPendingSparkNameChanges();
     }
 
     void sparkNameRemoved(const CSparkNameBlockIndexData &sparkNameData) {
         LOCK(cs_pendingSparkNameChanges);
         pendingSparkNameChanges.append(PendingSparkNameChange{CT_DELETED, sparkNameData});
+        queueProcessPendingSparkNameChanges();
     }
 
 public:

--- a/src/qt/addresstablemodel.h
+++ b/src/qt/addresstablemodel.h
@@ -91,7 +91,7 @@ public:
     PcodeAddressTableModel * getPcodeAddressTableModel();
 
     bool IsSparkAllowed();
-    void ProcessPendingSparkNameChanges();
+    Q_INVOKABLE void ProcessPendingSparkNameChanges();
 
     WalletModel *getWalletModel() const { return walletModel; }
 protected:

--- a/src/qt/addresstablemodel.h
+++ b/src/qt/addresstablemodel.h
@@ -92,6 +92,7 @@ public:
 
     bool IsSparkAllowed();
     Q_INVOKABLE void ProcessPendingSparkNameChanges();
+    virtual bool AutoProcessPendingSparkNameChanges() const { return true; }
 
     WalletModel *getWalletModel() const { return walletModel; }
 protected:
@@ -140,6 +141,7 @@ public:
     /*@}*/
 
     QString addRow(const QString &type, const QString &label, const QString &address, const QString &addressType) override;
+    bool AutoProcessPendingSparkNameChanges() const override { return false; }
 
     AddressTableModel::EditStatus getEditStatus() const { return editStatus; }
 


### PR DESCRIPTION
## **User description**
fix for issue #1714

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Medium Risk**
> Touches Qt model/view update flow for Spark Name additions/removals and changes how the UI determines address type, which could affect address book filtering and edit/delete behavior if type IDs are mis-mapped.
> 
> **Overview**
> Fixes Spark Name list refresh issues (including **"My own spark names"**) in the Qt address book.
> 
> The address book UI now drives behavior off the combo box’s stored type IDs (`currentData`/`itemData`) instead of comparing display text, ensuring edit/new/delete/export and filtering logic correctly treats `SparkName` and `SparkNameMine` as non-editable lists.
> 
> Spark Name add/remove notifications now **queue** `AddressTableModel::ProcessPendingSparkNameChanges()` via `QMetaObject::invokeMethod(..., Qt::QueuedConnection)` (and marks the method `Q_INVOKABLE`) so the table model refresh is scheduled on the Qt event loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdb0b0f40157f6c6bfd5bad9df29e3bd44a44bd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Fix spark-name refresh and address book actions**

### What Changed
- Spark name lists now refresh reliably after names are added or removed, including “My own spark names”
- Address book actions now use the selected address type instead of the visible label, so edit, new, delete, and export work correctly for Spark, Transparent, Spark names, and “My own spark names”
- Spark-name entries are treated as non-editable, and the UI no longer leaves unused pending spark-name updates on models that do not auto-refresh
- Multiple spark-name changes are combined into a single refresh, reducing repeated UI updates during bursts of changes

### Impact
`✅ Reliable spark-name list updates`
`✅ Correct address book actions by type`
`✅ Fewer repeated refreshes during sync`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=Yg25xVCiYD3dLQPPhfgJWUfgrFTVKoCgNuK3HBbfa4Y&org=firoorg)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
