### PR TITLE
Scripts and tools: test Dockerfile on linux/amd64 and linux/arm64

### DIFF
--- a/.github/workflows/test-dockerfile.yml
+++ b/.github/workflows/test-dockerfile.yml
@@ -24,6 +24,9 @@ jobs:
       - uses: actions/checkout@v5
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:latest@sha256:d3b963f787999e6c0219a48dba02978769286ff61a5f4d26245cb6a6e5567ea3
+          platforms: arm64
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build Docker image

--- a/.github/workflows/test-dockerfile.yml
+++ b/.github/workflows/test-dockerfile.yml
@@ -1,20 +1,30 @@
- 
 name: build Dockerfile
 
 on:
   push:
     paths:
       - 'Dockerfile'
+      - 'depends/**'
+      - '.github/workflows/test-dockerfile.yml'
   pull_request:
     paths:
       - 'Dockerfile'
+      - 'depends/**'
+      - '.github/workflows/test-dockerfile.yml'
 
 jobs:
   build:
-   runs-on: ubuntu-latest
-  
-   steps:
-     - uses: actions/checkout@v5
-     - name: Build Docker image 
-       run: docker build -t firo .
-
+    name: Build Dockerfile (${{ matrix.platform }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [linux/amd64, linux/arm64]
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build Docker image
+        run: docker buildx build --platform ${{ matrix.platform }} -t firo .


### PR DESCRIPTION
## **User description**
## Summary

Extends the existing Dockerfile build test to a buildx matrix covering both `linux/amd64` and `linux/arm64`.

## Why

The Dockerfile already cross-builds for the host architecture via the `depends/` system — `uname -m` resolves to `x86_64-linux-gnu` or `aarch64-linux-gnu`, both of which are listed in the `depends/` Makefile. The single-platform CI test masks any future change that would silently break arm64 (Apple Silicon hosts, AWS Graviton, Raspberry Pi 4/5).

## Change

- `.github/workflows/test-dockerfile.yml`: matrix on `[linux/amd64, linux/arm64]`, builds via `docker buildx` on `ubuntu-latest`. arm64 leg uses QEMU.
- Path filter widened to also re-trigger when `depends/**` or the workflow file itself changes.

## Test plan

- [x] PR CI run shows both matrix entries (`linux/amd64`, `linux/arm64`) green
- [ ] Run completes within reasonable time (arm64 via QEMU is slower; can be revisited with `ubuntu-24.04-arm` runners later)


___

## **CodeAnt-AI Description**
Test the Dockerfile on both amd64 and arm64

### What Changed
- The Dockerfile check now runs for both `linux/amd64` and `linux/arm64`
- Apple Silicon, Raspberry Pi, and other arm64 builds are now covered in PR checks
- The check also runs when files under `depends/` change, not just the Dockerfile itself
- The arm64 test uses a pinned QEMU image, reducing the risk of a broken or tampered CI dependency

### Impact
`✅ Fewer arm64 build regressions`
`✅ Safer Dockerfile checks in CI`
`✅ Earlier detection of dependency-related build failures`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=J-jKK2kA-7ixihbJgojl8Hbc7MbmGAvDCG3aRRQnctQ&org=firoorg)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
