### PR TITLE
CI: cryptographically verify Guix installer end-to-end

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -435,36 +435,45 @@ jobs:
           export ARCH=x86_64-linux
           export BASE=https://ftp.gnu.org/gnu/guix
           export TAR="guix-binary-${VER}.${ARCH}.tar.xz"
-          # Trust anchor: fingerprint of Ludovic Courtès' key, the official
-          # Guix release-signing key (https://guix.gnu.org/manual/en/html_node/Binary-Installation.html).
-          export GUIX_KEY_FPR=3CE464558A84FDC69DB40CFB090B11993D9AEBB5
+          # Trust anchors: the three Guix release-signing fingerprints
+          # declared upstream in etc/guix-install.sh's GPG_SIGNING_KEYS:
+          #   civodul (Ludovic Courtès), apteryx (Maxim Cournoyer),
+          #   efraim  (Efraim Flashner).
+          # Any one of them is sufficient to sign a release tarball
+          # (v1.5.0 was signed by efraim).
+          export GUIX_KEY_FPRS=(
+            3CE464558A84FDC69DB40CFB090B11993D9AEBB5
+            27D586A4F8900854329FF09F1260E46482E63562
+            A28BF40C3E551372662D14F741AAE7DCCA3D8351
+          )
+          export GUIX_FPR_REGEX="$(IFS='|'; echo "${GUIX_KEY_FPRS[*]}")"
 
           cd /tmp
 
-          # 1. Fetch the Guix maintainer key into an isolated keyring. Try
+          # 1. Fetch the Guix maintainer keys into an isolated keyring. Try
           #    multiple keyservers so a single one being unreachable doesn't
-          #    abort the build, then require the imported fingerprint to
-          #    match the pinned value (blocking).
-          echo "::group::Import Guix maintainer key"
+          #    abort the build, then require every pinned fingerprint to
+          #    end up present in the keyring (blocking).
+          echo "::group::Import Guix maintainer keys"
           export GNUPGHOME=$(mktemp -d)
           chmod 700 "${GNUPGHOME}"
-          imported=0
-          for ks in hkps://keys.openpgp.org hkps://keyserver.ubuntu.com hkps://pgp.mit.edu; do
-            if gpg --batch --keyserver "${ks}" --recv-keys "${GUIX_KEY_FPR}"; then
-              imported=1
-              break
+          for fpr in "${GUIX_KEY_FPRS[@]}"; do
+            imported=0
+            for ks in hkps://keys.openpgp.org hkps://keyserver.ubuntu.com hkps://pgp.mit.edu; do
+              if gpg --batch --keyserver "${ks}" --recv-keys "${fpr}"; then
+                imported=1
+                break
+              fi
+              echo "Keyserver ${ks} failed for ${fpr}, trying next..."
+            done
+            if [ "${imported}" -ne 1 ]; then
+              echo "All keyservers failed for ${fpr}"
+              exit 1
             fi
-            echo "Keyserver ${ks} failed, trying next..."
+            # Confirm the pinned fingerprint is present in the keyring.
+            gpg --list-keys --with-colons "${fpr}" \
+              | awk -F: '$1=="fpr"{print $10}' | grep -qx "${fpr}"
           done
-          if [ "${imported}" -ne 1 ]; then
-            echo "All keyservers failed; falling back to Savannah viewgpg.php"
-            wget --tries=5 --timeout=30 --waitretry=10 \
-              "https://sv.gnu.org/people/viewgpg.php?user_id=15145" -O guix-key.asc
-            gpg --batch --import guix-key.asc
-          fi
-          # Confirm the pinned fingerprint is present in the keyring.
-          gpg --list-keys --with-colons "${GUIX_KEY_FPR}" \
-            | awk -F: '$1=="fpr"{print $10}' | grep -qx "${GUIX_KEY_FPR}"
           echo "::endgroup::"
 
           # 2. Download the binary tarball and its detached signature.
@@ -473,12 +482,15 @@ jobs:
           wget --tries=5 --timeout=30 --waitretry=10 "${BASE}/${TAR}.sig" -O "${TAR}.sig"
           echo "::endgroup::"
 
