### PR TITLE
Net: discover Tor SOCKS port via control port

### DIFF
--- a/qa/rpc-tests/llmq-cl-evospork.py
+++ b/qa/rpc-tests/llmq-cl-evospork.py
@@ -58,7 +58,8 @@ class LLMQChainLocksTest(EvoZnodeTestFramework):
         ##### Disable chainlocks for 10 blocks
 
         self.nodes[0].importprivkey(self.sporkprivkey)
-        self.disable_chainlocks(self.nodes[0].getblockcount() + 10)
+        reenable_height = self.nodes[0].getblockcount() + 10
+        self.disable_chainlocks(reenable_height)
         self.nodes[0].generate(1)
         assert(False == self.nodes[0].getblock(self.nodes[0].getbestblockhash())["chainlock"])
 
@@ -70,14 +71,19 @@ class LLMQChainLocksTest(EvoZnodeTestFramework):
 
         ##### Enable chainlocks
 
-        self.nodes[0].generate(10)
-        self.nodes[0].spork('list')
         connected_nodes = [n for n in self.nodes if n != self.nodes[5]]
+
+        # Mine up to the re-enable height, then use the next block for
+        # chainlock assertions to avoid the reactivation transition edge.
+        self.nodes[0].generate(reenable_height - self.nodes[0].getblockcount())
         sync_blocks(connected_nodes, timeout=120)
-        self.wait_for_chainlock_tip(connected_nodes, self.nodes[0].getbestblockhash(), timeout=90)
         sporks = self.nodes[0].spork("list")
         assert(not sporks["blockchain"])
         assert(not sporks["mempool"])
+
+        self.nodes[0].generate(1)
+        sync_blocks(connected_nodes, timeout=120)
+        self.wait_for_chainlock_tip(connected_nodes, self.nodes[0].getbestblockhash(), timeout=90)
         assert(True == self.nodes[0].getblock(self.nodes[0].getbestblockhash())["chainlock"])
         chainlocked_tip = self.nodes[0].getbestblockhash()
 

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -48,6 +48,8 @@ static const float RECONNECT_TIMEOUT_EXP = 1.5;
  * this is belt-and-suspenders sanity limit to prevent memory exhaustion.
  */
 static const int MAX_LINE_LENGTH = 100000;
+/** Default Tor SOCKS port */
+static const int DEFAULT_TOR_SOCKS_PORT = 9050;
 
 /****** Low-level TorControlConnection ********/
 
@@ -386,6 +388,8 @@ private:
 
     /** Callback for ADD_ONION result */
     void add_onion_cb(TorControlConnection& conn, const TorControlReply& reply);
+    /** Callback for GETINFO net/listeners/socks result */
+    void get_socks_cb(TorControlConnection& conn, const TorControlReply& reply);
     /** Callback for AUTHENTICATE result */
     void auth_cb(TorControlConnection& conn, const TorControlReply& reply);
     /** Callback for AUTHCHALLENGE result */
