### PR TITLE
Spark name overflow fix

### DIFF
--- a/src/sparkname.cpp
+++ b/src/sparkname.cpp
@@ -209,10 +209,13 @@ bool CSparkNameManager::CheckSparkNameTx(const CTransaction &tx, int nHeight, CV
     }
 
     constexpr int nBlockPerYear = 365*24*24; // 24 blocks per hour
-    int validityBlocks = sparkNameData.sparkNameValidityBlocks;
-    if (validityBlocks == 0)
+    if (sparkNameData.sparkNameValidityBlocks == 0)
         return state.DoS(100, error("CheckSparkNameTx: validity period must be at least 1 block"));
-  
+    // Explicit uint32_t check before narrowing to int to prevent integer overflow in the update path
+    if (sparkNameData.sparkNameValidityBlocks > (uint32_t)(nBlockPerYear * 15))
+        return state.DoS(100, error("CheckSparkNameTx: can't be valid for more than 15 years"));
+    int validityBlocks = (int)sparkNameData.sparkNameValidityBlocks;
+
     if (nHeight >= consensusParams.nSparkNamesV21StartBlock) {
         if (existingExpirationHeight != -1)
             validityBlocks = std::max(validityBlocks, existingExpirationHeight - nHeight + validityBlocks);
@@ -461,12 +464,17 @@ bool CSparkNameManager::ValidateSparkNameData(const CSparkNameTxData &sparkNameD
     if (errorDescription.empty() && nHeight >= ::Params().GetConsensus().nSparkNamesV21StartBlock) {
         if (existingExpirationHeight != -1) {
             constexpr int nBlockPerYear = 365*24*24;
-            int validityBlocks = sparkNameData.sparkNameValidityBlocks;
-            int remainingBlocks = existingExpirationHeight - nHeight;
-            if (remainingBlocks > 0)
-                validityBlocks += remainingBlocks;
-            if (validityBlocks > nBlockPerYear * 15)
-                errorDescription = "total validity including remaining time can't exceed 15 years";
+            // Explicit uint32_t check before narrowing to int to prevent integer overflow in the update path
+            if (sparkNameData.sparkNameValidityBlocks > (uint32_t)(nBlockPerYear * 15)) {
+                errorDescription = "validity blocks in sparkNameData exceed 15 years limit";
+            } else {
+                int validityBlocks = (int)sparkNameData.sparkNameValidityBlocks;
+                int remainingBlocks = existingExpirationHeight - nHeight;
+                if (remainingBlocks > 0)
+                    validityBlocks += remainingBlocks;
+                if (validityBlocks > nBlockPerYear * 15)
+                    errorDescription = "total validity including remaining time can't exceed 15 years";
+            }
         }
     }
 

--- a/src/test/sparkname_tests.cpp
+++ b/src/test/sparkname_tests.cpp
@@ -772,4 +772,61 @@ BOOST_AUTO_TEST_CASE(extension_mempool_uses_next_block_height)
     BOOST_CHECK_EQUAL(sparkNameManager->GetSparkNameBlockHeight("nextheight"), originalExpiration + 1);
 }
 
+BOOST_AUTO_TEST_CASE(validity_overflow_protection)
+{
+    constexpr int nBlockPerYear = 365*24*24;
+
+    // Initialize past V2.1 (regtest V2.1 starts at 2700)
+    Initialize(2700);
+
+    std::string addr1 = GenerateSparkAddress();
+
+    // Register "overtest" with 1 year to have an existing name available for renewal
+    CMutableTransaction txReg = CreateSparkNameTx("overtest", addr1, nBlockPerYear, "", true);
+    BOOST_CHECK(lastState.IsValid());
+    GenerateBlock({txReg});
+    BOOST_CHECK(IsSparkNamePresent("overtest"));
+
+    // sparkNameValidityBlocks is uint32_t. Without the explicit uint32_t check, a value
+    // above INT_MAX narrows to a negative int, causing the 15-year cap comparison to
+    // silently pass. The tests below verify this is now rejected.
+
+    const uint32_t overflowBlocks = (uint32_t)INT_MAX + 1u; // minimal case that triggers the bug
+
+    // --- Fresh registration with sparkNameValidityBlocks = INT_MAX + 1 ---
+    std::string addr2 = GenerateSparkAddress();
+    CMutableTransaction txNewOverflow = CreateSparkNameTx("newname1", addr2, nBlockPerYear, "", false);
+    ModifySparkNameTx(txNewOverflow, [overflowBlocks](CSparkNameTxData &data) {
+        data.sparkNameValidityBlocks = overflowBlocks;
+    });
+    int oldHeight = chainActive.Height();
+    GenerateBlock({txNewOverflow});
+    BOOST_CHECK_EQUAL(chainActive.Height(), oldHeight); // block must be rejected
+
+    // --- Renewal of existing name with sparkNameValidityBlocks = INT_MAX + 1 ---
+    CMutableTransaction txUpdateOverflow = CreateSparkNameTx("overtest", addr1, nBlockPerYear, "", false);
+    ModifySparkNameTx(txUpdateOverflow, [overflowBlocks](CSparkNameTxData &data) {
+        data.sparkNameValidityBlocks = overflowBlocks;
+    });
+    oldHeight = chainActive.Height();
+    GenerateBlock({txUpdateOverflow});
+    BOOST_CHECK_EQUAL(chainActive.Height(), oldHeight); // block must be rejected
+
+    // --- UINT32_MAX variant ---
+    CMutableTransaction txMaxOverflow = CreateSparkNameTx("overtest", addr1, nBlockPerYear, "", false);
+    ModifySparkNameTx(txMaxOverflow, [](CSparkNameTxData &data) {
+        data.sparkNameValidityBlocks = UINT32_MAX;
+    });
+    oldHeight = chainActive.Height();
+    GenerateBlock({txMaxOverflow});
+    BOOST_CHECK_EQUAL(chainActive.Height(), oldHeight); // block must be rejected
+
+    // Sanity: a valid 1-year renewal still goes through after all the failed attempts
+    CMutableTransaction txValid = CreateSparkNameTx("overtest", addr1, nBlockPerYear, "ok", false);
+    oldHeight = chainActive.Height();
+    GenerateBlock({txValid});
+    BOOST_CHECK_EQUAL(chainActive.Height(), oldHeight + 1); // block must be accepted
+    BOOST_CHECK(IsSparkNamePresent("overtest"));
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## PR intention
Fixed a bug that may cause the spark name validity overflow over INT_MAX in some cases

## Code changes brief
Additional checks to test if the added number of blocks is within the bounds