-          # 3. Verify the tarball signature against the pinned key (blocking).
-          #    Match the VALIDSIG status line so a signature from an unrelated
-          #    key cannot pass.
+          # 3. Verify the tarball signature against the pinned keys (blocking).
+          #    The keyring contains ONLY the three pinned trust anchors, so a
+          #    valid signature must come from one of them; the explicit
+          #    VALIDSIG fingerprint match is a belt-and-suspenders check that
+          #    also documents which key signed this release.
           echo "::group::Verify tarball signature"
           gpg --status-fd 1 --verify "${TAR}.sig" "${TAR}" > gpg-status.txt
-          grep -qE "^\[GNUPG:\] VALIDSIG ${GUIX_KEY_FPR} " gpg-status.txt
+          cat gpg-status.txt
+          grep -qE "^\[GNUPG:\] VALIDSIG (${GUIX_FPR_REGEX}) " gpg-status.txt
           echo "::endgroup::"
 
           # 4. Fetch the Guix installer pinned to the v${VER} release tag.

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -430,27 +430,55 @@ jobs:
           sudo aa-complain unprivileged_userns || true
           # Remove apparmor_parser so Guix installer skips AppArmor setup
           sudo apt-get remove -y apparmor || true
-          # Pre-import Guix signing keys into root's keyring (installer runs as sudo), sometimes guix script fail to fetch keys from ftpmirror.gnu.org
+
           export VER=1.5.0
           export ARCH=x86_64-linux
           export BASE=https://ftp.gnu.org/gnu/guix
           export TAR="guix-binary-${VER}.${ARCH}.tar.xz"
-          # --- verify the signature, but never abort the job ---
-          if gpg --verify "${TAR}.sig" "${TAR}" &> /dev/null
-          then
-              echo "GPG verification succeeded."
-          else
-              echo "GPG verification failed – continuing anyway."
-          fi
+          # Trust anchor: fingerprint of Ludovic Courtès' key, the official
+          # Guix release-signing key (https://guix.gnu.org/manual/en/html_node/Binary-Installation.html).
+          export GUIX_KEY_FPR=3CE464558A84FDC69DB40CFB090B11993D9AEBB5
+
           cd /tmp
+
+          # 1. Fetch the Guix maintainer key into an isolated keyring and
+          #    require its fingerprint to match the pinned value (blocking).
+          export GNUPGHOME=$(mktemp -d)
+          wget -q --tries=5 --timeout=30 --waitretry=10 \
+            "https://sv.gnu.org/people/viewgpg.php?user_id=15145" -O guix-key.asc
+          gpg --import guix-key.asc
+          gpg --list-keys --with-colons "${GUIX_KEY_FPR}" \
+            | awk -F: '$1=="fpr"{print $10}' | grep -qx "${GUIX_KEY_FPR}"
+
+          # 2. Download the binary tarball and its detached signature.
           wget -q --tries=5 --timeout=30 --waitretry=10 "${BASE}/${TAR}" -O "${TAR}"
           wget -q --tries=5 --timeout=30 --waitretry=10 "${BASE}/${TAR}.sig" -O "${TAR}.sig"
-          wget -q --tries=5 --timeout=30 --waitretry=10 https://git.savannah.gnu.org/cgit/guix.git/plain/etc/guix-install.sh -O guix-install.sh \
-            || wget -q --tries=5 --timeout=30 --waitretry=10 https://codeberg.org/guix/guix-mirror/raw/branch/master/etc/guix-install.sh -O guix-install.sh
+
+          # 3. Verify the tarball signature against the pinned key (blocking).
+          #    Match VALIDSIG line so a signature from an unrelated subkey
+          #    won't slip through.
+          gpg --status-fd 1 --verify "${TAR}.sig" "${TAR}" \
+            | grep -qE "^\[GNUPG:\] VALIDSIG ${GUIX_KEY_FPR} "
+
+          # 4. Fetch guix-install.sh from two independent mirrors at the v${VER}
+          #    tag and require the hashes to match. A single mirror compromise
+          #    is not sufficient to substitute a malicious installer.
+          wget -q --tries=5 --timeout=30 --waitretry=10 \
+            "https://git.savannah.gnu.org/cgit/guix.git/plain/etc/guix-install.sh?h=v${VER}" \
+            -O guix-install.sh.savannah
+          wget -q --tries=5 --timeout=30 --waitretry=10 \
+            "https://codeberg.org/guix/guix-mirror/raw/tag/v${VER}/etc/guix-install.sh" \
+            -O guix-install.sh.codeberg
+          sha_savannah=$(sha256sum guix-install.sh.savannah | awk '{print $1}')
+          sha_codeberg=$(sha256sum guix-install.sh.codeberg | awk '{print $1}')
+          [ "${sha_savannah}" = "${sha_codeberg}" ]
+          cp guix-install.sh.savannah guix-install.sh
           chmod +x guix-install.sh
