### PR TITLE
Tests: tolerate disconnect during stop RPC in stop_node helper

### DIFF
--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -448,6 +448,11 @@ def stop_node(node, i, wait=True):
         node.stop()
     except http.client.CannotSendRequest as e:
         logger.exception("Unable to stop node")
+    except (ConnectionError, http.client.HTTPException) as e:
+        # firod may close the RPC socket before sending a response and then
+        # refuse further connections while shutting down. Treat these as a
+        # successful stop request; wait_node() below confirms the process exits.
+        logger.debug("Stop RPC on node %d disconnected (%s); relying on process exit" % (i, e))
     if wait:
         wait_node(i)
 


### PR DESCRIPTION
## **User description**
## Summary

- Catches `ConnectionError` / `http.client.HTTPException` in the shared `stop_node` helper so a disconnect during the `stop` RPC is treated as a successful stop request.
- `wait_node()` still verifies clean process exit within `BITCOIND_PROC_WAIT_TIMEOUT`, so genuinely stuck nodes are not masked.

## Why

Observed as a flaky failure in `receivedby.py` on the `linux-cmake-Debug` job of [run 24630045366](https://github.com/firoorg/firo/actions/runs/24630045366/job/72015699567). The failure is not specific to `receivedby.py` — it's in `initialize_chain`'s cache-creation `stop_nodes()` call, which any test can hit:

```
http.client.RemoteDisconnected: Remote end closed connection without response

During handling of the above exception, another exception occurred:
...
ConnectionRefusedError: [Errno 111] Connection refused
```

`firod` can close the RPC socket before sending a response to `stop`, and then refuse further connections while shutting down. `authproxy`'s retry-on-`ConnectionResetError` path then fails with `ConnectionRefusedError`, which was escaping `stop_node` because only `CannotSendRequest` was being caught. More likely to trigger under Debug-build + 15-node cache-creation load, which matches where we saw it.

## Test plan

- [ ] Re-run the failing `linux-cmake-Debug` CI job (or equivalent) and confirm `receivedby.py` passes.
- [ ] Confirm no regressions in the rest of the RPC test suite on Linux Debug/Release, macOS, and Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Tolerate RPC disconnects while stopping nodes in test runs**

### What Changed
- Stopping a node no longer fails when the RPC connection drops as the node is already shutting down
- The shared stop helper now treats these disconnects as a normal stop request and still waits for the process to exit cleanly
- This reduces flaky failures during test setup and node shutdown, especially in cache-creation cleanup

### Impact
`✅ Fewer flaky RPC test failures`
`✅ More reliable node shutdown in CI`
`✅ Fewer failures during test cleanup`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=Z8MD9p7wxbZi3XRBowfXiJD-wb2SktiCK2TV0O36Ohs&org=firoorg)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
