### PR TITLE
Evo: speed up early reindex merkle checks

### DIFF
--- a/qa/rpc-tests/dip3-deterministicmns.py
+++ b/qa/rpc-tests/dip3-deterministicmns.py
@@ -179,7 +179,7 @@ class DIP3Test(BitcoinTestFramework):
         for i in range(spend_mns_count):
             self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
             mns_tmp.append(mns[spend_mns_count - 1 - i])
-            self.assert_mnlist(self.nodes[0], mns_tmp)
+            self.assert_mnlist_now(self.nodes[0], mns_tmp)
 
         # self.log.info("cause a reorg with a double spend and check that mnlists are still correct on all nodes")
         # self.mine_double_spend(self.nodes[0], dummy_txins, self.nodes[0].getnewaddress(), use_mnmerkleroot_from_tip=True)
@@ -307,6 +307,16 @@ class DIP3Test(BitcoinTestFramework):
             if time.time() >= deadline:
                 break
             time.sleep(0.1)
+        expected = []
+        for mn in mns:
+            expected.append('%s, %d' % (mn.collateral_txid, mn.collateral_vout))
+        self.log.error('mnlist: ' + str(node.evoznode('list', 'status')))
+        self.log.error('expected: ' + str(expected))
+        raise AssertionError("mnlists does not match provided mns")
+
+    def assert_mnlist_now(self, node, mns):
+        if self.compare_mnlist(node, mns):
+            return
         expected = []
         for mn in mns:
             expected.append('%s, %d' % (mn.collateral_txid, mn.collateral_vout))