+
+          # 5. Run the installer with the cryptographically verified tarball.
           # Disable pipefail strictly for this command so 'yes' crashing doesn't fail the build
           set +o pipefail
-          yes '' 2>/dev/null | sudo env GUIX_BINARY_FILE_NAME="/tmp/${TAR}" ./guix-install.sh # Tell installer to use your already-verified tarball
+          yes '' 2>/dev/null | sudo env GUIX_BINARY_FILE_NAME="/tmp/${TAR}" ./guix-install.sh
           set -o pipefail
           echo "Guix install script completed"
           source /etc/profile.d/zzz-guix.sh

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -435,44 +435,41 @@ jobs:
           export ARCH=x86_64-linux
           export BASE=https://ftp.gnu.org/gnu/guix
           export TAR="guix-binary-${VER}.${ARCH}.tar.xz"
+          export GUIX_INSTALLER_SHA256=7f544e48c9082baf489207ac506acd78bf251355bbafffd744498e658880879d
+          export GUIX_TAR_SHA256=aa41025489c5061543e9c48873eaa829b900b2da75d40f9648913622f5f47817
+
+          # Keep these trust anchors explicit and reviewed. This set matches
+          # the release-signing keys trusted by the Guix 1.5.0 installer, so
+          # the release can be signed by a different Guix maintainer without
+          # letting a downloaded script decide our trust policy.
+          GUIX_KEY_FPRS=(
+            3CE464558A84FDC69DB40CFB090B11993D9AEBB5
+            27D586A4F8900854329FF09F1260E46482E63562
+            A28BF40C3E551372662D14F741AAE7DCCA3D8351
+          )
+          GUIX_FPR_REGEX="$(IFS='|'; echo "${GUIX_KEY_FPRS[*]}")"
 
           cd /tmp
 
-          # 1. Fetch the Guix installer pinned to the v${VER} release tag.
-          #    The tag is an immutable upstream ref, so even if Savannah is
-          #    transiently compromised at the TLS layer, the tagged content
-          #    cannot be silently rewritten without notice. We trust this
-          #    file as the source of truth for which keys may sign a
-          #    release at this version.
-          echo "::group::Fetch guix-install.sh at v${VER}"
+          # 1. Download and pin-check all unsigned inputs before use.
+          echo "::group::Download Guix installer and binary tarball"
           wget --tries=5 --timeout=30 --waitretry=10 \
             "https://git.savannah.gnu.org/cgit/guix.git/plain/etc/guix-install.sh?h=v${VER}" \
             -O guix-install.sh
+          echo "${GUIX_INSTALLER_SHA256}  guix-install.sh" | sha256sum -c -
           chmod +x guix-install.sh
+
+          wget --tries=5 --timeout=30 --waitretry=10 "${BASE}/${TAR}" -O "${TAR}"
+          echo "${GUIX_TAR_SHA256}  ${TAR}" | sha256sum -c -
+          wget --tries=5 --timeout=30 --waitretry=10 "${BASE}/${TAR}.sig" -O "${TAR}.sig"
           echo "::endgroup::"
 
