### PR TITLE
Tests: fix flaky dip3-deterministicmns assert_mnlist after invalidateblock

### DIFF
--- a/qa/rpc-tests/dip3-deterministicmns.py
+++ b/qa/rpc-tests/dip3-deterministicmns.py
@@ -296,14 +296,23 @@ class DIP3Test(BitcoinTestFramework):
         for node in self.nodes:
             self.assert_mnlist(node, mns)
 
-    def assert_mnlist(self, node, mns):
-        if not self.compare_mnlist(node, mns):
-            expected = []
-            for mn in mns:
-                expected.append('%s, %d' % (mn.collateral_txid, mn.collateral_vout))
-            self.log.error('mnlist: ' + str(node.evoznode('list', 'status')))
-            self.log.error('expected: ' + str(expected))
-            raise AssertionError("mnlists does not match provided mns")
+    def assert_mnlist(self, node, mns, timeout=10):
+        # Poll briefly so we don't race state propagation (e.g. right after
+        # invalidateblock, where the masternode manager's tip/cache may not
+        # yet reflect the new active tip on a slow debug build).
+        deadline = time.time() + timeout
+        while True:
+            if self.compare_mnlist(node, mns):
+                return
+            if time.time() >= deadline:
+                break
+            time.sleep(0.1)
+        expected = []
+        for mn in mns:
+            expected.append('%s, %d' % (mn.collateral_txid, mn.collateral_vout))
+        self.log.error('mnlist: ' + str(node.evoznode('list', 'status')))
+        self.log.error('expected: ' + str(expected))
+        raise AssertionError("mnlists does not match provided mns")
 
     def wait_for_sporks(self, timeout=30):
         st = time.time()


### PR DESCRIPTION
## **User description**
## Summary
- `dip3-deterministicmns.py` intermittently fails in linux-cmake-Debug at [line 182](https://github.com/firoorg/firo/blob/master/qa/rpc-tests/dip3-deterministicmns.py#L182) with `AssertionError: mnlists does not match provided mns`. Observed in [run 24627393556](https://github.com/firoorg/firo/actions/runs/24627393556/job/72008704574) on PR #1807, where the change set (Qt Wayland deps) is unrelated to masternode code.
- Root cause is a race: the revert loop calls `invalidateblock(getbestblockhash())` three times in a row and immediately asserts the full mnlist each iteration, with no intervening sync. On slow Debug runners the masternode manager's post-disconnect tip/cache update can lag the RPC reply just long enough for the assert to see a stale list.
- Convert `assert_mnlist` from a single-shot comparison to a short poll (default 10s, 100ms interval) before raising. Happy path is unchanged — the first `compare_mnlist` returns True and the function returns immediately. Genuine bugs still fail with the same `AssertionError` and the same log output, only delayed by up to the timeout.

Follows the same pattern used in [#1795](https://github.com/firoorg/firo/pull/1795) and [#1796](https://github.com/firoorg/firo/pull/1796) for flaky-test hardening, and mirrors the inline poll-with-deadline style of `wait_for_sporks` / `wait_for_instant_lock` already present in this file.

## Test plan
- [ ] CI passes on this branch (linux-cmake-Debug in particular)
- [ ] Re-run linux-cmake-Debug a few times to confirm the failure no longer surfaces
- [ ] No unrelated tests regress

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Reduce flaky failures in the deterministic masternode test**

### What Changed
- The deterministic masternode test now waits briefly for masternode lists to match before failing.
- This avoids false failures right after block invalidation, when the expected state may take a moment to appear on slower debug runs.
- If the list still does not match after the wait, the test fails with the same error message and logging as before.

### Impact
`✅ Fewer flaky test failures`
`✅ More reliable debug CI runs`
`✅ Fewer false masternode mismatch errors`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=A5x6eHTTPtFPMBraQnC_fuBKZySMkg6Ct4GLu8dvWZk&org=firoorg)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
