### PR TITLE
Tests: avoid llmq chainlock reactivation race

### DIFF
--- a/qa/rpc-tests/llmq-cl-evospork.py
+++ b/qa/rpc-tests/llmq-cl-evospork.py
@@ -58,7 +58,8 @@ class LLMQChainLocksTest(EvoZnodeTestFramework):
         ##### Disable chainlocks for 10 blocks
 
         self.nodes[0].importprivkey(self.sporkprivkey)
-        self.disable_chainlocks(self.nodes[0].getblockcount() + 10)
+        reenable_height = self.nodes[0].getblockcount() + 10
+        self.disable_chainlocks(reenable_height)
         self.nodes[0].generate(1)
         assert(False == self.nodes[0].getblock(self.nodes[0].getbestblockhash())["chainlock"])
 
@@ -70,14 +71,19 @@ class LLMQChainLocksTest(EvoZnodeTestFramework):
 
         ##### Enable chainlocks
 
-        self.nodes[0].generate(10)
-        self.nodes[0].spork('list')
         connected_nodes = [n for n in self.nodes if n != self.nodes[5]]
+
+        # Mine up to the re-enable height, then use the next block for
+        # chainlock assertions to avoid the reactivation transition edge.
+        self.nodes[0].generate(reenable_height - self.nodes[0].getblockcount())
         sync_blocks(connected_nodes, timeout=120)
-        self.wait_for_chainlock_tip(connected_nodes, self.nodes[0].getbestblockhash(), timeout=90)
         sporks = self.nodes[0].spork("list")
         assert(not sporks["blockchain"])
         assert(not sporks["mempool"])
+
+        self.nodes[0].generate(1)
+        sync_blocks(connected_nodes, timeout=120)
+        self.wait_for_chainlock_tip(connected_nodes, self.nodes[0].getbestblockhash(), timeout=90)
         assert(True == self.nodes[0].getblock(self.nodes[0].getbestblockhash())["chainlock"])
         chainlocked_tip = self.nodes[0].getbestblockhash()
 


### PR DESCRIPTION
## **User description**
## Summary
- avoid waiting for a chainlock on the exact evospork reactivation block
- mine to the re-enable height, verify the spork has expired, then assert chainlocks on the next fresh block

## Verification
- `python -m py_compile qa/rpc-tests/llmq-cl-evospork.py`
- `git diff --check -- qa/rpc-tests/llmq-cl-evospork.py`

Full RPC test not run locally; this checkout does not include built `firod` binaries.


___

## **CodeAnt-AI Description**
**Avoid a chainlock reactivation race in the evospork test**

### What Changed
- The test now waits until the chainlock re-enable height is reached, then checks chainlocks on the next newly mined block
- It still confirms that chainlocks are disabled during the spork window and return after reactivation
- This avoids checking the exact reactivation block, which could fail intermittently

### Impact
`✅ Fewer flaky RPC test failures`
`✅ More reliable chainlock reactivation checks`
`✅ Stable test runs`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=x2XEmzHYeVSkbPOQWuFun-btKCzow-iT1iaFcQ0qqOg&org=firoorg)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