-          # 2. Extract the trusted release-signer fingerprints declared in
-          #    the upstream installer's GPG_SIGNING_KEYS array. Tracking
-          #    upstream's own trust list means new maintainers don't need a
-          #    workflow patch when ${VER} is bumped.
-          echo "::group::Parse trusted Guix signers from installer"
-          mapfile -t GUIX_KEY_FPRS < <(grep -oE 'GPG_SIGNING_KEYS\[[^]]+\]=[A-Fa-f0-9]{40}' guix-install.sh \
-            | grep -oE '[A-Fa-f0-9]{40}' | tr a-f A-F | sort -u)
-          if [ "${#GUIX_KEY_FPRS[@]}" -eq 0 ]; then
-            echo "Failed to parse any GPG_SIGNING_KEYS fingerprints from guix-install.sh"
-            exit 1
-          fi
-          echo "Trusted fingerprints for v${VER}:"
-          printf '  %s\n' "${GUIX_KEY_FPRS[@]}"
-          GUIX_FPR_REGEX="$(IFS='|'; echo "${GUIX_KEY_FPRS[*]}")"
-          echo "::endgroup::"
-
-          # 3. Best-effort import each trusted key into an isolated keyring.
+          # 2. Best-effort import each trusted key into an isolated keyring.
           #    Some maintainers may not have published their key to every
           #    keyserver (or to any keyserver at all), so we don't fail on
-          #    individual misses — we only fail later if NONE of the imported
+          #    individual misses. We only fail later if NONE of the imported
           #    keys can verify the actual tarball signature. The trust set
-          #    is still bounded by the parsed pinned list: VALIDSIG must
+          #    is still bounded by the pinned list: VALIDSIG must
           #    name a fingerprint from GUIX_FPR_REGEX, regardless of which
           #    keys were imported.
           echo "::group::Import trusted Guix maintainer keys"
@@ -499,24 +496,21 @@ jobs:
           echo "Imported ${imported_count}/${#GUIX_KEY_FPRS[@]} trusted keys"
           echo "::endgroup::"
 
-          # 4. Download the binary tarball and its detached signature.
-          echo "::group::Download Guix binary tarball"
-          wget --tries=5 --timeout=30 --waitretry=10 "${BASE}/${TAR}" -O "${TAR}"
-          wget --tries=5 --timeout=30 --waitretry=10 "${BASE}/${TAR}.sig" -O "${TAR}.sig"
-          echo "::endgroup::"
-
-          # 5. Verify the tarball signature against the trusted keys (blocking).
-          #    The keyring contains ONLY the parsed trust anchors, so a valid
+          # 3. Verify the tarball signature against the trusted keys (blocking).
+          #    The keyring contains ONLY the pinned trust anchors, so a valid
           #    signature must come from one of them; the explicit VALIDSIG
-          #    fingerprint match is a belt-and-suspenders check that also
-          #    documents which key signed this release in the build log.
+          #    fingerprint match also documents which key signed this release.
           echo "::group::Verify tarball signature"
           gpg --status-fd 1 --verify "${TAR}.sig" "${TAR}" > gpg-status.txt
           cat gpg-status.txt
-          grep -qE "^\[GNUPG:\] VALIDSIG (${GUIX_FPR_REGEX}) " gpg-status.txt
+          awk -v allowed="${GUIX_FPR_REGEX}" '
+            $1 == "[GNUPG:]" && $2 == "VALIDSIG" &&
+              ($3 ~ "^(" allowed ")$" || $NF ~ "^(" allowed ")$") { found=1 }
+            END { exit found ? 0 : 1 }
+          ' gpg-status.txt
           echo "::endgroup::"
 
-          # 5. Run the installer with the cryptographically verified tarball.
+          # 4. Run the pinned installer with the cryptographically verified tarball.
           # Disable pipefail strictly for this command so 'yes' crashing doesn't fail the build
           set +o pipefail
           yes '' 2>/dev/null | sudo env GUIX_BINARY_FILE_NAME="/tmp/${TAR}" ./guix-install.sh

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -441,39 +441,56 @@ jobs:
 
           cd /tmp
 
