### PR TITLE
CI: harden Guix installer against Savannah flakes

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -443,9 +443,10 @@ jobs:
               echo "GPG verification failed – continuing anyway."
           fi
           cd /tmp
-          wget -q "${BASE}/${TAR}" -O "${TAR}"
-          wget -q "${BASE}/${TAR}.sig" -O "${TAR}.sig"
-          wget -q https://git.savannah.gnu.org/cgit/guix.git/plain/etc/guix-install.sh -O guix-install.sh
+          wget -q --tries=5 --timeout=30 --waitretry=10 "${BASE}/${TAR}" -O "${TAR}"
+          wget -q --tries=5 --timeout=30 --waitretry=10 "${BASE}/${TAR}.sig" -O "${TAR}.sig"
+          wget -q --tries=5 --timeout=30 --waitretry=10 https://git.savannah.gnu.org/cgit/guix.git/plain/etc/guix-install.sh -O guix-install.sh \
+            || wget -q --tries=5 --timeout=30 --waitretry=10 https://codeberg.org/guix/guix-mirror/raw/branch/master/etc/guix-install.sh -O guix-install.sh
           chmod +x guix-install.sh
           # Disable pipefail strictly for this command so 'yes' crashing doesn't fail the build
           set +o pipefail


### PR DESCRIPTION
## **User description**
## Summary
- Add `--tries=5 --timeout=30 --waitretry=10` to the three `wget` calls in the Install Guix step
- Fall back to the Codeberg Guix mirror (already trusted by this workflow for `guix pull`) if `git.savannah.gnu.org` is fully unreachable

## Why
The `guix-x86_64-linux-gnu` job has been failing intermittently with `wget` exit code 4 (network failure) when fetching `guix-install.sh` from `git.savannah.gnu.org`. Example failure: https://github.com/firoorg/firo/actions/runs/24631368960/job/72019245784

With `set -exo pipefail` in effect, a single wget failure aborts the step and skips the whole Guix build. The default wget timeout is ~900s, so a stuck connection hangs the runner for ~15 minutes before failing.

The retry flags handle transient hiccups (short timeout, up to 5 attempts with backoff). The Codeberg fallback handles Savannah being fully down.

## Test plan
- [ ] CI green on this branch
- [ ] `guix-x86_64-linux-gnu` job completes Install Guix step


___

## **CodeAnt-AI Description**
Make the Guix installer step withstand temporary download failures

### What Changed
- Guix download steps now retry instead of failing immediately on short network hiccups
- The installer script download now falls back to the Codeberg mirror if Savannah is unreachable
- Guix installation can continue when the main source is flaky or briefly down

### Impact
`✅ Fewer Guix CI failures from network flakes`
`✅ Shorter waits when downloads hang`
`✅ More reliable Guix installs during Savannah outages`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=BkhJrhKe4hdLBqnv4LJuTMFkiFSrTb4D_QIHynBoGoY&org=firoorg)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