--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -36,10 +36,10 @@ void CDSNotificationInterface::NotifyHeaderTip(const CBlockIndex *pindexNew, boo
 
 void CDSNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload)
 {
+    deterministicMNManager->UpdatedBlockTip(pindexNew);
+
     if (pindexNew == pindexFork) // blocks were disconnected without any new ones
         return;
-
-    deterministicMNManager->UpdatedBlockTip(pindexNew);
 
     masternodeSync.UpdatedBlockTip(pindexNew, fInitialDownload, connman);
 

--- a/src/evo/cbtx.cpp
+++ b/src/evo/cbtx.cpp
@@ -15,6 +15,21 @@
 #include "univalue.h"
 #include "validation.h"
 
+static bool SimplifiedMNListsEqual(const CSimplifiedMNList& a, const CSimplifiedMNList& b)
+{
+    if (a.mnList.size() != b.mnList.size()) {
+        return false;
+    }
+
+    for (size_t i = 0; i < a.mnList.size(); ++i) {
+        if (*a.mnList[i] != *b.mnList[i]) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 bool CheckCbTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValidationState& state)
 {
     if (tx.nType != TRANSACTION_COINBASE) {
@@ -49,7 +64,7 @@ bool CheckCbTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValidatio
 }
 
 // This can only be done after the block has been fully processed, as otherwise we won't have the finished MN list
-bool CheckCbTxMerkleRoots(const CBlock& block, const CBlockIndex* pindex, CValidationState& state)
+bool CheckCbTxMerkleRoots(const CBlock& block, const CBlockIndex* pindex, CValidationState& state, const CDeterministicMNList* deterministicMNList, bool cbTxMerkleRootMNListChanged)
 {
     if (block.vtx[0]->nType != TRANSACTION_COINBASE) {
         return true;
@@ -71,8 +86,21 @@ bool CheckCbTxMerkleRoots(const CBlock& block, const CBlockIndex* pindex, CValid
 
     if (pindex) {
         uint256 calculatedMerkleRoot;
-        if (!CalcCbTxMerkleRootMNList(block, pindex->pprev, calculatedMerkleRoot, state)) {
-            return state.DoS(100, false, REJECT_INVALID, "bad-cbtx-mnmerkleroot");
+        const CDeterministicMNList* mnListForMerkleRoot = nullptr;
+        if (deterministicMNList && deterministicMNList->GetHeight() == pindex->nHeight) {
+            if (deterministicMNList->GetBlockHash() == block.GetHash()) {
+                mnListForMerkleRoot = deterministicMNList;
+            }
+        }
+
+        if (mnListForMerkleRoot) {
+            if (!CalcCbTxMerkleRootMNList(*mnListForMerkleRoot, calculatedMerkleRoot, pindex->pprev, cbTxMerkleRootMNListChanged)) {
+                return state.DoS(100, false, REJECT_INVALID, "bad-cbtx-mnmerkleroot");
+            }
+        } else {
+            if (!CalcCbTxMerkleRootMNList(block, pindex->pprev, calculatedMerkleRoot, state)) {
+                return state.DoS(100, false, REJECT_INVALID, "bad-cbtx-mnmerkleroot");
+            }
         }
         if (calculatedMerkleRoot != cbTx.merkleRootMNList) {
             return state.DoS(100, false, REJECT_INVALID, "bad-cbtx-mnmerkleroot");
@@ -103,8 +131,6 @@ bool CalcCbTxMerkleRootMNList(const CBlock& block, const CBlockIndex* pindexPrev
     LOCK(deterministicMNManager->cs);
 
     static int64_t nTimeDMN = 0;
-    static int64_t nTimeSMNL = 0;
-    static int64_t nTimeMerkle = 0;
 
     int64_t nTime1 = GetTimeMicros();
 
@@ -116,16 +142,43 @@ bool CalcCbTxMerkleRootMNList(const CBlock& block, const CBlockIndex* pindexPrev
     int64_t nTime2 = GetTimeMicros(); nTimeDMN += nTime2 - nTime1;
     LogPrint("bench", "            - BuildNewListFromBlock: %.2fms [%.2fs]\n", 0.001 * (nTime2 - nTime1), nTimeDMN * 0.000001);
 
-    CSimplifiedMNList sml(tmpMNList);
+    return CalcCbTxMerkleRootMNList(tmpMNList, merkleRootRet);
+}
 
-    int64_t nTime3 = GetTimeMicros(); nTimeSMNL += nTime3 - nTime2;
-    LogPrint("bench", "            - CSimplifiedMNList: %.2fms [%.2fs]\n", 0.001 * (nTime3 - nTime2), nTimeSMNL * 0.000001);
+bool CalcCbTxMerkleRootMNList(const CDeterministicMNList& deterministicMNList, uint256& merkleRootRet, const CBlockIndex* pindexPrev, bool cbTxMerkleRootMNListChanged)
+{
+    LOCK(deterministicMNManager->cs);
 
-    static CSimplifiedMNList smlCached;
+    static int64_t nTimeSMNL = 0;
+    static int64_t nTimeMerkle = 0;
+    static CDeterministicMNList deterministicMNListCached;
     static uint256 merkleRootCached;
     static bool mutatedCached{false};
+    static bool hasCached{false};
 
-    if (sml.mnList == smlCached.mnList) {
+    if (!cbTxMerkleRootMNListChanged && pindexPrev && hasCached && deterministicMNListCached.GetBlockHash() == pindexPrev->GetBlockHash()) {
+        deterministicMNListCached = deterministicMNList;
+        merkleRootRet = merkleRootCached;
+        return !mutatedCached;
+    }
+
+    if (hasCached && deterministicMNList.HasSameMNMap(deterministicMNListCached)) {
+        merkleRootRet = merkleRootCached;
+        return !mutatedCached;
+    }
+
+    int64_t nTime1 = GetTimeMicros();
+
+    CSimplifiedMNList sml(deterministicMNList);
+
+    int64_t nTime2 = GetTimeMicros(); nTimeSMNL += nTime2 - nTime1;
+    LogPrint("bench", "            - CSimplifiedMNList: %.2fms [%.2fs]\n", 0.001 * (nTime2 - nTime1), nTimeSMNL * 0.000001);
+
+    static CSimplifiedMNList smlCached;
+
+    if (SimplifiedMNListsEqual(sml, smlCached)) {
+        deterministicMNListCached = deterministicMNList;
+        hasCached = true;
         merkleRootRet = merkleRootCached;
         return !mutatedCached;
     }
@@ -133,12 +186,14 @@ bool CalcCbTxMerkleRootMNList(const CBlock& block, const CBlockIndex* pindexPrev
     bool mutated = false;
     merkleRootRet = sml.CalcMerkleRoot(&mutated);
 
-    int64_t nTime4 = GetTimeMicros(); nTimeMerkle += nTime4 - nTime3;
-    LogPrint("bench", "            - CalcMerkleRoot: %.2fms [%.2fs]\n", 0.001 * (nTime4 - nTime3), nTimeMerkle * 0.000001);
+    int64_t nTime3 = GetTimeMicros(); nTimeMerkle += nTime3 - nTime2;
+    LogPrint("bench", "            - CalcMerkleRoot: %.2fms [%.2fs]\n", 0.001 * (nTime3 - nTime2), nTimeMerkle * 0.000001);
 
     smlCached = std::move(sml);
+    deterministicMNListCached = deterministicMNList;
     merkleRootCached = merkleRootRet;
     mutatedCached = mutated;
+    hasCached = true;
 
     return !mutated;
 }

--- a/src/evo/cbtx.h
+++ b/src/evo/cbtx.h
@@ -10,6 +10,7 @@
 
 class CBlock;
 class CBlockIndex;
+class CDeterministicMNList;
 class UniValue;
 
 // coinbase transaction
@@ -45,8 +46,9 @@ public:
 
 bool CheckCbTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValidationState& state);
 
-bool CheckCbTxMerkleRoots(const CBlock& block, const CBlockIndex* pindex, CValidationState& state);
+bool CheckCbTxMerkleRoots(const CBlock& block, const CBlockIndex* pindex, CValidationState& state, const CDeterministicMNList* deterministicMNList = nullptr, bool cbTxMerkleRootMNListChanged = true);
 bool CalcCbTxMerkleRootMNList(const CBlock& block, const CBlockIndex* pindexPrev, uint256& merkleRootRet, CValidationState& state);
+bool CalcCbTxMerkleRootMNList(const CDeterministicMNList& deterministicMNList, uint256& merkleRootRet, const CBlockIndex* pindexPrev = nullptr, bool cbTxMerkleRootMNListChanged = true);
 bool CalcCbTxMerkleRootQuorums(const CBlock& block, const CBlockIndex* pindexPrev, uint256& merkleRootRet, CValidationState& state);
 
 bool CbtxToJson(const CTransaction& tx, UniValue& obj);

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -503,9 +503,13 @@ CDeterministicMNManager::CDeterministicMNManager(CEvoDB& _evoDb) :
 {
 }
 
-bool CDeterministicMNManager::ProcessBlock(const CBlock& block, const CBlockIndex* pindex, CValidationState& _state, bool fJustCheck)
+bool CDeterministicMNManager::ProcessBlock(const CBlock& block, const CBlockIndex* pindex, CValidationState& _state, bool fJustCheck, CDeterministicMNList* newListRet, bool* cbTxMerkleRootMNListChangedRet)
 {
     AssertLockHeld(cs_main);
+
+    if (cbTxMerkleRootMNListChangedRet) {
+        *cbTxMerkleRootMNListChangedRet = true;
+    }
 
     const auto& consensusParams = Params().GetConsensus();
     bool fDIP0003Active = pindex->nHeight >= consensusParams.DIP0003Height;
@@ -525,18 +529,27 @@ bool CDeterministicMNManager::ProcessBlock(const CBlock& block, const CBlockInde
             return false;
         }
 
-        if (fJustCheck) {
-            return true;
-        }
-
         if (newList.GetHeight() == -1) {
             newList.SetHeight(nHeight);
         }
-
         newList.SetBlockHash(block.GetHash());
+
+        if (fJustCheck) {
+            if (newListRet) {
+                *newListRet = newList;
+            }
+            return true;
+        }
+
+        if (newListRet) {
+            *newListRet = newList;
+        }
 
         oldList = GetListForBlock(pindex->pprev);
         diff = oldList.BuildDiff(newList);
+        if (cbTxMerkleRootMNListChangedRet) {
+            *cbTxMerkleRootMNListChangedRet = diff.HasCbTxMerkleRootChanges();
+        }
 
         evoDb.Write(std::make_pair(DB_LIST_DIFF, newList.GetBlockHash()), diff);
         if ((nHeight % SNAPSHOT_LIST_PERIOD) == 0 || oldList.GetHeight() == -1) {

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -336,6 +336,11 @@ public:
         return mnMap.size();
     }
 
+    bool HasSameMNMap(const CDeterministicMNList& other) const
+    {
+        return mnMap.identity() == other.mnMap.identity();
+    }
+
     size_t GetValidMNsCount() const
     {
         size_t count = 0;
@@ -591,6 +596,30 @@ public:
     {
         return !addedMNs.empty() || !updatedMNs.empty() || !removedMns.empty();
     }
+
+    bool HasCbTxMerkleRootChanges() const
+    {
+        if (!addedMNs.empty() || !removedMns.empty()) {
+            return true;
+        }
+
+        // Keep this in sync with the CDeterministicMNState fields serialized by
+        // CSimplifiedMNListEntry, which defines cbTx.merkleRootMNList leaves.
+        static constexpr uint32_t relevantFields =
+            CDeterministicMNStateDiff::Field_nPoSeBanHeight |
+            CDeterministicMNStateDiff::Field_confirmedHash |
+            CDeterministicMNStateDiff::Field_pubKeyOperator |
+            CDeterministicMNStateDiff::Field_keyIDVoting |
+            CDeterministicMNStateDiff::Field_addr;
+
+        for (const auto& p : updatedMNs) {
+            if (p.second.fields & relevantFields) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 };
 
 // TODO can be removed in a future version
@@ -641,7 +670,7 @@ private:
 public:
     CDeterministicMNManager(CEvoDB& _evoDb);
 
-    bool ProcessBlock(const CBlock& block, const CBlockIndex* pindex, CValidationState& state, bool fJustCheck);
+    bool ProcessBlock(const CBlock& block, const CBlockIndex* pindex, CValidationState& state, bool fJustCheck, CDeterministicMNList* newListRet = nullptr, bool* cbTxMerkleRootMNListChangedRet = nullptr);
     bool UndoBlock(const CBlock& block, const CBlockIndex* pindex);
 
     void UpdatedBlockTip(const CBlockIndex* pindex);

--- a/src/evo/specialtx.cpp
+++ b/src/evo/specialtx.cpp
@@ -141,14 +141,18 @@ bool ProcessSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, CV
     int64_t nTime3 = GetTimeMicros(); nTimeQuorum += nTime3 - nTime2;
     LogPrint("bench", "        - quorumBlockProcessor: %.2fms [%.2fs]\n", 0.001 * (nTime3 - nTime2), nTimeQuorum * 0.000001);
 
-    if (!deterministicMNManager->ProcessBlock(block, pindex, state, fJustCheck)) {
+    CDeterministicMNList newMNList;
+    CDeterministicMNList* newMNListRet = fCheckCbTxMerleRoots ? &newMNList : nullptr;
+    bool cbTxMerkleRootMNListChanged = true;
+    bool* cbTxMerkleRootMNListChangedRet = fCheckCbTxMerleRoots ? &cbTxMerkleRootMNListChanged : nullptr;
+    if (!deterministicMNManager->ProcessBlock(block, pindex, state, fJustCheck, newMNListRet, cbTxMerkleRootMNListChangedRet)) {
         return false;
     }
 
     int64_t nTime4 = GetTimeMicros(); nTimeDMN += nTime4 - nTime3;
     LogPrint("bench", "        - deterministicMNManager: %.2fms [%.2fs]\n", 0.001 * (nTime4 - nTime3), nTimeDMN * 0.000001);
 
-    if (fCheckCbTxMerleRoots && !CheckCbTxMerkleRoots(block, pindex, state)) {
+    if (fCheckCbTxMerleRoots && !CheckCbTxMerkleRoots(block, pindex, state, newMNListRet, cbTxMerkleRootMNListChanged)) {
         return false;
     }
 

--- a/src/llmq/quorums_dkgsession.cpp
+++ b/src/llmq/quorums_dkgsession.cpp
@@ -244,6 +244,12 @@ bool CDKGSession::PreVerifyMessage(const uint256& hash, const CDKGContribution& 
         return false;
     }
 
+    if (!qc.sig.IsValid()) {
+        logger.Batch("invalid signature");
+        retBan = true;
+        return false;
+    }
+
     if (member->contributions.size() >= 2) {
         // don't do any further processing if we got more than 1 valid contributions already
         // this is a DoS protection against members sending multiple contributions with valid signatures to us
@@ -513,6 +519,12 @@ bool CDKGSession::PreVerifyMessage(const uint256& hash, const CDKGComplaint& qc,
         return false;
     }
 
+    if (!qc.sig.IsValid()) {
+        logger.Batch("invalid signature");
+        retBan = true;
+        return false;
+    }
+
     if (member->complaints.size() >= 2) {
         // don't do any further processing if we got more than 1 valid complaints already
         // this is a DoS protection against members sending multiple complaints with valid signatures to us
@@ -725,6 +737,12 @@ bool CDKGSession::PreVerifyMessage(const uint256& hash, const CDKGJustification&
             retBan = true;
             return false;
         }
+    }
+
+    if (!qj.sig.IsValid()) {
+        logger.Batch("invalid signature");
+        retBan = true;
+        return false;
     }
 
     if (member->justifications.size() >= 2) {

--- a/src/llmq/quorums_dkgsessionhandler.cpp
+++ b/src/llmq/quorums_dkgsessionhandler.cpp
@@ -295,6 +295,14 @@ std::set<NodeId> BatchVerifyMessageSigs(CDKGSession& session, const std::vector<
             continue;
         }
 
+        if (!msg.sig.IsValid()) {
+            // An invalid signature cannot be aggregated (CBLSSignature::AggregateInsecure
+            // asserts that its operands are valid, which would abort the process). Fall back
+            // to single verification, which safely identifies and bans the offending node(s).
+            revertToSingleVerification = true;
+            break;
+        }
+
         if (first) {
             aggSig = msg.sig;
         } else {

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -12,12 +12,16 @@
 #include "netbase.h"
 #include "messagesigner.h"
 #include "keystore.h"
+#include "validationinterface.h"
 
+#include "dsnotificationinterface.h"
 #include "evo/specialtx.h"
 #include "evo/providertx.h"
 #include "evo/deterministicmns.h"
 
+#include <atomic>
 #include <boost/test/unit_test.hpp>
+#include <boost/thread.hpp>
 
 static const CBitcoinAddress payoutAddress  ("TTJW6FsYqLbSiF3ZUwMXRghgQuXK7XTodR");
 //static const std::string payoutKey          ("cV3qrPWzDcnhzRMV4MqtTH4LhNPqPo26ZntGvfJhc8nqCi8Ae5xR");
@@ -197,6 +201,118 @@ static CScript GenerateRandomAddress()
     CKey key;
     key.MakeNewKey(false);
     return GetScriptForDestination(key.GetPubKey().GetID());
+}
+
+static CScript GetCoinbaseKeyScript(const CKey& coinbaseKey)
+{
+    return GetScriptForDestination(coinbaseKey.GetPubKey().GetID());
+}
+
+static CMutableTransaction CreateCollateralSpendTx(const COutPoint& collateralOutpoint, const CScript& scriptPayout, const CKey& coinbaseKey)
+{
+    CMutableTransaction tx;
+    tx.vin.emplace_back(CTxIn(collateralOutpoint));
+    tx.vout.emplace_back(CTxOut(999 * COIN, scriptPayout));
+    SignTransaction(tx, coinbaseKey);
+
+    return tx;
+}
+
+static void ProcessBlockAndUpdateMNManager(TestChain100Setup& setup, const std::vector<CMutableTransaction>& txns, const CKey& coinbaseKey)
+{
+    bool processed = false;
+    setup.CreateAndProcessBlock(txns, coinbaseKey, &processed);
+    BOOST_REQUIRE(processed);
+    deterministicMNManager->UpdatedBlockTip(chainActive.Tip());
+}
+
+static void InvalidateBlockAndUpdateMNManager(const uint256& blockHash)
+{
+    CValidationState state;
+    LOCK(cs_main);
+
+    auto it = mapBlockIndex.find(blockHash);
+    BOOST_REQUIRE(it != mapBlockIndex.end());
+    BOOST_REQUIRE(InvalidateBlock(state, Params(), it->second));
+    BOOST_REQUIRE(state.IsValid());
+    deterministicMNManager->UpdatedBlockTip(chainActive.Tip());
+}
+
+static void InvalidateBlockUsingValidationSignals(const uint256& blockHash)
+{
+    CValidationState state;
+    LOCK(cs_main);
+
+    auto it = mapBlockIndex.find(blockHash);
+    BOOST_REQUIRE(it != mapBlockIndex.end());
+    BOOST_REQUIRE(InvalidateBlock(state, Params(), it->second));
+    BOOST_REQUIRE(state.IsValid());
+}
+
+class DeterministicMNManagerTipSignalBridge : public CValidationInterface
+{
+protected:
+    void UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex*, bool) override
+    {
+        deterministicMNManager->UpdatedBlockTip(pindexNew);
+    }
+};
+
+class ExposedDSNotificationInterface : public CDSNotificationInterface
+{
+public:
+    using CDSNotificationInterface::CDSNotificationInterface;
+
+    void UpdatedBlockTipForTest(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload)
+    {
+        CDSNotificationInterface::UpdatedBlockTip(pindexNew, pindexFork, fInitialDownload);
+    }
+};
+
+class ScopedValidationInterfaceRegistration
+{
+public:
+    explicit ScopedValidationInterfaceRegistration(CValidationInterface& validationInterface) :
+        validationInterface(validationInterface)
+    {
+        RegisterValidationInterface(&validationInterface);
+    }
+
+    ~ScopedValidationInterfaceRegistration()
+    {
+        UnregisterValidationInterface(&validationInterface);
+    }
+
+private:
+    CValidationInterface& validationInterface;
+};
+
+static std::vector<uint256> RegisterDeterministicMNs(TestChain100Setup& setup, SimpleUTXOMap& utxos, size_t count, int& port, const CScript& payoutScript)
+{
+    std::vector<uint256> dmnHashes;
+    dmnHashes.reserve(count);
+
+    for (size_t i = 0; i < count; ++i) {
+        CKey ownerKey;
+        CBLSSecretKey operatorKey;
+        auto tx = CreateProRegTx(utxos, port++, payoutScript, setup.coinbaseKey, ownerKey, operatorKey);
+        auto proTxHash = tx.GetHash();
+        ProcessBlockAndUpdateMNManager(setup, {tx}, setup.coinbaseKey);
+
+        BOOST_REQUIRE(deterministicMNManager->GetListAtChainTip().HasMN(proTxHash));
+        dmnHashes.emplace_back(proTxHash);
+    }
+
+    return dmnHashes;
+}
+
+static void AssertTipMNSet(const std::vector<uint256>& expectedDmnHashes)
+{
+    auto mnList = deterministicMNManager->GetListAtChainTip();
+    BOOST_REQUIRE_EQUAL(mnList.GetAllMNsCount(), expectedDmnHashes.size());
+    for (const auto& proTxHash : expectedDmnHashes) {
+        BOOST_CHECK(mnList.HasMN(proTxHash));
+    }
 }
 
 static CDeterministicMNCPtr FindPayoutDmn(const CBlock& block)
@@ -406,5 +522,179 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChainDIP3Setup)
     BOOST_ASSERT(foundRevived);
 
     const_cast<Consensus::Params&>(Params().GetConsensus()).DIP0003EnforcementHeight = DIP0003EnforcementHeightBackup;
+}
+
+BOOST_FIXTURE_TEST_CASE(dip3_invalidate_restores_single_collateral_spend_immediately, TestChainDIP3Setup)
+{
+    auto utxos = BuildSimpleUtxoMap(coinbaseTxns);
+    auto payoutScript = GetCoinbaseKeyScript(coinbaseKey);
+    int port = 10000;
+
+    auto dmnHashes = RegisterDeterministicMNs(*this, utxos, 3, port, payoutScript);
+    AssertTipMNSet(dmnHashes);
+
+    auto spendTx = CreateCollateralSpendTx(COutPoint(dmnHashes[0], 0), payoutScript, coinbaseKey);
+    ProcessBlockAndUpdateMNManager(*this, {spendTx}, coinbaseKey);
+
+    std::vector<uint256> afterSpend{dmnHashes.begin() + 1, dmnHashes.end()};
+    AssertTipMNSet(afterSpend);
+
+    auto removedTipHash = chainActive.Tip()->GetBlockHash();
+    InvalidateBlockAndUpdateMNManager(removedTipHash);
+
+    AssertTipMNSet(dmnHashes);
+}
+
+BOOST_FIXTURE_TEST_CASE(dip3_invalidate_restores_multiple_collateral_spends_immediately, TestChainDIP3Setup)
+{
+    auto utxos = BuildSimpleUtxoMap(coinbaseTxns);
+    auto payoutScript = GetCoinbaseKeyScript(coinbaseKey);
+    int port = 11000;
+
+    auto dmnHashes = RegisterDeterministicMNs(*this, utxos, 5, port, payoutScript);
+    AssertTipMNSet(dmnHashes);
+
+    uint256 firstRemovalBlockHash;
+    std::vector<uint256> expectedAfterSpends = dmnHashes;
+    for (size_t i = 0; i < 3; ++i) {
+        auto spendTx = CreateCollateralSpendTx(COutPoint(dmnHashes[i], 0), payoutScript, coinbaseKey);
+        ProcessBlockAndUpdateMNManager(*this, {spendTx}, coinbaseKey);
+        if (i == 0) {
+            firstRemovalBlockHash = chainActive.Tip()->GetBlockHash();
+        }
+        expectedAfterSpends.erase(expectedAfterSpends.begin());
+        AssertTipMNSet(expectedAfterSpends);
+    }
+
+    InvalidateBlockAndUpdateMNManager(firstRemovalBlockHash);
+
+    AssertTipMNSet(dmnHashes);
+}
+
+BOOST_FIXTURE_TEST_CASE(dip3_invalidate_does_not_reuse_cached_descendant_mn_list, TestChainDIP3Setup)
+{
+    auto utxos = BuildSimpleUtxoMap(coinbaseTxns);
+    auto payoutScript = GetCoinbaseKeyScript(coinbaseKey);
+    int port = 12000;
+
+    auto dmnHashes = RegisterDeterministicMNs(*this, utxos, 4, port, payoutScript);
+    AssertTipMNSet(dmnHashes);
+
+    auto preRemovalTip = chainActive.Tip();
+    auto spendTx = CreateCollateralSpendTx(COutPoint(dmnHashes[0], 0), payoutScript, coinbaseKey);
+    ProcessBlockAndUpdateMNManager(*this, {spendTx}, coinbaseKey);
+    auto descendantTip = chainActive.Tip();
+
+    std::vector<uint256> afterSpend{dmnHashes.begin() + 1, dmnHashes.end()};
+    AssertTipMNSet(afterSpend);
+
+    // Populate manager caches for both sides of the rollback boundary before
+    // invalidating, then assert the active tip list cannot be served from the
+    // stale descendant entry after disconnect.
+    BOOST_CHECK_EQUAL(deterministicMNManager->GetListForBlock(preRemovalTip).GetAllMNsCount(), dmnHashes.size());
+    BOOST_CHECK_EQUAL(deterministicMNManager->GetListForBlock(descendantTip).GetAllMNsCount(), afterSpend.size());
+
+    InvalidateBlockAndUpdateMNManager(descendantTip->GetBlockHash());
+
+    BOOST_CHECK_EQUAL(chainActive.Tip()->GetBlockHash().ToString(), preRemovalTip->GetBlockHash().ToString());
+    AssertTipMNSet(dmnHashes);
+    BOOST_CHECK_EQUAL(deterministicMNManager->GetListForBlock(chainActive.Tip()).GetAllMNsCount(), dmnHashes.size());
+}
+
+BOOST_FIXTURE_TEST_CASE(dip3_invalidate_pure_disconnect_notification_updates_tip_list, TestChainDIP3Setup)
+{
+    auto utxos = BuildSimpleUtxoMap(coinbaseTxns);
+    auto payoutScript = GetCoinbaseKeyScript(coinbaseKey);
+    int port = 13000;
+
+    auto dmnHashes = RegisterDeterministicMNs(*this, utxos, 3, port, payoutScript);
+    AssertTipMNSet(dmnHashes);
+
+    auto preRemovalTip = chainActive.Tip();
+    auto spendTx = CreateCollateralSpendTx(COutPoint(dmnHashes[0], 0), payoutScript, coinbaseKey);
+    ProcessBlockAndUpdateMNManager(*this, {spendTx}, coinbaseKey);
+
+    std::vector<uint256> afterSpend{dmnHashes.begin() + 1, dmnHashes.end()};
+    AssertTipMNSet(afterSpend);
+
+    ExposedDSNotificationInterface notificationInterface(*connman);
+    notificationInterface.UpdatedBlockTipForTest(preRemovalTip, preRemovalTip, false);
+    AssertTipMNSet(dmnHashes);
+}
+
+BOOST_FIXTURE_TEST_CASE(dip3_repeated_invalidate_signal_restores_each_intermediate_tip, TestChainDIP3Setup)
+{
+    DeterministicMNManagerTipSignalBridge tipSignalBridge;
+    ScopedValidationInterfaceRegistration bridgeRegistration(tipSignalBridge);
+
+    auto utxos = BuildSimpleUtxoMap(coinbaseTxns);
+    auto payoutScript = GetCoinbaseKeyScript(coinbaseKey);
+    int port = 14000;
+
+    auto dmnHashes = RegisterDeterministicMNs(*this, utxos, 5, port, payoutScript);
+    AssertTipMNSet(dmnHashes);
+
+    std::vector<std::vector<uint256>> expectedAfterDisconnect;
+    std::vector<uint256> expectedAfterSpends = dmnHashes;
+
+    for (size_t i = 0; i < 3; ++i) {
+        auto spendTx = CreateCollateralSpendTx(COutPoint(dmnHashes[i], 0), payoutScript, coinbaseKey);
+        ProcessBlockAndUpdateMNManager(*this, {spendTx}, coinbaseKey);
+        expectedAfterSpends.erase(expectedAfterSpends.begin());
+        AssertTipMNSet(expectedAfterSpends);
+
+        std::vector<uint256> restored{dmnHashes.begin() + i, dmnHashes.end()};
+        expectedAfterDisconnect.emplace(expectedAfterDisconnect.begin(), std::move(restored));
+    }
+
+    for (size_t i = 0; i < expectedAfterDisconnect.size(); ++i) {
+        InvalidateBlockUsingValidationSignals(chainActive.Tip()->GetBlockHash());
+        AssertTipMNSet(expectedAfterDisconnect[i]);
+    }
+}
+
+BOOST_FIXTURE_TEST_CASE(dip3_invalidate_tip_list_remains_consistent_for_parallel_readers, TestChainDIP3Setup)
+{
+    DeterministicMNManagerTipSignalBridge tipSignalBridge;
+    ScopedValidationInterfaceRegistration bridgeRegistration(tipSignalBridge);
+
+    auto utxos = BuildSimpleUtxoMap(coinbaseTxns);
+    auto payoutScript = GetCoinbaseKeyScript(coinbaseKey);
+    int port = 15000;
+
+    auto dmnHashes = RegisterDeterministicMNs(*this, utxos, 6, port, payoutScript);
+    AssertTipMNSet(dmnHashes);
+
+    for (size_t i = 0; i < 3; ++i) {
+        auto spendTx = CreateCollateralSpendTx(COutPoint(dmnHashes[i], 0), payoutScript, coinbaseKey);
+        ProcessBlockAndUpdateMNManager(*this, {spendTx}, coinbaseKey);
+    }
+
+    InvalidateBlockUsingValidationSignals(chainActive.Tip()->GetBlockHash());
+    std::vector<uint256> expectedAfterOneDisconnect{dmnHashes.begin() + 2, dmnHashes.end()};
+    AssertTipMNSet(expectedAfterOneDisconnect);
+
+    std::atomic<bool> failed{false};
+    boost::thread_group readers;
+    for (size_t i = 0; i < 8; ++i) {
+        readers.create_thread([&]() {
+            for (size_t j = 0; j < 100; ++j) {
+                auto mnList = deterministicMNManager->GetListAtChainTip();
+                if (mnList.GetAllMNsCount() != expectedAfterOneDisconnect.size()) {
+                    failed = true;
+                    return;
+                }
+                for (const auto& proTxHash : expectedAfterOneDisconnect) {
+                    if (!mnList.HasMN(proTxHash)) {
+                        failed = true;
+                        return;
+                    }
+                }
+            }
+        });
+    }
+    readers.join_all();
+
+    BOOST_CHECK(!failed);
 }
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/evo_simplifiedmns_tests.cpp
+++ b/src/test/evo_simplifiedmns_tests.cpp
@@ -5,12 +5,58 @@
 #include "test/test_bitcoin.h"
 
 #include "bls/bls.h"
+#include "evo/deterministicmns.h"
 #include "evo/simplifiedmns.h"
 #include "netbase.h"
+#include "script/script.h"
 
 #include <boost/test/unit_test.hpp>
 
+#include <functional>
+
 BOOST_FIXTURE_TEST_SUITE(evo_simplifiedmns_tests, BasicTestingSetup)
+
+static CBLSPublicKey MakeTestBLSPublicKey(unsigned char value)
+{
+    std::vector<unsigned char> bytes{value};
+    bytes.resize(CBLSSecretKey::SerSize);
+    return CBLSSecretKey(bytes).GetPublicKey();
+}
+
+static CService MakeTestService(uint16_t port)
+{
+    CService service;
+    BOOST_REQUIRE(Lookup("127.0.0.1", service, port, false));
+    return service;
+}
+
+static CDeterministicMNState MakeTestMNState()
+{
+    CDeterministicMNState state;
+    state.nRegisteredHeight = 1;
+    state.nLastPaidHeight = 2;
+    state.nPoSePenalty = 3;
+    state.nPoSeRevivedHeight = 4;
+    state.nPoSeBanHeight = -1;
+    state.nRevocationReason = 5;
+    state.confirmedHash.SetHex(strprintf("%064x", 6));
+    state.confirmedHashWithProRegTxHash.SetHex(strprintf("%064x", 7));
+    state.keyIDOwner.SetHex(strprintf("%040x", 8));
+    state.pubKeyOperator.Set(MakeTestBLSPublicKey(9));
+    state.keyIDVoting.SetHex(strprintf("%040x", 10));
+    state.addr = MakeTestService(11000);
+    state.scriptPayout = CScript() << OP_1;
+    state.scriptOperatorPayout = CScript() << OP_2;
+    return state;
+}
+
+static CDeterministicMN MakeTestMN(const CDeterministicMNState& state)
+{
+    CDeterministicMN dmn;
+    dmn.proTxHash.SetHex(strprintf("%064x", 1));
+    dmn.pdmnState = std::make_shared<CDeterministicMNState>(state);
+    return dmn;
+}
 
 BOOST_AUTO_TEST_CASE(simplifiedmns_merkleroots)
 {
@@ -66,5 +112,51 @@ BOOST_AUTO_TEST_CASE(simplifiedmns_merkleroots)
     //printf("merkleRoot=\"%s\",\n", calculatedMerkleRoot.c_str());
 
     BOOST_CHECK(expectedMerkleRoot == calculatedMerkleRoot);
+}
+
+BOOST_AUTO_TEST_CASE(deterministicmn_diff_cbtx_merkle_relevance)
+{
+    CDeterministicMNListDiff diff;
+    BOOST_CHECK(!diff.HasCbTxMerkleRootChanges());
+
+    auto checkUpdatedField = [](uint32_t field, const std::function<void(CDeterministicMNState&)>& update) {
+        CDeterministicMNState oldState = MakeTestMNState();
+        CDeterministicMNState newState = oldState;
+        update(newState);
+
+        const CDeterministicMN oldDmn = MakeTestMN(oldState);
+        const CDeterministicMN newDmn = MakeTestMN(newState);
+        const bool changesMerkleEntry = CSimplifiedMNListEntry(oldDmn) != CSimplifiedMNListEntry(newDmn);
+
+        CDeterministicMNListDiff diff;
+        CDeterministicMNStateDiff stateDiff(oldState, newState);
+        BOOST_CHECK_EQUAL(stateDiff.fields, field);
+        diff.updatedMNs.emplace(1, stateDiff);
+        BOOST_CHECK_EQUAL(diff.HasCbTxMerkleRootChanges(), changesMerkleEntry);
+    };
+
+    checkUpdatedField(CDeterministicMNStateDiff::Field_nRegisteredHeight, [](auto& state) { state.nRegisteredHeight = 11; });
+    checkUpdatedField(CDeterministicMNStateDiff::Field_nLastPaidHeight, [](auto& state) { state.nLastPaidHeight = 12; });
+    checkUpdatedField(CDeterministicMNStateDiff::Field_nPoSePenalty, [](auto& state) { state.nPoSePenalty = 13; });
+    checkUpdatedField(CDeterministicMNStateDiff::Field_nPoSeRevivedHeight, [](auto& state) { state.nPoSeRevivedHeight = 14; });
+    checkUpdatedField(CDeterministicMNStateDiff::Field_nRevocationReason, [](auto& state) { state.nRevocationReason = 15; });
+    checkUpdatedField(CDeterministicMNStateDiff::Field_confirmedHashWithProRegTxHash, [](auto& state) { state.confirmedHashWithProRegTxHash.SetHex(strprintf("%064x", 16)); });
+    checkUpdatedField(CDeterministicMNStateDiff::Field_keyIDOwner, [](auto& state) { state.keyIDOwner.SetHex(strprintf("%040x", 17)); });
+    checkUpdatedField(CDeterministicMNStateDiff::Field_scriptPayout, [](auto& state) { state.scriptPayout = CScript() << OP_3; });
+    checkUpdatedField(CDeterministicMNStateDiff::Field_scriptOperatorPayout, [](auto& state) { state.scriptOperatorPayout = CScript() << OP_4; });
+
+    checkUpdatedField(CDeterministicMNStateDiff::Field_nPoSeBanHeight, [](auto& state) { state.nPoSeBanHeight = 18; });
+    checkUpdatedField(CDeterministicMNStateDiff::Field_confirmedHash, [](auto& state) { state.confirmedHash.SetHex(strprintf("%064x", 19)); });
+    checkUpdatedField(CDeterministicMNStateDiff::Field_pubKeyOperator, [](auto& state) { state.pubKeyOperator.Set(MakeTestBLSPublicKey(20)); });
+    checkUpdatedField(CDeterministicMNStateDiff::Field_keyIDVoting, [](auto& state) { state.keyIDVoting.SetHex(strprintf("%040x", 21)); });
+    checkUpdatedField(CDeterministicMNStateDiff::Field_addr, [](auto& state) { state.addr = MakeTestService(12000); });
+
+    diff.updatedMNs.clear();
+    diff.addedMNs.emplace_back();
+    BOOST_CHECK(diff.HasCbTxMerkleRootChanges());
+
+    diff.addedMNs.clear();
+    diff.removedMns.emplace(1);
+    BOOST_CHECK(diff.HasCbTxMerkleRootChanges());
 }
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -575,7 +575,7 @@ int GetUTXOConfirmations(const COutPoint& outpoint)
 
 bool CheckTransaction(const CTransaction &tx, CValidationState &state, bool fCheckDuplicateInputs, uint256 hashTx,  bool isVerifyDB, int nHeight, bool isCheckWallet, bool fStatefulZerocoinCheck, spark::CSparkTxInfo* sparkTxInfo)
 {
-    LogPrintf("CheckTransaction nHeight=%d, isVerifyDB=%d, isCheckWallet=%d, txHash=%s\n", nHeight, (int)isVerifyDB, (int)isCheckWallet, tx.GetHash().ToString());
+    LogPrint("validation", "CheckTransaction nHeight=%d, isVerifyDB=%d, isCheckWallet=%d, txHash=%s\n", nHeight, (int)isVerifyDB, (int)isCheckWallet, tx.GetHash().ToString());
 
     bool allowEmptyTxInOut = false;
     if (tx.nType == TRANSACTION_QUORUM_COMMITMENT) {
@@ -2511,7 +2511,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     int64_t nTimeStart = GetTimeMicros();
     //btzc: update nHeight, isVerifyDB
     // Check it again in case a previous version let a bad block in
-    LogPrintf("ConnectBlock nHeight=%d, hash=%s\n", pindex->nHeight, block.GetHash().ToString());
+    LogPrint("validation", "ConnectBlock nHeight=%d, hash=%s\n", pindex->nHeight, block.GetHash().ToString());
     if (!CheckBlock(block, state, chainparams.GetConsensus(), !fJustCheck, !fJustCheck, pindex->nHeight, false)) {
         LogPrintf("--> failed\n");
         return error("%s: Consensus::CheckBlock: %s", __func__, FormatStateMessage(state));
@@ -3155,7 +3155,7 @@ void PruneAndFlush() {
 
 /** Update chainActive and related internal data structures. */
 void static UpdateTip(CBlockIndex *pindexNew, const CChainParams &chainParams) {
-    LogPrintf("UpdateTip() pindexNew.nHeight=%d\n", pindexNew->nHeight);
+    LogPrint("validation", "UpdateTip() pindexNew.nHeight=%d\n", pindexNew->nHeight);
     chainActive.SetTip(pindexNew);
 
     // New best block
@@ -3364,7 +3364,7 @@ struct ConnectTrace {
  */
 bool static ConnectTip(CValidationState& state, const CChainParams& chainparams, CBlockIndex* pindexNew, const std::shared_ptr<const CBlock>& pblock, ConnectTrace& connectTrace)
 {
-    LogPrintf("ConnectTip() nHeight=%d\n", pindexNew->nHeight);
+    LogPrint("validation", "ConnectTip() nHeight=%d\n", pindexNew->nHeight);
     assert(pindexNew->pprev == chainActive.Tip());
     // Read block from disk.
     int64_t nTime1 = GetTimeMicros();
@@ -3606,7 +3606,7 @@ static void PruneBlockIndexCandidates() {
  */
 static bool ActivateBestChainStep(CValidationState& state, const CChainParams& chainparams, CBlockIndex* pindexMostWork, const std::shared_ptr<const CBlock>& pblock, bool& fInvalidFound, ConnectTrace& connectTrace)
 {
-    LogPrintf("ActivateBestChainStep()\n");
+    LogPrint("validation", "ActivateBestChainStep()\n");
     AssertLockHeld(cs_main);
     const CBlockIndex *pindexOldTip = chainActive.Tip();
     const CBlockIndex *pindexFork = chainActive.FindFork(pindexMostWork);
@@ -4198,7 +4198,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
     // Check transactions (when called from ProcessNewBlock, nHeight is INT_MAX and we derive it here)
     if (nHeight == INT_MAX)
         nHeight = GetNHeight(block.GetBlockHeader());
-    LogPrintf("CheckBlock() nHeight=%d, blockHash=%s, isVerifyDB=%d\n", nHeight, block.GetHash().ToString(), isVerifyDB);
+    LogPrint("validation", "CheckBlock() nHeight=%d, blockHash=%s, isVerifyDB=%d\n", nHeight, block.GetHash().ToString(), isVerifyDB);
 
     for (CTransactionRef tx : block.vtx) {
         // We don't check transactions against sigma/lelantus state here, we'll check it again later in ConnectBlock
@@ -4601,7 +4601,7 @@ static bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidation
     if (!AcceptBlockHeader(block, state, chainparams, &pindex))
         return false;
 
-    LogPrintf("AcceptBlock nHeight=%d\n", pindex->nHeight);
+    LogPrint("validation", "AcceptBlock nHeight=%d\n", pindex->nHeight);
     // Try to process all requested blocks that we don't have, but only
     // process an unrequested block if it's new and has enough work to
     // advance our tip, and isn't too many blocks ahead.


### PR DESCRIPTION
This patch speeds up early -reindex around the DIP3 deterministic masternode activation window by avoiding redundant cbTx masternode-list merkle-root rebuilds. During ConnectBlock, Firo already builds the deterministic masternode list and diff for the block; the patch reuses that freshly computed list for cbTx merkle validation, and if the diff only changes fields that are not serialized into CSimplifiedMNListEntry, it safely reuses the previous merkle root instead of rebuilding and rehashing the same effective simplified MN list. Consensus behavior is preserved because additions, removals, and every state field that affects the cbTx MN merkle root still force recomputation, while unrelated fields such as payout/last-paid metadata do not. It also gates several high-volume validation trace logs behind -debug=validation, reducing reindex log I/O without removing opt-in diagnostics.