-          # 1. Fetch the Guix maintainer key into an isolated keyring and
-          #    require its fingerprint to match the pinned value (blocking).
+          # 1. Fetch the Guix maintainer key into an isolated keyring. Try
+          #    multiple keyservers so a single one being unreachable doesn't
+          #    abort the build, then require the imported fingerprint to
+          #    match the pinned value (blocking).
+          echo "::group::Import Guix maintainer key"
           export GNUPGHOME=$(mktemp -d)
-          wget -q --tries=5 --timeout=30 --waitretry=10 \
-            "https://sv.gnu.org/people/viewgpg.php?user_id=15145" -O guix-key.asc
-          gpg --import guix-key.asc
+          chmod 700 "${GNUPGHOME}"
+          imported=0
+          for ks in hkps://keys.openpgp.org hkps://keyserver.ubuntu.com hkps://pgp.mit.edu; do
+            if gpg --batch --keyserver "${ks}" --recv-keys "${GUIX_KEY_FPR}"; then
+              imported=1
+              break
+            fi
+            echo "Keyserver ${ks} failed, trying next..."
+          done
+          if [ "${imported}" -ne 1 ]; then
+            echo "All keyservers failed; falling back to Savannah viewgpg.php"
+            wget --tries=5 --timeout=30 --waitretry=10 \
+              "https://sv.gnu.org/people/viewgpg.php?user_id=15145" -O guix-key.asc
+            gpg --batch --import guix-key.asc
+          fi
+          # Confirm the pinned fingerprint is present in the keyring.
           gpg --list-keys --with-colons "${GUIX_KEY_FPR}" \
             | awk -F: '$1=="fpr"{print $10}' | grep -qx "${GUIX_KEY_FPR}"
+          echo "::endgroup::"
 
           # 2. Download the binary tarball and its detached signature.
-          wget -q --tries=5 --timeout=30 --waitretry=10 "${BASE}/${TAR}" -O "${TAR}"
-          wget -q --tries=5 --timeout=30 --waitretry=10 "${BASE}/${TAR}.sig" -O "${TAR}.sig"
+          echo "::group::Download Guix binary tarball"
+          wget --tries=5 --timeout=30 --waitretry=10 "${BASE}/${TAR}" -O "${TAR}"
+          wget --tries=5 --timeout=30 --waitretry=10 "${BASE}/${TAR}.sig" -O "${TAR}.sig"
+          echo "::endgroup::"
 
           # 3. Verify the tarball signature against the pinned key (blocking).
-          #    Match VALIDSIG line so a signature from an unrelated subkey
-          #    won't slip through.
-          gpg --status-fd 1 --verify "${TAR}.sig" "${TAR}" \
-            | grep -qE "^\[GNUPG:\] VALIDSIG ${GUIX_KEY_FPR} "
+          #    Match the VALIDSIG status line so a signature from an unrelated
+          #    key cannot pass.
+          echo "::group::Verify tarball signature"
+          gpg --status-fd 1 --verify "${TAR}.sig" "${TAR}" > gpg-status.txt
+          grep -qE "^\[GNUPG:\] VALIDSIG ${GUIX_KEY_FPR} " gpg-status.txt
+          echo "::endgroup::"
 
-          # 4. Fetch guix-install.sh from two independent mirrors at the v${VER}
-          #    tag and require the hashes to match. A single mirror compromise
-          #    is not sufficient to substitute a malicious installer.
-          wget -q --tries=5 --timeout=30 --waitretry=10 \
+          # 4. Fetch the Guix installer pinned to the v${VER} release tag.
+          #    The tag is an immutable upstream ref, so even if Savannah is
+          #    transiently compromised at the TLS layer, the tagged content
+          #    cannot be silently rewritten without notice.
+          echo "::group::Fetch guix-install.sh at v${VER}"
+          wget --tries=5 --timeout=30 --waitretry=10 \
             "https://git.savannah.gnu.org/cgit/guix.git/plain/etc/guix-install.sh?h=v${VER}" \
-            -O guix-install.sh.savannah
-          wget -q --tries=5 --timeout=30 --waitretry=10 \
-            "https://codeberg.org/guix/guix-mirror/raw/tag/v${VER}/etc/guix-install.sh" \
-            -O guix-install.sh.codeberg
-          sha_savannah=$(sha256sum guix-install.sh.savannah | awk '{print $1}')
-          sha_codeberg=$(sha256sum guix-install.sh.codeberg | awk '{print $1}')
-          [ "${sha_savannah}" = "${sha_codeberg}" ]
-          cp guix-install.sh.savannah guix-install.sh
+            -O guix-install.sh
           chmod +x guix-install.sh