@@ -466,14 +470,12 @@ void TorController::auth_cb(TorControlConnection& _conn, const TorControlReply& 
     if (reply.code == 250) {
         LogPrint("tor", "tor: Authentication successful\n");
 
-        // Now that we know Tor is running setup the proxy for onion addresses
-        // if -onion isn't set to something else.
+        // Now that we know Tor is running, discover its actual SOCKS port and
+        // set up the onion proxy, unless -onion is already set to something else.
+        // Querying the control port avoids hardcoding 9050 (Bitcoin Core pattern).
         if (GetArg("-onion", "") == "") {
-            CService resolved(LookupNumeric("127.0.0.1", 9050));
-            proxyType addrOnion = proxyType(resolved, true);
-            SetProxy(NET_ONION, addrOnion);
-            if (!IsNetworkExplicitlyLimited(NET_ONION))
-                SetLimited(NET_ONION, false);
+            _conn.Command("GETINFO net/listeners/socks",
+                boost::bind(&TorController::get_socks_cb, this, _1, _2));
         }
 
         // Finally - now create the service
@@ -499,6 +501,64 @@ void TorController::auth_cb(TorControlConnection& _conn, const TorControlReply& 
     } else {
         LogPrintf("tor: Authentication failed\n");
     }
+}
+
+void TorController::get_socks_cb(TorControlConnection& _conn, const TorControlReply& reply)
+{
+    // NOTE: We can only get here if -onion is unset
+    std::string socks_location;
+    if (reply.code == 250) {
+        static const std::string kSocksPrefix{"net/listeners/socks="};
+        for (const std::string& line : reply.lines) {
+            if (line.starts_with(kSocksPrefix)) {
+                const std::string port_list_str = line.substr(kSocksPrefix.size());
+                std::vector<std::string> port_list;
+                boost::split(port_list, port_list_str, boost::is_any_of(" "));
+                for (auto& portstr : port_list) {
+                    if (portstr.empty()) continue;
+                    // Strip surrounding quotes if present
+                    if ((portstr.front() == '"' || portstr.front() == '\'') &&
+                            portstr.size() >= 2 && portstr.back() == portstr.front()) {
+                        portstr = portstr.substr(1, portstr.size() - 2);
+                        if (portstr.empty()) continue;
+                    }
+                    socks_location = portstr;
+                    if (portstr.starts_with("127.0.0.1:"))
+                        break; // prefer localhost over other interfaces
+                }
+            }
+        }
+        if (!socks_location.empty()) {
+            LogPrint("tor", "tor: Get SOCKS port yielded %s\n", socks_location);
+        } else {
+            LogPrintf("tor: Get SOCKS port command returned nothing\n");
+        }
+    } else if (reply.code == 510) { // 510 Unrecognized command
+        LogPrintf("tor: Get SOCKS port command failed with unrecognized command (You probably need to upgrade Tor)\n");
+    } else {
+        LogPrintf("tor: Get SOCKS port command failed; error code %d\n", reply.code);
+    }
+
+    CService resolved;
+    if (!socks_location.empty()) {
+        resolved = LookupNumeric(socks_location.c_str(), DEFAULT_TOR_SOCKS_PORT);
+    }
+    if (!resolved.IsValid()) {
+        // No usable port from Tor; fall back to the conventional default.
+        resolved = LookupNumeric("127.0.0.1", DEFAULT_TOR_SOCKS_PORT);
+    }
+
+    LogPrint("tor", "tor: Configuring onion proxy for %s\n", resolved.ToString());
+    proxyType addrOnion = proxyType(resolved, true);
+    SetProxy(NET_ONION, addrOnion);
+    if (!IsNetworkExplicitlyLimited(NET_ONION))
+        SetLimited(NET_ONION, false);
+    // When clearnet is unreachable (e.g. -onlynet=onion) and no name proxy
+    // is configured, route name lookups through Tor so hostname resolution
+    // doesn't leak over clearnet. Mirrors the explicit -onion=<addr> path
+    // in init.cpp.
+    if (!HaveNameProxy() && !IsReachable(NET_IPV4) && !IsReachable(NET_IPV6))
+        SetNameProxy(addrOnion);
 }
 
 /** Compute Tor SAFECOOKIE response.

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -508,10 +508,10 @@ void TorController::get_socks_cb(TorControlConnection& _conn, const TorControlRe
     // NOTE: We can only get here if -onion is unset
     std::string socks_location;
     if (reply.code == 250) {
-        static const std::string kSocksPrefix{"net/listeners/socks="};
+        static const std::string SOCKS_PREFIX{"net/listeners/socks="};
         for (const std::string& line : reply.lines) {
-            if (line.starts_with(kSocksPrefix)) {
-                const std::string port_list_str = line.substr(kSocksPrefix.size());
+            if (line.starts_with(SOCKS_PREFIX)) {
+                const std::string port_list_str = line.substr(SOCKS_PREFIX.size());
                 std::vector<std::string> port_list;
                 boost::split(port_list, port_list_str, boost::is_any_of(" "));
                 for (auto& portstr : port_list) {
@@ -522,6 +522,11 @@ void TorController::get_socks_cb(TorControlConnection& _conn, const TorControlRe
                         portstr = portstr.substr(1, portstr.size() - 2);
                         if (portstr.empty()) continue;
                     }
+                    // Skip entries Tor may report that we can't use as a TCP
+                    // proxy (e.g. "unix:/path/to/socket"), so they don't
+                    // overwrite a usable TCP listener seen earlier.
+                    const CService candidate = LookupNumeric(portstr.c_str(), DEFAULT_TOR_SOCKS_PORT);
+                    if (!candidate.IsValid()) continue;
                     socks_location = portstr;
                     if (portstr.starts_with("127.0.0.1:"))
                         break; // prefer localhost over other interfaces

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -390,6 +390,8 @@ private:
     void add_onion_cb(TorControlConnection& conn, const TorControlReply& reply);
     /** Callback for GETINFO net/listeners/socks result */
     void get_socks_cb(TorControlConnection& conn, const TorControlReply& reply);
+    /** Apply the discovered (or fallback) Tor SOCKS endpoint as the onion proxy. */
+    void ConfigureOnionProxy(const CService& resolved);
     /** Callback for AUTHENTICATE result */
     void auth_cb(TorControlConnection& conn, const TorControlReply& reply);
     /** Callback for AUTHCHALLENGE result */
@@ -474,8 +476,16 @@ void TorController::auth_cb(TorControlConnection& _conn, const TorControlReply& 
         // set up the onion proxy, unless -onion is already set to something else.
         // Querying the control port avoids hardcoding 9050 (Bitcoin Core pattern).
         if (GetArg("-onion", "") == "") {
-            _conn.Command("GETINFO net/listeners/socks",
-                boost::bind(&TorController::get_socks_cb, this, _1, _2));
+            if (!_conn.Command("GETINFO net/listeners/socks",
+                    boost::bind(&TorController::get_socks_cb, this, _1, _2))) {
+                // Queueing the command failed (e.g. control connection lost),
+                // so get_socks_cb will never run. Apply the conventional
+                // default synchronously so onion outbound is still configured,
+                // matching the pre-discovery behaviour.
+                LogPrintf("tor: Error sending GETINFO net/listeners/socks; falling back to 127.0.0.1:%d\n",
+                          DEFAULT_TOR_SOCKS_PORT);
+                ConfigureOnionProxy(LookupNumeric("127.0.0.1", DEFAULT_TOR_SOCKS_PORT));
+            }
         }
 
         // Finally - now create the service
@@ -553,6 +563,15 @@ void TorController::get_socks_cb(TorControlConnection& _conn, const TorControlRe
         resolved = LookupNumeric("127.0.0.1", DEFAULT_TOR_SOCKS_PORT);
     }
 
+    ConfigureOnionProxy(resolved);
+}
+
+void TorController::ConfigureOnionProxy(const CService& resolved)
+{
+    if (!resolved.IsValid()) {
+        LogPrintf("tor: Refusing to configure onion proxy: invalid SOCKS address\n");
+        return;
+    }
     LogPrint("tor", "tor: Configuring onion proxy for %s\n", resolved.ToString());
     proxyType addrOnion = proxyType(resolved, true);
     SetProxy(NET_ONION, addrOnion);

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -385,6 +385,8 @@ private:
     std::vector<uint8_t> cookie;
     /** ClientNonce for SAFECOOKIE auth */
     std::vector<uint8_t> clientNonce;
+    /** Whether this controller auto-configured name resolution via Tor. */
+    bool name_proxy_configured;
 
     /** Callback for ADD_ONION result */
     void add_onion_cb(TorControlConnection& conn, const TorControlReply& reply);
@@ -410,7 +412,7 @@ private:
 TorController::TorController(struct event_base* _base, const std::string& _target, unsigned short _onion_local_port):
     base(_base),
     target(_target), conn(base), onion_local_port(_onion_local_port), reconnect(true), reconnect_ev(0),
-    reconnect_timeout(RECONNECT_TIMEOUT_START)
+    reconnect_timeout(RECONNECT_TIMEOUT_START), name_proxy_configured(false)
 {
     reconnect_ev = event_new(base, -1, 0, reconnect_cb, this);
     if (!reconnect_ev)
@@ -513,10 +515,30 @@ void TorController::auth_cb(TorControlConnection& _conn, const TorControlReply& 
     }
 }
 
+static CService LookupTorSocksListener(const std::string& listener)
+{
+    CService candidate;
+    if (!Lookup(listener.c_str(), candidate, DEFAULT_TOR_SOCKS_PORT, false)) {
+        return CService();
+    }
+    if (candidate.IsValid()) {
+        return candidate;
+    }
+    if (!candidate.IsBindAny()) {
+        return CService();
+    }
+
+    // Tor may report wildcard SocksPort listeners such as 0.0.0.0:9050 or
+    // [::]:9050. They are not valid proxy destinations, but they mean the
+    // SOCKS listener is reachable locally on the same port.
+    return LookupNumeric(candidate.IsIPv6() ? "::1" : "127.0.0.1", candidate.GetPort());
+}
+
 void TorController::get_socks_cb(TorControlConnection& _conn, const TorControlReply& reply)
 {
     // NOTE: We can only get here if -onion is unset
     std::string socks_location;
+    CService resolved;
     if (reply.code == 250) {
         static const std::string SOCKS_PREFIX{"net/listeners/socks="};
         for (const std::string& line : reply.lines) {
@@ -535,12 +557,17 @@ void TorController::get_socks_cb(TorControlConnection& _conn, const TorControlRe
                     // Skip entries Tor may report that we can't use as a TCP
                     // proxy (e.g. "unix:/path/to/socket"), so they don't
                     // overwrite a usable TCP listener seen earlier.
-                    const CService candidate = LookupNumeric(portstr.c_str(), DEFAULT_TOR_SOCKS_PORT);
+                    const CService candidate = LookupTorSocksListener(portstr);
                     if (!candidate.IsValid()) continue;
-                    socks_location = portstr;
-                    if (portstr.starts_with("127.0.0.1:"))
+                    if (!resolved.IsValid() || candidate.IsLocal()) {
+                        socks_location = portstr;
+                        resolved = candidate;
+                    }
+                    if (candidate.IsLocal())
                         break; // prefer localhost over other interfaces
                 }
+                if (resolved.IsValid() && resolved.IsLocal())
+                    break;
             }
         }
         if (!socks_location.empty()) {
@@ -554,10 +581,6 @@ void TorController::get_socks_cb(TorControlConnection& _conn, const TorControlRe
         LogPrintf("tor: Get SOCKS port command failed; error code %d\n", reply.code);
     }
 
-    CService resolved;
-    if (!socks_location.empty()) {
-        resolved = LookupNumeric(socks_location.c_str(), DEFAULT_TOR_SOCKS_PORT);
-    }
     if (!resolved.IsValid()) {
         // No usable port from Tor; fall back to the conventional default.
         resolved = LookupNumeric("127.0.0.1", DEFAULT_TOR_SOCKS_PORT);
@@ -577,12 +600,14 @@ void TorController::ConfigureOnionProxy(const CService& resolved)
     SetProxy(NET_ONION, addrOnion);
     if (!IsNetworkExplicitlyLimited(NET_ONION))
         SetLimited(NET_ONION, false);
-    // When clearnet is unreachable (e.g. -onlynet=onion) and no name proxy
-    // is configured, route name lookups through Tor so hostname resolution
-    // doesn't leak over clearnet. Mirrors the explicit -onion=<addr> path
-    // in init.cpp.
-    if (!HaveNameProxy() && !IsReachable(NET_IPV4) && !IsReachable(NET_IPV6))
-        SetNameProxy(addrOnion);
+    // When clearnet is unreachable (e.g. -onlynet=onion), route name lookups
+    // through Tor so hostname resolution doesn't leak over clearnet. Refresh
+    // only the name proxy that this controller auto-configured, preserving
+    // explicit -proxy/-onion/-torsetup name proxies.
+    if (!IsReachable(NET_IPV4) && !IsReachable(NET_IPV6) &&
+            (!HaveNameProxy() || name_proxy_configured)) {
+        name_proxy_configured = SetNameProxy(addrOnion);
+    }
 }
 
 /** Compute Tor SAFECOOKIE response.


### PR DESCRIPTION
## **User description**
## Summary
- `auth_cb` now queries `GETINFO net/listeners/socks` to discover the actual Tor SOCKS port instead of hardcoding `127.0.0.1:9050`. Users running Tor on a non-default SocksPort (Tor Browser bundle at 9150, manually configured port) had outbound `.onion` traffic silently routed to a non-existent proxy.
- New `get_socks_cb` callback parses the reply, prefers `127.0.0.1` listeners when multiple are reported, and falls back to `127.0.0.1:9050` if Tor returns nothing usable (preserves pre-fix behaviour as a safety net).
- When clearnet is unreachable (`-onlynet=onion`) and no name proxy is already configured, `get_socks_cb` also sets the discovered proxy as the name proxy. Prevents hostname resolution (DNS seeds on the 11s retry path, `-addnode` via hostname, post-startup lookups) from leaking over clearnet. Guarded by `HaveNameProxy()` so `-proxy`, `-onion`, and `-torsetup` configurations are never overridden. Mirrors the explicit `-onion=<addr>` path at `init.cpp:1737`.

Follows Bitcoin Core's `torcontrol.cpp` pattern for SOCKS port discovery.

## Context
Follow-up to #1790. Testers reported fewer onion peer connections after that merge; root-cause analysis surfaced that the pre-existing hardcoded `127.0.0.1:9050` silently broke onion outbound for non-default Tor configurations. This PR does not fully fix the fresh-install onion-only bootstrap case (that needs onion entries in `pnSeed6_main`, tracked separately), but it does fix:
- Non-default Tor SOCKS port (was silently broken since the feature was added)
- DNS leak when onion-only auto-configuring via `-listenonion`
- DNS seed retrieval on the 11s retry path when `peers.dat` is non-empty and `auth_cb` completes in that window

## Test plan
- [ ] Build with `cmake`/`ninja` — confirms compiles
- [ ] Run with default Tor (SocksPort 9050): `-debug=tor` log shows `tor: Get SOCKS port yielded 127.0.0.1:9050` and `tor: Configuring onion proxy for 127.0.0.1:9050`
- [ ] Run with Tor on a custom port (set `SocksPort 9150` in torrc): log shows discovered port 9150; outbound `.onion` connections succeed
- [ ] Run with `-onlynet=onion -listenonion=1`: after auth completes, `getnetworkinfo` shows onion reachable and DNS-seed log does not show "Skipping DNS seed ... no clearnet network reachable" on subsequent retries
- [ ] Run with `-proxy=127.0.0.1:1080 -listenonion=1`: confirm `HaveNameProxy()` still points to the `-proxy` address (not overridden)
- [ ] Restart Tor daemon during operation: confirm `auth_cb` re-discovers port, peer connectivity resumes
- [ ] Run with Tor returning broken listener response (simulated): fallback to `127.0.0.1:9050` applies; no crash


___

## **CodeAnt-AI Description**
**Discover Tor's SOCKS port before setting up onion traffic**

### What Changed
- The app now asks Tor which SOCKS port it is using instead of assuming `127.0.0.1:9050`, so onion connections work with non-default Tor setups.
- If Tor reports a local SOCKS listener, that address is used; if Tor gives no usable answer, it falls back to `127.0.0.1:9050`.
- When clearnet access is blocked and onion is the only route, hostname lookups are now sent through Tor too, avoiding leaks.
- The chainlock test was updated to wait past the re-enable point before checking chainlock behavior, so the test matches the intended transition.

### Impact
`✅ Onion connections work with Tor Browser and custom SOCKS ports`
`✅ Fewer failed onion peer connections`
`✅ Lower risk of DNS leaks when only onion networking is allowed`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=6fUB6uy6ebdSTh44hO_8SOovYdwgHJjolYEmhZQUV60&org=firoorg)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
