### PR TITLE
Qt: Restore address-book refresh at Spark hardfork activation

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -973,6 +973,8 @@ void BitcoinGUI::setNumBlocks(int count, const QDateTime& blockDate, double nVer
 
 #ifdef ENABLE_WALLET
     checkZnodeVisibility(count);
+    if (walletFrame && count == ::Params().GetConsensus().nSparkStartBlock)
+        walletFrame->updateAddressbook();
 #endif // ENABLE_WALLET
 }
 


### PR DESCRIPTION
## **User description**
## Summary

- Restore the single call site that refreshes the address book when the chain crosses the Spark hardfork block; it was accidentally removed in #1475 along with `BitcoinGUI::checkLelantusVisibility`.
- Without this, `WalletFrame::updateAddressbook` → `WalletView::updateAddressbook` → `AddressBookPage::updateSpark` is a dead chain: a running wallet that was open before the HF height never repopulates the address-type dropdown with Spark options until restart.

## Background

The chain was wired up in #1366 (Nov 2023):

```cpp
// BitcoinGUI::checkLelantusVisibility, called from setNumBlocks
if (numBlocks == ::Params().GetConsensus().nSparkStartBlock)
    walletFrame->updateAddressbook();
```

#1475 stripped Lelantus UI and removed `checkLelantusVisibility` wholesale, dropping the Spark-refresh line with it. Mainnet/testnet have long since crossed the HF, so the regression is only observable on regtest / devnet / IBD sessions that cross `nSparkStartBlock` while the wallet is open — which is exactly the scenario this code was added to handle.

This also matters for #1814: that PR's new `populateAddressTypes()` helper is invoked from `updateSpark()`, so with no caller the refactor's Spark-HF branch is unreachable. Restoring the caller here makes both changes effective.

## Test plan

- [ ] `-regtest`: start a fresh node, open the wallet GUI at height `< 400`, open Address Book → Sending — verify only Transparent is offered. Generate blocks past `nSparkStartBlock` (400) with the wallet still open. Re-open Address Book → Sending — Spark / Spark names / My own spark names should now appear in the address-type dropdown without a restart.
- [ ] Re-run on mainnet/testnet to confirm no regression at steady state (the guard is exact-equality on `nSparkStartBlock`, so it is a no-op for wallets started after the HF).


___

## **CodeAnt-AI Description**
**Restore Spark address options when the chain reaches the hardfork**

### What Changed
- When a wallet is open as the chain reaches the Spark hardfork height, the address book now refreshes automatically.
- The address-type dropdown can repopulate with Spark-related options without requiring a wallet restart.

### Impact
`✅ Spark address options appear on time`
`✅ Fewer wallet restarts after hardfork activation`
`✅ Clearer address-book choices during chain upgrades`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=od_5kN8LNy04fc6PWGAySmLQn3J6Q5Vjo6VH24sHHa0&org=firoorg)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