+          echo "::endgroup::"
 
           # 5. Run the installer with the cryptographically verified tarball.
           # Disable pipefail strictly for this command so 'yes' crashing doesn't fail the build

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -435,73 +435,85 @@ jobs:
           export ARCH=x86_64-linux
           export BASE=https://ftp.gnu.org/gnu/guix
           export TAR="guix-binary-${VER}.${ARCH}.tar.xz"
-          # Trust anchors: the three Guix release-signing fingerprints
-          # declared upstream in etc/guix-install.sh's GPG_SIGNING_KEYS:
-          #   civodul (Ludovic Courtès), apteryx (Maxim Cournoyer),
-          #   efraim  (Efraim Flashner).
-          # Any one of them is sufficient to sign a release tarball
-          # (v1.5.0 was signed by efraim).
-          export GUIX_KEY_FPRS=(
-            3CE464558A84FDC69DB40CFB090B11993D9AEBB5
-            27D586A4F8900854329FF09F1260E46482E63562
-            A28BF40C3E551372662D14F741AAE7DCCA3D8351
-          )
-          export GUIX_FPR_REGEX="$(IFS='|'; echo "${GUIX_KEY_FPRS[*]}")"
 
           cd /tmp
 
-          # 1. Fetch the Guix maintainer keys into an isolated keyring. Try
-          #    multiple keyservers so a single one being unreachable doesn't
-          #    abort the build, then require every pinned fingerprint to
-          #    end up present in the keyring (blocking).
-          echo "::group::Import Guix maintainer keys"
-          export GNUPGHOME=$(mktemp -d)
-          chmod 700 "${GNUPGHOME}"
-          for fpr in "${GUIX_KEY_FPRS[@]}"; do
-            imported=0
-            for ks in hkps://keys.openpgp.org hkps://keyserver.ubuntu.com hkps://pgp.mit.edu; do
-              if gpg --batch --keyserver "${ks}" --recv-keys "${fpr}"; then
-                imported=1
-                break
-              fi
-              echo "Keyserver ${ks} failed for ${fpr}, trying next..."
-            done
-            if [ "${imported}" -ne 1 ]; then
-              echo "All keyservers failed for ${fpr}"
-              exit 1
-            fi
-            # Confirm the pinned fingerprint is present in the keyring.
-            gpg --list-keys --with-colons "${fpr}" \
-              | awk -F: '$1=="fpr"{print $10}' | grep -qx "${fpr}"
-          done
-          echo "::endgroup::"
-
-          # 2. Download the binary tarball and its detached signature.
-          echo "::group::Download Guix binary tarball"
-          wget --tries=5 --timeout=30 --waitretry=10 "${BASE}/${TAR}" -O "${TAR}"
-          wget --tries=5 --timeout=30 --waitretry=10 "${BASE}/${TAR}.sig" -O "${TAR}.sig"
-          echo "::endgroup::"
-
-          # 3. Verify the tarball signature against the pinned keys (blocking).
-          #    The keyring contains ONLY the three pinned trust anchors, so a
-          #    valid signature must come from one of them; the explicit
-          #    VALIDSIG fingerprint match is a belt-and-suspenders check that
-          #    also documents which key signed this release.
-          echo "::group::Verify tarball signature"
-          gpg --status-fd 1 --verify "${TAR}.sig" "${TAR}" > gpg-status.txt
-          cat gpg-status.txt
-          grep -qE "^\[GNUPG:\] VALIDSIG (${GUIX_FPR_REGEX}) " gpg-status.txt
-          echo "::endgroup::"
-
-          # 4. Fetch the Guix installer pinned to the v${VER} release tag.
+          # 1. Fetch the Guix installer pinned to the v${VER} release tag.
           #    The tag is an immutable upstream ref, so even if Savannah is
           #    transiently compromised at the TLS layer, the tagged content
