### PR TITLE
CI: avoid unverified remote Guix installer

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -422,39 +422,10 @@ jobs:
         run: |
           set -exo pipefail
           sudo apt-get update
-          sudo apt-get install -y wget gpg apparmor-utils ${{ matrix.is_windows && 'g++-mingw-w64-x86-64 gcc-mingw-w64-x86-64' || '' }}
-          # Disable AppArmor to prevent Guix installer conflict
-          sudo systemctl stop apparmor || true
-          sudo systemctl disable apparmor || true
-          sudo aa-teardown || true
-          sudo aa-complain unprivileged_userns || true
-          # Remove apparmor_parser so Guix installer skips AppArmor setup
-          sudo apt-get remove -y apparmor || true
-          # Pre-import Guix signing keys into root's keyring (installer runs as sudo), sometimes guix script fail to fetch keys from ftpmirror.gnu.org
-          export VER=1.5.0
-          export ARCH=x86_64-linux
-          export BASE=https://ftp.gnu.org/gnu/guix
-          export TAR="guix-binary-${VER}.${ARCH}.tar.xz"
-          # --- verify the signature, but never abort the job ---
-          if gpg --verify "${TAR}.sig" "${TAR}" &> /dev/null
-          then
-              echo "GPG verification succeeded."
-          else
-              echo "GPG verification failed – continuing anyway."
-          fi
-          cd /tmp
-          wget -q "${BASE}/${TAR}" -O "${TAR}"
-          wget -q "${BASE}/${TAR}.sig" -O "${TAR}.sig"
-          wget -q https://git.savannah.gnu.org/cgit/guix.git/plain/etc/guix-install.sh -O guix-install.sh
-          chmod +x guix-install.sh
-          # Disable pipefail strictly for this command so 'yes' crashing doesn't fail the build
-          set +o pipefail
-          yes '' 2>/dev/null | sudo env GUIX_BINARY_FILE_NAME="/tmp/${TAR}" ./guix-install.sh # Tell installer to use your already-verified tarball
-          set -o pipefail
-          echo "Guix install script completed"
-          source /etc/profile.d/zzz-guix.sh
-          # Verify installation using absolute path
-          /usr/local/bin/guix --version
+          sudo apt-get install -y guix apparmor-utils ${{ matrix.is_windows && 'g++-mingw-w64-x86-64 gcc-mingw-w64-x86-64' || '' }}
+          # Verify installation
+          command -v guix
+          guix --version
           guix pull --url=https://codeberg.org/guix/guix-mirror --substitute-urls="http://git.savannah.gnu.org/git/guix.git http://hydra-guix-129.guix.gnu.org http://ci.guix.gnu.org"
       - name: Clean Guix build dirs
         if: matrix.is_darwin


### PR DESCRIPTION
### Motivation
- Remediate a CI supply-chain risk where the workflow downloaded and executed an unverified `guix-install.sh` script as root, enabling arbitrary code execution if the upstream host or transport were compromised.

### Description
- Replaced the installer download-and-execute flow with a package-managed install via `sudo apt-get install -y guix`, removing the unverified `wget`/`sudo ./guix-install.sh` path.
- Removed the related key import, tarball download, signature-check-without-failure, AppArmor teardown, and `yes | sudo ./guix-install.sh` plumbing to eliminate the attack surface.
- Kept post-install checks and behavior by verifying `guix` is present with `command -v guix` and `guix --version`, and preserved the existing `guix pull` step to retain CI intent.

### Testing
- Inspected the modified section with `sed -n '380,500p' .github/workflows/ci-master.yml` to confirm the unverified installer and key import code was removed, which succeeded.
- Verified the produced diff with `git diff -- .github/workflows/ci-master.yml` and ensured there are no whitespace problems with `git diff --check`, both of which succeeded.
- Applied the patch successfully (update recorded) and committed the change with message `CI: avoid unverified remote Guix installer` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d56691e2f4832fbde777eb45ccd073)