-          #    cannot be silently rewritten without notice.
+          #    cannot be silently rewritten without notice. We trust this
+          #    file as the source of truth for which keys may sign a
+          #    release at this version.
           echo "::group::Fetch guix-install.sh at v${VER}"
           wget --tries=5 --timeout=30 --waitretry=10 \
             "https://git.savannah.gnu.org/cgit/guix.git/plain/etc/guix-install.sh?h=v${VER}" \
             -O guix-install.sh
           chmod +x guix-install.sh
+          echo "::endgroup::"
+
+          # 2. Extract the trusted release-signer fingerprints declared in
+          #    the upstream installer's GPG_SIGNING_KEYS array. Tracking
+          #    upstream's own trust list means new maintainers don't need a
+          #    workflow patch when ${VER} is bumped.
+          echo "::group::Parse trusted Guix signers from installer"
+          mapfile -t GUIX_KEY_FPRS < <(grep -oE 'GPG_SIGNING_KEYS\[[^]]+\]=[A-Fa-f0-9]{40}' guix-install.sh \
+            | grep -oE '[A-Fa-f0-9]{40}' | tr a-f A-F | sort -u)
+          if [ "${#GUIX_KEY_FPRS[@]}" -eq 0 ]; then
+            echo "Failed to parse any GPG_SIGNING_KEYS fingerprints from guix-install.sh"
+            exit 1
+          fi
+          echo "Trusted fingerprints for v${VER}:"
+          printf '  %s\n' "${GUIX_KEY_FPRS[@]}"
+          GUIX_FPR_REGEX="$(IFS='|'; echo "${GUIX_KEY_FPRS[*]}")"
+          echo "::endgroup::"
+
+          # 3. Best-effort import each trusted key into an isolated keyring.
+          #    Some maintainers may not have published their key to every
+          #    keyserver (or to any keyserver at all), so we don't fail on
+          #    individual misses — we only fail later if NONE of the imported
+          #    keys can verify the actual tarball signature. The trust set
+          #    is still bounded by the parsed pinned list: VALIDSIG must
+          #    name a fingerprint from GUIX_FPR_REGEX, regardless of which
+          #    keys were imported.
+          echo "::group::Import trusted Guix maintainer keys"
+          export GNUPGHOME=$(mktemp -d)
+          chmod 700 "${GNUPGHOME}"
+          imported_count=0
+          for fpr in "${GUIX_KEY_FPRS[@]}"; do
+            for ks in hkps://keys.openpgp.org hkps://keyserver.ubuntu.com hkps://pgp.mit.edu; do
+              if gpg --batch --keyserver "${ks}" --recv-keys "${fpr}"; then
+                # Confirm the imported key actually has the expected fingerprint.
+                if gpg --list-keys --with-colons "${fpr}" \
+                    | awk -F: '$1=="fpr"{print $10}' | grep -qx "${fpr}"; then
+                  imported_count=$((imported_count + 1))
+                  break
+                fi
+              fi
+              echo "Keyserver ${ks} failed for ${fpr}, trying next..."
+            done
+          done
+          if [ "${imported_count}" -eq 0 ]; then
+            echo "Could not import any trusted Guix signing key from any keyserver"
+            exit 1
+          fi
+          echo "Imported ${imported_count}/${#GUIX_KEY_FPRS[@]} trusted keys"
+          echo "::endgroup::"
+
+          # 4. Download the binary tarball and its detached signature.
+          echo "::group::Download Guix binary tarball"
+          wget --tries=5 --timeout=30 --waitretry=10 "${BASE}/${TAR}" -O "${TAR}"
+          wget --tries=5 --timeout=30 --waitretry=10 "${BASE}/${TAR}.sig" -O "${TAR}.sig"
+          echo "::endgroup::"
+
+          # 5. Verify the tarball signature against the trusted keys (blocking).
+          #    The keyring contains ONLY the parsed trust anchors, so a valid
+          #    signature must come from one of them; the explicit VALIDSIG
+          #    fingerprint match is a belt-and-suspenders check that also
+          #    documents which key signed this release in the build log.
+          echo "::group::Verify tarball signature"
+          gpg --status-fd 1 --verify "${TAR}.sig" "${TAR}" > gpg-status.txt
+          cat gpg-status.txt
+          grep -qE "^\[GNUPG:\] VALIDSIG (${GUIX_FPR_REGEX}) " gpg-status.txt
           echo "::endgroup::"
 
           # 5. Run the installer with the cryptographically verified tarball.


### PR DESCRIPTION
## **User description**
## Motivation

The "Install Guix" step in `.github/workflows/ci-master.yml` was executing the Guix binary tarball as root with no working signature verification. Two compounding bugs caused this:

1. **Wrong order.** `gpg --verify "${TAR}.sig" "${TAR}"` ran *before* the `wget` calls that downloaded those files, so the check operated on non-existent paths. The error was redirected to `/dev/null`, hiding the failure.
2. **Non-blocking.** Even if the order had been correct, the `if/else` printed `"GPG verification failed - continuing anyway."` and proceeded to `sudo ./guix-install.sh` regardless.

The pre-existing comment claimed Guix signing keys were pre-imported into root's keyring, but no code performed that step. The keyring was empty, so verification could not have succeeded under any timing.

The same concern motivated #1824, which proposed switching to `apt-get install -y guix`. That approach trades one problem for a worse one: Ubuntu 22.04 ships Guix **1.2.0** while CI pins **1.5.0**. Because Firo uses Guix specifically to produce bit-for-bit reproducible release binaries (`contrib/guix/README.md`), changing the base Guix version risks desynchronising the build environment from existing `guix.sigs` attestations. This PR keeps Guix 1.5.0 and fixes the verification logic instead.

## Description

Establish a blocking trust chain for Guix 1.5.0 while keeping the trust inputs reviewed in the workflow:

- **Installer script.** Fetch `guix-install.sh` from the `v1.5.0` tag and require its reviewed SHA256 before making it executable or running it with `sudo`.
- **Release signing keys.** Use an explicit pinned set of Guix release-signing fingerprints from the Guix 1.5.0 installer (`civodul`, `apteryx`, and `efraim`) instead of deriving trust anchors from a downloaded script. This still allows the release artifact to be signed by a different trusted Guix maintainer.
- **Binary tarball.** Require the reviewed SHA256 for `guix-binary-1.5.0.x86_64-linux.tar.xz`, then verify its detached GPG signature in an isolated `GNUPGHOME`. The `VALIDSIG` status line must match one of the pinned primary/signing fingerprints.

`set -exo pipefail` is already in effect, so any failed download, hash check, key import, or signature check aborts the job.

## What's preserved

- `VER=1.5.0` - reproducible-build output hashes remain comparable to existing `guix.sigs` attestations.
- AppArmor teardown - Ubuntu's AppArmor still conflicts with the upstream installer.
- `wget`, `gpg`, `apparmor-utils` apt packages - all still required.
- `guix pull` step with the same substitute URLs.
- Trailing newline at EOF.

## Testing

End-to-end verification requires the live `guix-build` matrix in `ci-master.yml`; it exercises this exact step on `ubuntu-22.04` across the five platform configurations.

Local checks performed:

- `git diff --check`
- `bash -n` against the edited `Install Guix` shell block after replacing GitHub expressions

The previous head commit passed all five GitHub Actions `guix-*` jobs; this commit keeps the install path intact while tightening the trust inputs.

refs #1824


___

## **CodeAnt-AI Description**
**Require verified Guix downloads before CI installs it**

### What Changed
- CI now stops on failed Guix signature checks instead of continuing with an unverified installer
- The Guix installer and binary tarball are both checked against pinned SHA-256 values before use
- Guix release signatures are verified against a fixed set of trusted maintainer keys before the tarball is installed
- The workflow still installs the same Guix version and keeps the existing build setup unchanged

### Impact
`✅ Fewer unsafe CI installs`
`✅ Lower risk of tampered Guix downloads`
`✅ Clearer release verification in CI`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=tilkQaATE26GpCb8Qzz_HtFMZJqYmFFbxhKdt2CImLc&org=firoorg)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
