### PR TITLE
Spark: Speed up reindex proof verification

### DIFF
--- a/src/batchproof_container.cpp
+++ b/src/batchproof_container.cpp
@@ -17,9 +17,16 @@ void BatchProofContainer::init() {
     tempSparkTransactions.clear();
 }
 
+void BatchProofContainer::clear() {
+    tempSparkTransactions.clear();
+    sparkTransactions.clear();
+    fCollectProofs = false;
+}
+
 void BatchProofContainer::finalize() {
     if (fCollectProofs) {
         sparkTransactions.insert(sparkTransactions.end(), tempSparkTransactions.begin(), tempSparkTransactions.end());
+        tempSparkTransactions.clear();
     }
     fCollectProofs = false;
 }

--- a/src/batchproof_container.cpp
+++ b/src/batchproof_container.cpp
@@ -2,7 +2,17 @@
 #include "ui_interface.h"
 #include "spark/state.h"
 
+#include <stdexcept>
+#include <unordered_map>
+
 std::unique_ptr<BatchProofContainer> BatchProofContainer::instance;
+
+namespace
+{
+struct SparkBatchCoverSetSelection {
+    int maxHeight = -1;
+};
+} // namespace
 
 BatchProofContainer* BatchProofContainer::get_instance() {
     if (instance) {
@@ -57,6 +67,10 @@ void BatchProofContainer::batch_spark() {
         return;
     }
 
+    // Grootle batching verifies each proof against the suffix identified by
+    // its own cover-set size, so each group only needs the largest referenced
+    // historical set, not the current full group.
+    std::unordered_map<uint64_t, SparkBatchCoverSetSelection> cover_set_selections;
     std::unordered_map<uint64_t, std::vector<spark::Coin>> cover_sets;
     spark::CSparkState* sparkState = spark::CSparkState::GetState();
 
@@ -64,13 +78,43 @@ void BatchProofContainer::batch_spark() {
         auto& idAndBlockHashes = itr.getBlockHashes();
         for (const auto& idAndHash : idAndBlockHashes) {
             int cover_set_id = idAndHash.first;
-            if (!cover_sets.count(cover_set_id)) {
-                std::vector<spark::Coin> cover_set;
-                sparkState->GetCoinSet(cover_set_id, cover_set);
-                cover_sets[cover_set_id] = cover_set;
-            }
+            spark::CSparkState::SparkCoinGroupInfo coinGroup;
+            if (!sparkState->GetCoinGroupInfo(cover_set_id, coinGroup))
+                throw std::invalid_argument("Spark batch verification missing cover set");
+
+            CBlockIndex* index = coinGroup.lastBlock;
+            while (index != coinGroup.firstBlock && index->GetBlockHash() != idAndHash.second)
+                index = index->pprev;
+
+            if (!index || index->GetBlockHash() != idAndHash.second)
+                throw std::invalid_argument("Spark batch verification missing cover set block");
+
+            auto& selection = cover_set_selections[idAndHash.first];
+            if (index && index->nHeight > selection.maxHeight)
+                selection.maxHeight = index->nHeight;
         }
     }
+
+    for (const auto& selection : cover_set_selections) {
+        if (selection.second.maxHeight < 0)
+            throw std::invalid_argument("Spark batch verification missing cover set block");
+
+        uint256 blockHash;
+        std::vector<unsigned char> setHash;
+        std::vector<spark::Coin> cover_set;
+        const int nCoins = sparkState->GetCoinSetForSpend(
+                &chainActive,
+                selection.second.maxHeight,
+                static_cast<int>(selection.first),
+                blockHash,
+                cover_set,
+                setHash);
+        if (nCoins <= 0 || cover_set.empty())
+            throw std::invalid_argument("Spark batch verification empty cover set");
+
+        cover_sets[selection.first] = cover_set;
+    }
+
     auto* params = spark::Params::get_default();
 
     bool passed;

--- a/src/batchproof_container.h
+++ b/src/batchproof_container.h
@@ -13,6 +13,8 @@ public:
 
     void init();
 
+    void clear();
+
     void finalize();
 
     void verify();

--- a/src/libspark/grootle.cpp
+++ b/src/libspark/grootle.cpp
@@ -432,13 +432,6 @@ bool Grootle::verify(
         bind_weight.randomize();
     }
 
-    // Bind the commitment lists
-    std::vector<GroupElement> commits;
-    commits.reserve(S.size());
-    for (std::size_t i = 0; i < S.size(); i++) {
-        commits.emplace_back(S[i] + V[i]*bind_weight);
-    }
-
     // Final batch multiscalar multiplication
     Scalar H_scalar;
     std::vector<Scalar> Gi_scalars;
@@ -446,25 +439,17 @@ bool Grootle::verify(
     std::vector<Scalar> commit_scalars;
     Gi_scalars.resize(n*m);
     Hi_scalars.resize(n*m);
-    commit_scalars.resize(commits.size());
+    commit_scalars.resize(S.size());
 
     // Set up the final batch elements
     std::vector<GroupElement> points;
     std::vector<Scalar> scalars;
-    std::size_t final_size = 1 + 2*m*n + commits.size(); // F, (Gi), (Hi), (commits)
+    std::size_t final_size = 1 + 2*m*n + 2*S.size(); // F, (Gi), (Hi), (S), (V)
     for (std::size_t t = 0; t < M; t++) {
         final_size += 2 + proofs[t].X.size() + proofs[t].X1.size(); // A, B, (Gs), (Gv)
     }
     points.reserve(final_size);
     scalars.reserve(final_size);
-
-    // Index decomposition, which is common among all proofs
-    std::vector<std::vector<std::size_t> > I_;
-    I_.reserve(commits.size());
-    I_.resize(commits.size());
-    for (std::size_t i = 0; i < commits.size(); i++) {
-        I_[i] = decompose(i, n, m);
-    }
 
     // Process all proofs
     for (std::size_t t = 0; t < M; t++) {
@@ -500,6 +485,11 @@ bool Grootle::verify(
 
         // Effective set size
         const std::size_t size = sizes[t];
+        if (size == 0 || size > S.size()) {
+            LogPrintf("Invalid effective set size");
+            return false;
+        }
+        const std::vector<std::size_t> I_last = decompose(size - 1, n, m);
 
         // A, B (and associated commitments)
         points.emplace_back(proof.A);
@@ -518,27 +508,27 @@ bool Grootle::verify(
 
         Scalar f_sum;
         Scalar f_i(uint64_t(1));
-        std::vector<Scalar>::iterator ptr = commit_scalars.begin() + commits.size() - size;
+        std::vector<Scalar>::iterator ptr = commit_scalars.begin() + S.size() - size;
         compute_batch_fis(f_sum, f_i, m, f_, w2, ptr, ptr, ptr + size - 1, n);
 
         Scalar pow(uint64_t(1));
         std::vector<Scalar> f_part_product;
         for (std::ptrdiff_t j = m - 1; j >= 0; j--) {
             f_part_product.push_back(pow);
-            pow *= f_[j*n + I_[size - 1][j]];
+            pow *= f_[j*n + I_last[j]];
         }
 
         Scalar x_powers(uint64_t(1));
         for (std::size_t j = 0; j < m; j++) {
             Scalar fi_sum(uint64_t(0));
-            for (std::size_t i = I_[size - 1][j] + 1; i < n; i++)
+            for (std::size_t i = I_last[j] + 1; i < n; i++)
                 fi_sum += f_[j*n + i];
             pow += fi_sum * x_powers * f_part_product[m - j - 1];
             x_powers *= x;
         }
 
         f_sum += pow;
-        commit_scalars[commits.size() - 1] += pow * w2;
+        commit_scalars[S.size() - 1] += pow * w2;
 
         // S1, V1
         points.emplace_back(S1[t] + V1[t] * bind_weight);
@@ -566,9 +556,11 @@ bool Grootle::verify(
         points.emplace_back(Hi[i]);
         scalars.emplace_back(Hi_scalars[i]);
     }
-    for (std::size_t i = 0; i < commits.size(); i++) {
-        points.emplace_back(commits[i]);
+    for (std::size_t i = 0; i < S.size(); i++) {
+        points.emplace_back(S[i]);
         scalars.emplace_back(commit_scalars[i]);
+        points.emplace_back(V[i]);
+        scalars.emplace_back(commit_scalars[i] * bind_weight);
     }
 
     // Verify the batch

--- a/src/libspark/spend_transaction.cpp
+++ b/src/libspark/spend_transaction.cpp
@@ -391,10 +391,12 @@ bool SpendTransaction::verify(
             if (!cover_sets.count(cover_set_id))
                 throw std::invalid_argument("Cover set missing");
 			// Because we assume all proofs in this list share a monotonic cover set, the largest such set is the one to use for verification
-            if (!tx.cover_set_sizes.count(cover_set_id))
-                throw std::invalid_argument("Cover set size missing");
+			if (!tx.cover_set_sizes.count(cover_set_id))
+				throw std::invalid_argument("Cover set size missing");
 
 			std::size_t this_cover_set_size = tx.cover_set_sizes.at(cover_set_id);
+            if (this_cover_set_size == 0 || this_cover_set_size > full_cover_set_size)
+                throw std::invalid_argument("Bad cover set size");
 
 			// We always use the other elements
 			S1.emplace_back(tx.S1[proof_index.second]);

--- a/src/libspark/test/grootle_test.cpp
+++ b/src/libspark/test/grootle_test.cpp
@@ -14,6 +14,15 @@ static std::vector<GroupElement> random_group_vector(const std::size_t n) {
     return result;
 }
 
+static std::vector<unsigned char> random_root() {
+    Scalar temp;
+    temp.randomize();
+    std::vector<unsigned char> root;
+    root.resize(SCALAR_ENCODING);
+    temp.serialize(root.data());
+    return root;
+}
+
 BOOST_FIXTURE_TEST_SUITE(spark_grootle_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(batch)
@@ -166,6 +175,112 @@ BOOST_AUTO_TEST_CASE(invalid_batch)
     sizes.emplace_back(sizes.back());
 
     BOOST_CHECK(!grootle.verify(S, S1, V, V1, roots, sizes, proofs));
+}
+
+BOOST_AUTO_TEST_CASE(boundary_sizes_and_mutations)
+{
+    // Parameters
+    const std::size_t n = 4;
+    const std::size_t m = 3;
+
+    // Generators
+    GroupElement H;
+    H.randomize();
+    std::vector<GroupElement> Gi = random_group_vector(n*m);
+    std::vector<GroupElement> Hi = random_group_vector(n*m);
+
+    // Commitments
+    const std::size_t commit_size = 60; // require padding
+    std::vector<GroupElement> S = random_group_vector(commit_size);
+    std::vector<GroupElement> V = random_group_vector(commit_size);
+
+    // Cover every verifier boundary: full set, truncated suffixes, and size == 1.
+    std::vector<std::size_t> indexes = { 0, 3, 44, 58, 59 };
+    std::vector<std::size_t> sizes = { 60, 59, 16, 2, 1 };
+    std::vector<GroupElement> S1, V1;
+    std::vector<std::vector<unsigned char>> roots;
+    std::vector<Scalar> s, v;
+    for (std::size_t index : indexes) {
+        Scalar s_, v_;
+        s_.randomize();
+        v_.randomize();
+        s.emplace_back(s_);
+        v.emplace_back(v_);
+
+        S1.emplace_back(S[index]);
+        V1.emplace_back(V[index]);
+
+        S[index] += H*s_;
+        V[index] += H*v_;
+        roots.emplace_back(random_root());
+    }
+
+    Grootle grootle(H, Gi, Hi, n, m);
+    std::vector<GrootleProof> proofs;
+    for (std::size_t i = 0; i < indexes.size(); i++) {
+        proofs.emplace_back();
+        std::vector<GroupElement> S_(S.begin() + commit_size - sizes[i], S.end());
+        std::vector<GroupElement> V_(V.begin() + commit_size - sizes[i], V.end());
+        grootle.prove(
+            indexes[i] - (commit_size - sizes[i]),
+            s[i],
+            S_,
+            S1[i],
+            v[i],
+            V_,
+            V1[i],
+            roots[i],
+            proofs.back()
+        );
+
+        BOOST_CHECK(grootle.verify(S, S1[i], V, V1[i], roots[i], sizes[i], proofs.back()));
+    }
+
+    BOOST_CHECK(grootle.verify(S, S1, V, V1, roots, sizes, proofs));
+
+    std::vector<std::size_t> bad_sizes = sizes;
+    bad_sizes[0] = 0;
+    BOOST_CHECK(!grootle.verify(S, S1, V, V1, roots, bad_sizes, proofs));
+
+    bad_sizes = sizes;
+    bad_sizes[0] = S.size() + 1;
+    BOOST_CHECK(!grootle.verify(S, S1, V, V1, roots, bad_sizes, proofs));
+
+    bad_sizes = sizes;
+    bad_sizes.pop_back();
+    BOOST_CHECK(!grootle.verify(S, S1, V, V1, roots, bad_sizes, proofs));
+
+    std::vector<std::vector<unsigned char>> bad_roots = roots;
+    bad_roots[0][0] ^= 1;
+    BOOST_CHECK(!grootle.verify(S, S1, V, V1, bad_roots, sizes, proofs));
+
+    bad_roots = roots;
+    bad_roots.pop_back();
+    BOOST_CHECK(!grootle.verify(S, S1, V, V1, bad_roots, sizes, proofs));
+
+    std::vector<GroupElement> bad_S = S;
+    bad_S[indexes[0]].randomize();
+    BOOST_CHECK(!grootle.verify(bad_S, S1, V, V1, roots, sizes, proofs));
+
+    std::vector<GroupElement> bad_V = V;
+    bad_V[indexes[0]].randomize();
+    BOOST_CHECK(!grootle.verify(S, S1, bad_V, V1, roots, sizes, proofs));
+
+    std::vector<GroupElement> bad_S1 = S1;
+    bad_S1[0].randomize();
+    BOOST_CHECK(!grootle.verify(S, bad_S1, V, V1, roots, sizes, proofs));
+
+    std::vector<GroupElement> bad_V1 = V1;
+    bad_V1[0].randomize();
+    BOOST_CHECK(!grootle.verify(S, S1, V, bad_V1, roots, sizes, proofs));
+
+    std::vector<GrootleProof> bad_proofs = proofs;
+    bad_proofs[0].f[0] += Scalar(uint64_t(1));
+    BOOST_CHECK(!grootle.verify(S, S1, V, V1, roots, sizes, bad_proofs));
+
+    bad_proofs = proofs;
+    bad_proofs[0].X[0].randomize();
+    BOOST_CHECK(!grootle.verify(S, S1, V, V1, roots, sizes, bad_proofs));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/secp256k1/src/cpp/MultiExponent.cpp
+++ b/src/secp256k1/src/cpp/MultiExponent.cpp
@@ -12,6 +12,8 @@
 #include "../src/scratch_impl.h"
 #include "../src/ecmult_impl.h"
 
+#include <stdexcept>
+
 
 typedef struct {
     secp256k1_scalar *sc;
@@ -74,7 +76,14 @@ GroupElement MultiExponent::get_multiple() {
 
     secp256k1_ecmult_context ctx;
 
-    secp256k1_ecmult_multi_var(&ctx, scratch, &r, NULL, ecmult_multi_callback, &data, n_points);
+    if (scratch == NULL) {
+        throw std::runtime_error("MultiExponent scratch allocation failed");
+    }
+
+    if (!secp256k1_ecmult_multi_var(&ctx, scratch, &r, NULL, ecmult_multi_callback, &data, n_points)) {
+        secp256k1_scratch_destroy(scratch);
+        throw std::runtime_error("MultiExponent computation failed");
+    }
 
     secp256k1_scratch_destroy(scratch);
 

--- a/src/spark/state.cpp
+++ b/src/spark/state.cpp
@@ -1,9 +1,9 @@
-#include "threadpool.h"
 #include "state.h"
 #include "compat_layer.h"
 #include "sparkname.h"
 #include "../validation.h"
 #include "../batchproof_container.h"
+#include "../hash.h"
 
 #include <memory>
 #include <set>
@@ -11,23 +11,51 @@
 namespace spark {
 
 struct ProofCheckState {
+    ProofCheckState() : fChecked(false), fResult(false) {}
+
     // if this is true, then the proof was already checked, no need to check again
     bool fChecked;
 
     // result of the check (if fChecked is true)
     bool fResult;
 
-    // if this is non-null, then the proof is being checked right now
-    std::shared_ptr<boost::future<bool>> checkInProgress;
+    // Spark spend proofs are valid only for the exact anonymity-set inputs used.
+    uint256 proofInputHash;
 };
 
 // map from transaction hash to the state of checking its proofs
 static std::map<uint256, ProofCheckState> gCheckedSparkSpendTransactions;
 static CCriticalSection cs_checkedSparkSpendTransactions;
-
-static ParallelOpThreadPool<bool> gCheckProofThreadPool(std::min(boost::thread::hardware_concurrency(), 4u));
+static const std::size_t MAX_CACHED_SPARK_SPEND_PROOFS = 10000;
 
 static CSparkState sparkState;
+
+static uint256 GetSparkSpendProofInputHash(
+        const uint256& hashTx,
+        const std::map<uint64_t, uint256>& idAndBlockHashes,
+        const std::unordered_map<uint64_t, CoverSetData>& coverSetData,
+        const std::unordered_map<uint64_t, std::vector<Coin>>& coverSets) {
+    CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
+    ss << hashTx;
+    ss << idAndBlockHashes;
+
+    std::map<uint64_t, CoverSetData> orderedCoverSetData(
+            coverSetData.begin(), coverSetData.end());
+    for (const auto& item : orderedCoverSetData) {
+        ss << item.first;
+        ss << static_cast<uint64_t>(item.second.cover_set_size);
+        ss << item.second.cover_set_representation;
+    }
+
+    std::map<uint64_t, std::vector<Coin>> orderedCoverSets(
+            coverSets.begin(), coverSets.end());
+    for (const auto& item : orderedCoverSets) {
+        ss << item.first;
+        ss << item.second;
+    }
+
+    return ss.GetHash();
+}
 
 static bool CheckLTag(
         CValidationState &state,
@@ -622,7 +650,8 @@ bool CheckSparkSpendTransaction(
         int nHeight,
         bool isCheckWallet,
         bool fStatefulSigmaCheck,
-        CSparkTxInfo* sparkTxInfo) {
+        CSparkTxInfo* sparkTxInfo,
+        bool fVerifySparkSpendProof) {
 
     std::unordered_set<GroupElement, spark::CLTagHash> txLTags;
 
@@ -702,17 +731,30 @@ bool CheckSparkSpendTransaction(
     if (!CheckSparkSMintTransaction(tx.vout, state, hashTx, fStatefulSigmaCheck, out_coins, sparkTxInfo))
         return false;
     spend->setOutCoins(out_coins);
+    spend->setVout(Vout);
+
+    const bool fVerifyProofNow = fVerifySparkSpendProof || fStatefulSigmaCheck;
+    if (!fVerifyProofNow)
+        return true;
+
     std::unordered_map<uint64_t, std::vector<Coin>> cover_sets;
     std::unordered_map<uint64_t, CoverSetData> cover_set_data;
     const auto idAndBlockHashes = spend->getBlockHashes();
 
+    const bool fRequireProofInputs = fStatefulSigmaCheck || isVerifyDB;
     BatchProofContainer* batchProofContainer = BatchProofContainer::get_instance();
-    bool useBatching = batchProofContainer->fCollectProofs && !isVerifyDB && !isCheckWallet && sparkTxInfo && !sparkTxInfo->fInfoIsComplete;
+    const bool fMustVerifyBeforeStateUpdate = fStatefulSigmaCheck;
+    bool useBatching = batchProofContainer->fCollectProofs &&
+        !fMustVerifyBeforeStateUpdate &&
+        !isVerifyDB &&
+        !isCheckWallet &&
+        sparkTxInfo &&
+        !sparkTxInfo->fInfoIsComplete;
 
     for (const auto& idAndHash : idAndBlockHashes) {
         CSparkState::SparkCoinGroupInfo coinGroup;
         if (!sparkState.GetCoinGroupInfo(idAndHash.first, coinGroup)) {
-            if (fStatefulSigmaCheck)
+            if (fRequireProofInputs)
                 return state.DoS(100, false, NO_MINT_ZEROCOIN,
                                  "CheckSparkSpendTransaction: Error: no coins were minted with such parameters");
             else
@@ -725,7 +767,7 @@ bool CheckSparkSpendTransaction(
         while (index != coinGroup.firstBlock && index->GetBlockHash() != idAndHash.second)
             index = index->pprev;
 
-        if (index->GetBlockHash() != idAndHash.second && !fStatefulSigmaCheck)
+        if (index->GetBlockHash() != idAndHash.second && !fRequireProofInputs)
             // if fStatefulSigmaCheck is false, we are in the mempool acceptance code, it's a soft error
             // just return true. If fStatefulSigmaCheck is true, use coinGroup.firstBlock as a reference block
             return true;
@@ -773,14 +815,15 @@ bool CheckSparkSpendTransaction(
         cover_set_data [idAndHash.first] = setData;
     }
     spend->setCoverSets(cover_set_data);
-    spend->setVout(Vout);
 
     const std::vector<uint64_t>& ids = spend->getCoinGroupIds();
     for (const auto& id : ids) {
         if (!cover_sets.count(id) || !cover_set_data.count(id))
-            return fStatefulSigmaCheck ? state.DoS(100,
+            return fRequireProofInputs ? state.DoS(100,
                              error("CheckSparkSpendTransaction: No cover set found.")) : true;
     }
+
+    const uint256 proofInputHash = GetSparkSpendProofInputHash(hashTx, idAndBlockHashes, cover_set_data, cover_sets);
     
     // if we are collecting proofs, skip verification and collect proofs
     // add proofs into container
@@ -789,101 +832,48 @@ bool CheckSparkSpendTransaction(
         batchProofContainer->add(*spend);
     } else {
         bool fChecked = false;
-        bool scheduledAsync = false;
 
         try {
-            bool fRecheckNeeded;
-            do {
-                fRecheckNeeded = false;
-
+            {
                 LOCK(cs_checkedSparkSpendTransactions);
-                if (gCheckedSparkSpendTransactions.count(hashTx)) {
-                    auto& checkState = gCheckedSparkSpendTransactions[hashTx];
+                auto it = gCheckedSparkSpendTransactions.find(hashTx);
+                if (it != gCheckedSparkSpendTransactions.end()) {
+                    auto& checkState = it->second;
                     if (checkState.fChecked) {
-                        if (!checkState.fResult)
+                        if (checkState.proofInputHash != proofInputHash) {
+                            LogPrintf("CheckSparkSpendTransaction: cached proof inputs changed for tx %s\n", hashTx.ToString());
+                            gCheckedSparkSpendTransactions.erase(it);
+                        } else if (!checkState.fResult) {
                             return state.DoS(100, false, REJECT_INVALID, "CheckSparkSpendTransaction: previously checked and failed");
-                        else {
+                        } else {
                             LogPrintf("CheckSparkSpendTransaction: already checked tx %s\n", hashTx.ToString());
                             fChecked = true;
                         }
                     }
-                    // If the check is in progress and we are doing a stateful check, we need to wait
-                    else if (checkState.checkInProgress && fStatefulSigmaCheck) {
-                        // wait for the check to complete
-                        auto future = checkState.checkInProgress;
-                        cs_checkedSparkSpendTransactions.unlock();
-                        bool result = future->get();
-                        cs_checkedSparkSpendTransactions.lock();
-
-                        // Entry may have been erased by DisconnectTipSpark during the unlock window
-                        auto it = gCheckedSparkSpendTransactions.find(hashTx);
-                        if (it == gCheckedSparkSpendTransactions.end()) {
-                            fRecheckNeeded = true;
-                            continue;
-                        }
-                        ProofCheckState& checkStateAfterWait = it->second;
-
-                        checkStateAfterWait.fChecked = true;
-                        checkStateAfterWait.fResult = result;
-                        checkStateAfterWait.checkInProgress = nullptr;
-
-                        if (!result) {
-                            // unfortunately, it's possible that the proof was checked and failed
-                            // because the anonymity set was incomplete at the time of checking. We need
-                            // to recheck the proof again
-                            fRecheckNeeded = true;
-                            gCheckedSparkSpendTransactions.erase(hashTx);
-                        }
-                        else
-                            fChecked = true;
-                    }
-                }
-                else if (!fStatefulSigmaCheck && !gCheckProofThreadPool.IsPoolShutdown()) {
-                    // not an urgent check, put the proof into the thread pool for verification
-                    // don't post a request if there are too many tasks already
-                    if (gCheckProofThreadPool.GetPendingTaskCount() < (std::size_t)gCheckProofThreadPool.GetNumberOfThreads()/2) {
-                        auto future = gCheckProofThreadPool.PostTask([spend, cover_sets]() mutable {
-                            try {
-                                bool result = spark::SpendTransaction::verify(*spend, cover_sets);
-                                spend.reset();
-                                cover_sets.clear();
-                                return result;
-                            } catch (const std::exception &) {
-                                return false;
-                            }
-                        });
-                        auto &checkState = gCheckedSparkSpendTransactions[hashTx];
-                        checkState.fChecked = false;
-                        checkState.fResult = false;
-                        checkState.checkInProgress = std::make_shared<boost::future<bool>>(std::move(future));
-                        scheduledAsync = true;
-                    }
                 }
             }
-            while (fRecheckNeeded);
 
             if (fChecked) {
                 // if we are here, then the proof was already checked and it passed
                 passVerify = true;
             }
             else {
-                if (fStatefulSigmaCheck) {
-                    // we need the answer now, so verify and execute
-                    passVerify = spark::SpendTransaction::verify(*spend, cover_sets);
-                }
-                else {
-                    if (scheduledAsync) {
-                        // result will be processed later by the async task
-                        passVerify = true;
-                    } else {
-                        // Pool was busy so verification was not scheduled; verify synchronously for defense-in-depth
-                        passVerify = spark::SpendTransaction::verify(*spend, cover_sets);
-                    }
-                }
+                passVerify = spark::SpendTransaction::verify(*spend, cover_sets);
             }
         }
         catch (const std::exception &) {
             passVerify = false;
+        }
+
+        if (passVerify) {
+            LOCK(cs_checkedSparkSpendTransactions);
+            if (gCheckedSparkSpendTransactions.size() >= MAX_CACHED_SPARK_SPEND_PROOFS)
+                gCheckedSparkSpendTransactions.clear();
+
+            auto& checkState = gCheckedSparkSpendTransactions[hashTx];
+            checkState.fChecked = true;
+            checkState.fResult = true;
+            checkState.proofInputHash = proofInputHash;
         }
 
     }
@@ -951,7 +941,8 @@ bool CheckSparkTransaction(
         int nHeight,
         bool isCheckWallet,
         bool fStatefulSigmaCheck,
-        CSparkTxInfo* sparkTxInfo)
+        CSparkTxInfo* sparkTxInfo,
+        bool fVerifySparkSpendProof)
 {
     Consensus::Params const & consensus = ::Params().GetConsensus();
 
@@ -996,14 +987,14 @@ bool CheckSparkTransaction(
                              "bad-txns-spend-invalid");
         }
 
-        if (!isVerifyDB) {
-            try {
-                if (!CheckSparkSpendTransaction(
-                        tx, state, hashTx, isVerifyDB, nHeight,
-                        isCheckWallet, fStatefulSigmaCheck, sparkTxInfo)) {
-                    return false;
-                }
+        try {
+            if (!CheckSparkSpendTransaction(
+                    tx, state, hashTx, isVerifyDB, nHeight,
+                    isCheckWallet, fStatefulSigmaCheck, sparkTxInfo, fVerifySparkSpendProof)) {
+                return false;
+            }
 
+            if (!isVerifyDB) {
                 CSparkNameManager *sparkNameManager = CSparkNameManager::GetInstance();
                 CSparkNameTxData sparkTxData;
                 if (sparkNameManager->CheckSparkNameTx(tx, nRealHeight, state, &sparkTxData)) {
@@ -1021,11 +1012,10 @@ bool CheckSparkTransaction(
                 else {
                     return false;
                 }
-
             }
-            catch (const std::exception &x) {
-                return state.Error(x.what());
-            }
+        }
+        catch (const std::exception &x) {
+            return state.Error(x.what());
         }
     }
 
@@ -1033,7 +1023,6 @@ bool CheckSparkTransaction(
 }
 
 void ShutdownSparkState() {
-    gCheckProofThreadPool.Shutdown();
 }
 
 uint256 GetTxHashFromCoin(const spark::Coin& coin) {

--- a/src/spark/state.cpp
+++ b/src/spark/state.cpp
@@ -743,9 +743,8 @@ bool CheckSparkSpendTransaction(
 
     const bool fRequireProofInputs = fStatefulSigmaCheck || isVerifyDB;
     BatchProofContainer* batchProofContainer = BatchProofContainer::get_instance();
-    const bool fMustVerifyBeforeStateUpdate = fStatefulSigmaCheck;
+    // ConnectBlock completes this batch before persistent block/Spark state updates.
     bool useBatching = batchProofContainer->fCollectProofs &&
-        !fMustVerifyBeforeStateUpdate &&
         !isVerifyDB &&
         !isCheckWallet &&
         sparkTxInfo &&

--- a/src/spark/state.cpp
+++ b/src/spark/state.cpp
@@ -651,7 +651,13 @@ bool CheckSparkSpendTransaction(
         bool isCheckWallet,
         bool fStatefulSigmaCheck,
         CSparkTxInfo* sparkTxInfo,
-        bool fVerifySparkSpendProof) {
+        bool fVerifySparkSpendProof,
+        SparkSpendProofVerificationResult* sparkSpendProofResult) {
+
+    auto setProofResult = [sparkSpendProofResult](SparkSpendProofVerificationResult result) {
+        if (sparkSpendProofResult)
+            *sparkSpendProofResult = result;
+    };
 
     std::unordered_set<GroupElement, spark::CLTagHash> txLTags;
 
@@ -734,8 +740,10 @@ bool CheckSparkSpendTransaction(
     spend->setVout(Vout);
 
     const bool fVerifyProofNow = fVerifySparkSpendProof || fStatefulSigmaCheck;
-    if (!fVerifyProofNow)
+    if (!fVerifyProofNow) {
+        setProofResult(SparkSpendProofVerificationResult::Deferred);
         return true;
+    }
 
     std::unordered_map<uint64_t, std::vector<Coin>> cover_sets;
     std::unordered_map<uint64_t, CoverSetData> cover_set_data;
@@ -743,12 +751,14 @@ bool CheckSparkSpendTransaction(
 
     const bool fRequireProofInputs = fStatefulSigmaCheck || isVerifyDB;
     BatchProofContainer* batchProofContainer = BatchProofContainer::get_instance();
-    // ConnectBlock completes this batch before persistent block/Spark state updates.
+    // ConnectBlock finalizes and verifies this batch before persistent block,
+    // index, or Spark state updates.
     bool useBatching = batchProofContainer->fCollectProofs &&
         !isVerifyDB &&
         !isCheckWallet &&
         sparkTxInfo &&
         !sparkTxInfo->fInfoIsComplete;
+    const bool fNeedFullCoverSets = !useBatching;
 
     for (const auto& idAndHash : idAndBlockHashes) {
         CSparkState::SparkCoinGroupInfo coinGroup;
@@ -756,9 +766,11 @@ bool CheckSparkSpendTransaction(
             if (fRequireProofInputs)
                 return state.DoS(100, false, NO_MINT_ZEROCOIN,
                                  "CheckSparkSpendTransaction: Error: no coins were minted with such parameters");
-            else
+            else {
                 // soft error, will check the proof later
+                setProofResult(SparkSpendProofVerificationResult::Deferred);
                 return true;
+            }
         }
 
         CBlockIndex *index = coinGroup.lastBlock;
@@ -766,10 +778,12 @@ bool CheckSparkSpendTransaction(
         while (index != coinGroup.firstBlock && index->GetBlockHash() != idAndHash.second)
             index = index->pprev;
 
-        if (index->GetBlockHash() != idAndHash.second && !fRequireProofInputs)
+        if (index->GetBlockHash() != idAndHash.second && !fRequireProofInputs) {
             // if fStatefulSigmaCheck is false, we are in the mempool acceptance code, it's a soft error
             // just return true. If fStatefulSigmaCheck is true, use coinGroup.firstBlock as a reference block
+            setProofResult(SparkSpendProofVerificationResult::Deferred);
             return true;
+        }
 
         // take the hash from last block of anonymity set
         std::vector<unsigned char> set_hash = GetAnonymitySetHash(index, idAndHash.first);
@@ -793,7 +807,7 @@ bool CheckSparkSpendTransaction(
                     const auto& coin,
                     index->sparkMintedCoins[id]) {
                         set_size++;
-                        if (!useBatching)
+                        if (fNeedFullCoverSets)
                             cover_set.push_back(coin);
                     }
                 }
@@ -817,64 +831,62 @@ bool CheckSparkSpendTransaction(
 
     const std::vector<uint64_t>& ids = spend->getCoinGroupIds();
     for (const auto& id : ids) {
-        if (!cover_sets.count(id) || !cover_set_data.count(id))
+        if (!cover_sets.count(id) || !cover_set_data.count(id)) {
+            setProofResult(SparkSpendProofVerificationResult::Deferred);
             return fRequireProofInputs ? state.DoS(100,
                              error("CheckSparkSpendTransaction: No cover set found.")) : true;
+        }
     }
 
     const uint256 proofInputHash = GetSparkSpendProofInputHash(hashTx, idAndBlockHashes, cover_set_data, cover_sets);
     
-    // if we are collecting proofs, skip verification and collect proofs
-    // add proofs into container
-    if (useBatching) {
-        passVerify = true;
-        batchProofContainer->add(*spend);
-    } else {
-        bool fChecked = false;
+    bool fChecked = false;
 
-        try {
-            {
-                LOCK(cs_checkedSparkSpendTransactions);
-                auto it = gCheckedSparkSpendTransactions.find(hashTx);
-                if (it != gCheckedSparkSpendTransactions.end()) {
-                    auto& checkState = it->second;
-                    if (checkState.fChecked) {
-                        if (checkState.proofInputHash != proofInputHash) {
-                            LogPrintf("CheckSparkSpendTransaction: cached proof inputs changed for tx %s\n", hashTx.ToString());
-                            gCheckedSparkSpendTransactions.erase(it);
-                        } else if (!checkState.fResult) {
-                            return state.DoS(100, false, REJECT_INVALID, "CheckSparkSpendTransaction: previously checked and failed");
-                        } else {
-                            LogPrintf("CheckSparkSpendTransaction: already checked tx %s\n", hashTx.ToString());
-                            fChecked = true;
-                        }
-                    }
+    try {
+        {
+            LOCK(cs_checkedSparkSpendTransactions);
+            auto it = gCheckedSparkSpendTransactions.find(hashTx);
+            if (it != gCheckedSparkSpendTransactions.end()) {
+                auto& checkState = it->second;
+                if (checkState.proofInputHash != proofInputHash) {
+                    LogPrintf("CheckSparkSpendTransaction: cached proof inputs changed for tx %s\n", hashTx.ToString());
+                    gCheckedSparkSpendTransactions.erase(it);
+                } else if (checkState.fChecked) {
+                    if (!checkState.fResult)
+                        return state.DoS(100, false, REJECT_INVALID, "CheckSparkSpendTransaction: previously checked and failed");
+
+                    LogPrintf("CheckSparkSpendTransaction: already checked tx %s\n", hashTx.ToString());
+                    fChecked = true;
                 }
             }
-
-            if (fChecked) {
-                // if we are here, then the proof was already checked and it passed
-                passVerify = true;
-            }
-            else {
-                passVerify = spark::SpendTransaction::verify(*spend, cover_sets);
-            }
-        }
-        catch (const std::exception &) {
-            passVerify = false;
         }
 
-        if (passVerify) {
-            LOCK(cs_checkedSparkSpendTransactions);
-            if (gCheckedSparkSpendTransactions.size() >= MAX_CACHED_SPARK_SPEND_PROOFS)
-                gCheckedSparkSpendTransactions.clear();
-
-            auto& checkState = gCheckedSparkSpendTransactions[hashTx];
-            checkState.fChecked = true;
-            checkState.fResult = true;
-            checkState.proofInputHash = proofInputHash;
+        if (fChecked) {
+            passVerify = true;
+            setProofResult(SparkSpendProofVerificationResult::Verified);
+        } else if (useBatching) {
+            passVerify = true;
+            batchProofContainer->add(*spend);
+            setProofResult(SparkSpendProofVerificationResult::Batched);
+        } else {
+            passVerify = spark::SpendTransaction::verify(*spend, cover_sets);
+            if (passVerify)
+                setProofResult(SparkSpendProofVerificationResult::Verified);
         }
+    }
+    catch (const std::exception &) {
+        passVerify = false;
+    }
 
+    if (passVerify && !useBatching) {
+        LOCK(cs_checkedSparkSpendTransactions);
+        if (gCheckedSparkSpendTransactions.size() >= MAX_CACHED_SPARK_SPEND_PROOFS)
+            gCheckedSparkSpendTransactions.clear();
+
+        auto& checkState = gCheckedSparkSpendTransactions[hashTx];
+        checkState.fChecked = true;
+        checkState.fResult = true;
+        checkState.proofInputHash = proofInputHash;
     }
 
     if (!fStatefulSigmaCheck)
@@ -941,8 +953,12 @@ bool CheckSparkTransaction(
         bool isCheckWallet,
         bool fStatefulSigmaCheck,
         CSparkTxInfo* sparkTxInfo,
-        bool fVerifySparkSpendProof)
+        bool fVerifySparkSpendProof,
+        SparkSpendProofVerificationResult* sparkSpendProofResult)
 {
+    if (sparkSpendProofResult)
+        *sparkSpendProofResult = SparkSpendProofVerificationResult::NotApplicable;
+
     Consensus::Params const & consensus = ::Params().GetConsensus();
 
     bool const allowSpark = IsSparkAllowed();
@@ -989,7 +1005,8 @@ bool CheckSparkTransaction(
         try {
             if (!CheckSparkSpendTransaction(
                     tx, state, hashTx, isVerifyDB, nHeight,
-                    isCheckWallet, fStatefulSigmaCheck, sparkTxInfo, fVerifySparkSpendProof)) {
+                    isCheckWallet, fStatefulSigmaCheck, sparkTxInfo, fVerifySparkSpendProof,
+                    sparkSpendProofResult)) {
                 return false;
             }
 

--- a/src/spark/state.cpp
+++ b/src/spark/state.cpp
@@ -739,7 +739,7 @@ bool CheckSparkSpendTransaction(
     spend->setOutCoins(out_coins);
     spend->setVout(Vout);
 
-    const bool fVerifyProofNow = fVerifySparkSpendProof || fStatefulSigmaCheck;
+    const bool fVerifyProofNow = fVerifySparkSpendProof || fStatefulSigmaCheck || (isVerifyDB && !isCheckWallet);
     if (!fVerifyProofNow) {
         setProofResult(SparkSpendProofVerificationResult::Deferred);
         return true;

--- a/src/spark/state.h
+++ b/src/spark/state.h
@@ -81,7 +81,8 @@ bool CheckSparkTransaction(
         int nHeight,
         bool isCheckWallet,
         bool fStatefulSigmaCheck,
-        CSparkTxInfo* sparkTxInfo);
+        CSparkTxInfo* sparkTxInfo,
+        bool fVerifySparkSpendProof = true);
 
 // call this on shutdown
 void ShutdownSparkState();

--- a/src/spark/state.h
+++ b/src/spark/state.h
@@ -42,6 +42,13 @@ public:
     void Complete();
 };
 
+enum class SparkSpendProofVerificationResult {
+    NotApplicable,
+    Verified,
+    Deferred,
+    Batched
+};
+
 // check if spark activation block is passed
 bool IsSparkAllowed();
 bool IsSparkAllowed(int height);
@@ -82,7 +89,8 @@ bool CheckSparkTransaction(
         bool isCheckWallet,
         bool fStatefulSigmaCheck,
         CSparkTxInfo* sparkTxInfo,
-        bool fVerifySparkSpendProof = true);
+        bool fVerifySparkSpendProof = true,
+        SparkSpendProofVerificationResult* sparkSpendProofResult = nullptr);
 
 // call this on shutdown
 void ShutdownSparkState();

--- a/src/test/spark_tests.cpp
+++ b/src/test/spark_tests.cpp
@@ -557,7 +557,11 @@ BOOST_AUTO_TEST_CASE(checktransaction)
 
     CValidationState walletLoadState;
     BOOST_CHECK(CheckTransaction(
-            tamperedSpend, walletLoadState, true, tamperedSpend.GetHash(), true, INT_MAX, false, false, NULL, false));
+            tamperedSpend, walletLoadState, true, tamperedSpend.GetHash(), true, INT_MAX, true, false, NULL, false));
+
+    CValidationState directVerifyDBState;
+    BOOST_CHECK(!CheckTransaction(
+            tamperedSpend, directVerifyDBState, true, tamperedSpend.GetHash(), true, INT_MAX, false, false, NULL, false));
 
     CSparkTxInfo statefulDeferredInfo;
     CValidationState statefulDeferredState;

--- a/src/test/spark_tests.cpp
+++ b/src/test/spark_tests.cpp
@@ -559,6 +559,13 @@ BOOST_AUTO_TEST_CASE(checktransaction)
     BOOST_CHECK(CheckTransaction(
             tamperedSpend, walletLoadState, true, tamperedSpend.GetHash(), true, INT_MAX, true, false, NULL, false));
 
+    CMutableTransaction walletLoadMalformedSpendTx(spendTx);
+    walletLoadMalformedSpendTx.vout.push_back(CTxOut(0, CScript() << OP_SPARKMINT));
+    CTransaction walletLoadMalformedSpend(walletLoadMalformedSpendTx);
+    CValidationState walletLoadMalformedState;
+    BOOST_CHECK(!CheckTransaction(
+            walletLoadMalformedSpend, walletLoadMalformedState, true, walletLoadMalformedSpend.GetHash(), true, INT_MAX, true, false, NULL, false));
+
     CValidationState directVerifyDBState;
     BOOST_CHECK(!CheckTransaction(
             tamperedSpend, directVerifyDBState, true, tamperedSpend.GetHash(), true, INT_MAX, false, false, NULL, false));
@@ -582,7 +589,16 @@ BOOST_AUTO_TEST_CASE(checktransaction)
     CValidationState verifiedValidBlockState;
     BOOST_CHECK(CheckBlock(
             verifiedValidBlock, verifiedValidBlockState, consensus, true, true, chainActive.Height() + 1, false));
-    BOOST_CHECK(verifiedValidBlock.fChecked);
+    BOOST_CHECK(!verifiedValidBlock.fChecked);
+
+    sparkState->Reset();
+
+    CValidationState verifiedValidBlockVerifyDBState;
+    BOOST_CHECK(!CheckBlock(
+            verifiedValidBlock, verifiedValidBlockVerifyDBState, consensus, true, true, chainActive.Height() + 1, true));
+    BOOST_CHECK(!verifiedValidBlock.fChecked);
+
+    BOOST_CHECK(BuildSparkStateFromIndex(&chainActive));
 
     CBlock tamperedBlock = CreateBlock({tamperedSpendTx}, script);
     CValidationState deferredBlockState;
@@ -673,6 +689,22 @@ BOOST_AUTO_TEST_CASE(checktransaction)
     for (const auto& lTag : spend.getUsedLTags()) {
         BOOST_CHECK(!sparkState->IsUsedLTag(lTag));
     }
+
+    batchProofContainer->fCollectProofs = true;
+    batchProofContainer->init();
+
+    CBlock batchedTamperedDeferredBlock = CreateBlock({batchedTamperedSpendTx}, script);
+    CValidationState batchedTamperedDeferredBlockState;
+    BOOST_CHECK(CheckBlock(
+            batchedTamperedDeferredBlock, batchedTamperedDeferredBlockState, consensus, true, true, chainActive.Height() + 1, false, true));
+    BOOST_CHECK(!batchedTamperedDeferredBlock.fChecked);
+
+    CBlock batchedTamperedVerifiedBlock = CreateBlock({batchedTamperedSpendTx}, script);
+    CValidationState batchedTamperedVerifiedBlockState;
+    BOOST_CHECK(!CheckBlock(
+            batchedTamperedVerifiedBlock, batchedTamperedVerifiedBlockState, consensus, true, true, chainActive.Height() + 1, false));
+    BOOST_CHECK(!batchedTamperedVerifiedBlock.fChecked);
+    batchProofContainer->clear();
 
     batchProofContainer->fCollectProofs = false;
     batchProofContainer->init();

--- a/src/test/spark_tests.cpp
+++ b/src/test/spark_tests.cpp
@@ -9,6 +9,7 @@
 #include "test_bitcoin.h"
 #include "fixtures.h"
 #include <iostream>
+#include <stdexcept>
 #include <boost/test/unit_test.hpp>
 
 namespace spark {
@@ -564,6 +565,18 @@ BOOST_AUTO_TEST_CASE(checktransaction)
     BOOST_CHECK(!CheckSparkTransaction(
             tamperedSpend, nonStatefulVerifiedState, tamperedSpend.GetHash(), false, chainActive.Height(), false, false, NULL));
 
+    CBlock deferredValidBlock = CreateBlock({spendTx}, script);
+    CValidationState deferredValidBlockState;
+    BOOST_CHECK(CheckBlock(
+            deferredValidBlock, deferredValidBlockState, consensus, true, true, chainActive.Height() + 1, false, true));
+    BOOST_CHECK(!deferredValidBlock.fChecked);
+
+    CBlock verifiedValidBlock = CreateBlock({spendTx}, script);
+    CValidationState verifiedValidBlockState;
+    BOOST_CHECK(CheckBlock(
+            verifiedValidBlock, verifiedValidBlockState, consensus, true, true, chainActive.Height() + 1, false));
+    BOOST_CHECK(verifiedValidBlock.fChecked);
+
     CBlock tamperedBlock = CreateBlock({tamperedSpendTx}, script);
     CValidationState deferredBlockState;
     BOOST_CHECK(CheckBlock(
@@ -586,8 +599,11 @@ BOOST_AUTO_TEST_CASE(checktransaction)
 
     CSparkTxInfo batchedTamperedInfo;
     CValidationState batchedVerifiedState;
-    BOOST_CHECK(!CheckSparkTransaction(
+    BOOST_CHECK(CheckSparkTransaction(
             tamperedSpend, batchedVerifiedState, tamperedSpend.GetHash(), false, chainActive.Height(), false, true, &batchedTamperedInfo));
+    batchProofContainer->finalize();
+    BOOST_CHECK_THROW(batchProofContainer->verify(), std::invalid_argument);
+    batchProofContainer->clear();
 
     batchProofContainer->fCollectProofs = false;
     batchProofContainer->init();

--- a/src/test/spark_tests.cpp
+++ b/src/test/spark_tests.cpp
@@ -1,6 +1,7 @@
 #include "../chainparams.h"
 #include "../batchproof_container.h"
 #include "../script/standard.h"
+#include "../utiltime.h"
 #include "../validation.h"
 #include "../wallet/coincontrol.h"
 #include "../wallet/wallet.h"
@@ -548,9 +549,11 @@ BOOST_AUTO_TEST_CASE(checktransaction)
     tamperedSpendTx.vout[0].nValue += CENT;
     CTransaction tamperedSpend(tamperedSpendTx);
 
+    SparkSpendProofVerificationResult deferredProofResult;
     CValidationState deferredState;
     BOOST_CHECK(CheckSparkTransaction(
-            tamperedSpend, deferredState, tamperedSpend.GetHash(), false, chainActive.Height(), false, false, NULL, false));
+            tamperedSpend, deferredState, tamperedSpend.GetHash(), false, chainActive.Height(), false, false, NULL, false, &deferredProofResult));
+    BOOST_CHECK(deferredProofResult == SparkSpendProofVerificationResult::Deferred);
 
     CValidationState walletLoadState;
     BOOST_CHECK(CheckTransaction(
@@ -593,17 +596,79 @@ BOOST_AUTO_TEST_CASE(checktransaction)
             tamperedBlock, verifyDBBlockState, consensus, true, true, chainActive.Height() + 1, true, true));
     BOOST_CHECK(!tamperedBlock.fChecked);
 
+    CBlock missingSparkStateBlock = CreateBlock({spendTx}, script);
+    CBlock missingSparkStateVerifyDBBlock = CreateBlock({spendTx}, script);
+
+    sparkState->Reset();
+
+    CValidationState missingSparkStateBlockState;
+    BOOST_CHECK(CheckBlock(
+            missingSparkStateBlock, missingSparkStateBlockState, consensus, true, true, chainActive.Height() + 1, false));
+    BOOST_CHECK(!missingSparkStateBlock.fChecked);
+
+    CValidationState missingSparkStateVerifyDBBlockState;
+    BOOST_CHECK(!CheckBlock(
+            missingSparkStateVerifyDBBlock, missingSparkStateVerifyDBBlockState, consensus, true, true, chainActive.Height() + 1, true));
+    BOOST_CHECK(!missingSparkStateVerifyDBBlock.fChecked);
+
+    BOOST_CHECK(BuildSparkStateFromIndex(&chainActive));
+
+    std::vector<CMutableTransaction> laterMintTxs;
+    GenerateMints({2 * COIN, 3 * COIN}, laterMintTxs);
+    mempool.clear();
+    BOOST_CHECK(GenerateBlock(laterMintTxs));
+
     BatchProofContainer* batchProofContainer = BatchProofContainer::get_instance();
+
     batchProofContainer->fCollectProofs = true;
     batchProofContainer->init();
 
+    SparkSpendProofVerificationResult batchedValidProofResult;
+    CSparkTxInfo batchedValidInfo;
+    CValidationState batchedValidState;
+    BOOST_CHECK(CheckSparkTransaction(
+            spendTx, batchedValidState, spendTx.GetHash(), false, chainActive.Height(), false, true, &batchedValidInfo, true, &batchedValidProofResult));
+    BOOST_CHECK(batchedValidProofResult == SparkSpendProofVerificationResult::Batched);
+    batchProofContainer->finalize();
+    BOOST_CHECK_NO_THROW(batchProofContainer->verify());
+    batchProofContainer->clear();
+
+    batchProofContainer->fCollectProofs = true;
+    batchProofContainer->init();
+
+    CMutableTransaction batchedTamperedSpendTx(spendTx);
+    batchedTamperedSpendTx.vout[0].nValue += 2 * CENT;
+    CTransaction batchedTamperedSpend(batchedTamperedSpendTx);
+
+    SparkSpendProofVerificationResult batchedProofResult;
     CSparkTxInfo batchedTamperedInfo;
     CValidationState batchedVerifiedState;
     BOOST_CHECK(CheckSparkTransaction(
-            tamperedSpend, batchedVerifiedState, tamperedSpend.GetHash(), false, chainActive.Height(), false, true, &batchedTamperedInfo));
+            batchedTamperedSpend, batchedVerifiedState, batchedTamperedSpend.GetHash(), false, chainActive.Height(), false, true, &batchedTamperedInfo, true, &batchedProofResult));
+    BOOST_CHECK(batchedProofResult == SparkSpendProofVerificationResult::Batched);
     batchProofContainer->finalize();
     BOOST_CHECK_THROW(batchProofContainer->verify(), std::invalid_argument);
     batchProofContainer->clear();
+
+    CBlock connectTamperedBlock = CreateBlock({batchedTamperedSpendTx}, script);
+    CBlockIndex connectTamperedIndex(connectTamperedBlock);
+    connectTamperedIndex.pprev = chainActive.Tip();
+    connectTamperedIndex.nHeight = chainActive.Height() + 1;
+    connectTamperedIndex.nTime = GetSystemTimeInSeconds() - 2 * 86400;
+
+    CCoinsViewCache connectTamperedView(pcoinsTip);
+    CValidationState connectTamperedState;
+    BOOST_CHECK(!ConnectBlock(
+            connectTamperedBlock,
+            connectTamperedState,
+            &connectTamperedIndex,
+            connectTamperedView,
+            ::Params(),
+            true));
+    BOOST_CHECK(!connectTamperedState.IsValid());
+    for (const auto& lTag : spend.getUsedLTags()) {
+        BOOST_CHECK(!sparkState->IsUsedLTag(lTag));
+    }
 
     batchProofContainer->fCollectProofs = false;
     batchProofContainer->init();

--- a/src/test/spark_tests.cpp
+++ b/src/test/spark_tests.cpp
@@ -1,4 +1,5 @@
 #include "../chainparams.h"
+#include "../batchproof_container.h"
 #include "../script/standard.h"
 #include "../validation.h"
 #include "../wallet/coincontrol.h"
@@ -541,6 +542,60 @@ BOOST_AUTO_TEST_CASE(checktransaction)
     info.spTransactions.clear();
     BOOST_CHECK(!CheckSparkTransaction(
             spendTx, state, spendTx.GetHash(), false, chainActive.Height(), false, true, &info));
+
+    CMutableTransaction tamperedSpendTx(spendTx);
+    tamperedSpendTx.vout[0].nValue += CENT;
+    CTransaction tamperedSpend(tamperedSpendTx);
+
+    CValidationState deferredState;
+    BOOST_CHECK(CheckSparkTransaction(
+            tamperedSpend, deferredState, tamperedSpend.GetHash(), false, chainActive.Height(), false, false, NULL, false));
+
+    CValidationState walletLoadState;
+    BOOST_CHECK(CheckTransaction(
+            tamperedSpend, walletLoadState, true, tamperedSpend.GetHash(), true, INT_MAX, false, false, NULL, false));
+
+    CSparkTxInfo statefulDeferredInfo;
+    CValidationState statefulDeferredState;
+    BOOST_CHECK(!CheckSparkTransaction(
+            tamperedSpend, statefulDeferredState, tamperedSpend.GetHash(), false, chainActive.Height(), false, true, &statefulDeferredInfo, false));
+
+    CValidationState nonStatefulVerifiedState;
+    BOOST_CHECK(!CheckSparkTransaction(
+            tamperedSpend, nonStatefulVerifiedState, tamperedSpend.GetHash(), false, chainActive.Height(), false, false, NULL));
+
+    CBlock tamperedBlock = CreateBlock({tamperedSpendTx}, script);
+    CValidationState deferredBlockState;
+    BOOST_CHECK(CheckBlock(
+            tamperedBlock, deferredBlockState, consensus, true, true, chainActive.Height() + 1, false, true));
+    BOOST_CHECK(!tamperedBlock.fChecked);
+
+    CValidationState verifiedBlockState;
+    BOOST_CHECK(!CheckBlock(
+            tamperedBlock, verifiedBlockState, consensus, true, true, chainActive.Height() + 1, false));
+    BOOST_CHECK(!tamperedBlock.fChecked);
+
+    CValidationState verifyDBBlockState;
+    BOOST_CHECK(!CheckBlock(
+            tamperedBlock, verifyDBBlockState, consensus, true, true, chainActive.Height() + 1, true, true));
+    BOOST_CHECK(!tamperedBlock.fChecked);
+
+    BatchProofContainer* batchProofContainer = BatchProofContainer::get_instance();
+    batchProofContainer->fCollectProofs = true;
+    batchProofContainer->init();
+
+    CSparkTxInfo batchedTamperedInfo;
+    CValidationState batchedVerifiedState;
+    BOOST_CHECK(!CheckSparkTransaction(
+            tamperedSpend, batchedVerifiedState, tamperedSpend.GetHash(), false, chainActive.Height(), false, true, &batchedTamperedInfo));
+
+    batchProofContainer->fCollectProofs = false;
+    batchProofContainer->init();
+
+    CSparkTxInfo tamperedInfo;
+    CValidationState verifiedState;
+    BOOST_CHECK(!CheckSparkTransaction(
+            tamperedSpend, verifiedState, tamperedSpend.GetHash(), false, chainActive.Height(), false, true, &tamperedInfo));
 
     mempool.clear();
     sparkState->Reset();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -30,6 +30,7 @@
 #include "script/script.h"
 #include "script/sigcache.h"
 #include "script/standard.h"
+#include "spark/state.h"
 #include "timedata.h"
 #include "tinyformat.h"
 #include "txdb.h"
@@ -573,8 +574,11 @@ int GetUTXOConfirmations(const COutPoint& outpoint)
     return (nPrevoutHeight > -1 && chainActive.Tip()) ? chainActive.Height() - nPrevoutHeight + 1 : -1;
 }
 
-bool CheckTransaction(const CTransaction &tx, CValidationState &state, bool fCheckDuplicateInputs, uint256 hashTx,  bool isVerifyDB, int nHeight, bool isCheckWallet, bool fStatefulZerocoinCheck, spark::CSparkTxInfo* sparkTxInfo, bool fVerifySparkSpendProof)
+bool CheckTransaction(const CTransaction &tx, CValidationState &state, bool fCheckDuplicateInputs, uint256 hashTx,  bool isVerifyDB, int nHeight, bool isCheckWallet, bool fStatefulZerocoinCheck, spark::CSparkTxInfo* sparkTxInfo, bool fVerifySparkSpendProof, spark::SparkSpendProofVerificationResult* sparkSpendProofResult)
 {
+    if (sparkSpendProofResult)
+        *sparkSpendProofResult = spark::SparkSpendProofVerificationResult::NotApplicable;
+
     LogPrintf("CheckTransaction nHeight=%d, isVerifyDB=%d, isCheckWallet=%d, txHash=%s\n", nHeight, (int)isVerifyDB, (int)isCheckWallet, tx.GetHash().ToString());
 
     bool allowEmptyTxInOut = false;
@@ -699,7 +703,7 @@ bool CheckTransaction(const CTransaction &tx, CValidationState &state, bool fChe
         if (tx.IsSparkTransaction()) {
             if (hasExchangeUTXOs)
                 return state.DoS(100, false, REJECT_INVALID, "bad-exchange-address");
-            if (!CheckSparkTransaction(tx, state, hashTx, isVerifyDB, nHeight, isCheckWallet, fStatefulZerocoinCheck, sparkTxInfo, fVerifySparkSpendProof))
+            if (!CheckSparkTransaction(tx, state, hashTx, isVerifyDB, nHeight, isCheckWallet, fStatefulZerocoinCheck, sparkTxInfo, fVerifySparkSpendProof, sparkSpendProofResult))
                 return false;
         }
 
@@ -4213,19 +4217,21 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
     LogPrintf("CheckBlock() nHeight=%d, blockHash=%s, isVerifyDB=%d\n", nHeight, block.GetHash().ToString(), isVerifyDB);
 
     // Only callers that immediately run stateful Spark checks may defer this expensive proof.
-    // VerifyDB keeps its explicit proof-verification request.
     const bool fVerifySparkSpendProof = isVerifyDB || !fDeferSparkSpendProofVerification;
-    // CheckBlock passes no Spark tx info, so verified Spark spend proofs complete
+    // CheckBlock passes no Spark tx info, so non-deferred proof checks complete
     // synchronously here; deferred import blocks are deliberately not cached.
     bool fSparkSpendProofsComplete = true;
     for (CTransactionRef tx : block.vtx) {
-        if (tx->IsSparkSpend())
-            fSparkSpendProofsComplete = fSparkSpendProofsComplete && fVerifySparkSpendProof;
+        spark::SparkSpendProofVerificationResult sparkSpendProofResult = spark::SparkSpendProofVerificationResult::NotApplicable;
 
         // We don't check transactions against sigma/lelantus state here, we'll check it again later in ConnectBlock
-        if (!CheckTransaction(*tx, state, false, tx->GetHash(), isVerifyDB, nHeight, false, false, NULL, fVerifySparkSpendProof))
+        if (!CheckTransaction(*tx, state, false, tx->GetHash(), isVerifyDB, nHeight, false, false, NULL, fVerifySparkSpendProof, &sparkSpendProofResult))
             return state.Invalid(false, state.GetRejectCode(), state.GetRejectReason(),
                                 strprintf("Transaction check failed (tx hash %s) %s", tx->GetHash().ToString(), state.GetDebugMessage()));
+
+        if (tx->IsSparkSpend())
+            fSparkSpendProofsComplete = fSparkSpendProofsComplete &&
+                    sparkSpendProofResult == spark::SparkSpendProofVerificationResult::Verified;
 
     }
     unsigned int nSigOps = 0;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4218,9 +4218,11 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
 
     // Only callers that immediately run stateful Spark checks may defer this expensive proof.
     const bool fVerifySparkSpendProof = isVerifyDB || !fDeferSparkSpendProofVerification;
-    // CheckBlock passes no Spark tx info, so non-deferred proof checks complete
-    // synchronously here; deferred import blocks are deliberately not cached.
+    // CheckBlock passes no Spark tx info. Spark spend blocks are not cached here:
+    // non-stateful Spark checks can soft-pass on missing historical proof inputs,
+    // and ConnectBlock performs the final stateful validation before state updates.
     bool fSparkSpendProofsComplete = true;
+    bool fContainsSparkSpend = false;
     for (CTransactionRef tx : block.vtx) {
         spark::SparkSpendProofVerificationResult sparkSpendProofResult = spark::SparkSpendProofVerificationResult::NotApplicable;
 
@@ -4229,9 +4231,11 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
             return state.Invalid(false, state.GetRejectCode(), state.GetRejectReason(),
                                 strprintf("Transaction check failed (tx hash %s) %s", tx->GetHash().ToString(), state.GetDebugMessage()));
 
-        if (tx->IsSparkSpend())
+        if (tx->IsSparkSpend()) {
+            fContainsSparkSpend = true;
             fSparkSpendProofsComplete = fSparkSpendProofsComplete &&
                     sparkSpendProofResult == spark::SparkSpendProofVerificationResult::Verified;
+        }
 
     }
     unsigned int nSigOps = 0;
@@ -4245,7 +4249,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
     if (!spark::CheckSparkBlock(state, block, nHeight))
         return false;
 
-    if (fCheckPOW && fCheckMerkleRoot && fSparkSpendProofsComplete)
+    if (fCheckPOW && fCheckMerkleRoot && fSparkSpendProofsComplete && !fContainsSparkSpend)
         block.fChecked = true;
 
     return true;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4225,7 +4225,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
     if (!spark::CheckSparkBlock(state, block, nHeight))
         return false;
 
-    if (fCheckPOW && fCheckMerkleRoot && fVerifySparkSpendProof && !fHasSparkSpend)
+    if (fCheckPOW && fCheckMerkleRoot && (!fHasSparkSpend || fVerifySparkSpendProof))
         block.fChecked = true;
 
     return true;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -573,7 +573,7 @@ int GetUTXOConfirmations(const COutPoint& outpoint)
     return (nPrevoutHeight > -1 && chainActive.Tip()) ? chainActive.Height() - nPrevoutHeight + 1 : -1;
 }
 
-bool CheckTransaction(const CTransaction &tx, CValidationState &state, bool fCheckDuplicateInputs, uint256 hashTx,  bool isVerifyDB, int nHeight, bool isCheckWallet, bool fStatefulZerocoinCheck, spark::CSparkTxInfo* sparkTxInfo)
+bool CheckTransaction(const CTransaction &tx, CValidationState &state, bool fCheckDuplicateInputs, uint256 hashTx,  bool isVerifyDB, int nHeight, bool isCheckWallet, bool fStatefulZerocoinCheck, spark::CSparkTxInfo* sparkTxInfo, bool fVerifySparkSpendProof)
 {
     LogPrintf("CheckTransaction nHeight=%d, isVerifyDB=%d, isCheckWallet=%d, txHash=%s\n", nHeight, (int)isVerifyDB, (int)isCheckWallet, tx.GetHash().ToString());
 
@@ -699,7 +699,7 @@ bool CheckTransaction(const CTransaction &tx, CValidationState &state, bool fChe
         if (tx.IsSparkTransaction()) {
             if (hasExchangeUTXOs)
                 return state.DoS(100, false, REJECT_INVALID, "bad-exchange-address");
-            if (!CheckSparkTransaction(tx, state, hashTx, isVerifyDB, nHeight, isCheckWallet, fStatefulZerocoinCheck, sparkTxInfo))
+            if (!CheckSparkTransaction(tx, state, hashTx, isVerifyDB, nHeight, isCheckWallet, fStatefulZerocoinCheck, sparkTxInfo, fVerifySparkSpendProof))
                 return false;
         }
 
@@ -2512,7 +2512,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     //btzc: update nHeight, isVerifyDB
     // Check it again in case a previous version let a bad block in
     LogPrintf("ConnectBlock nHeight=%d, hash=%s\n", pindex->nHeight, block.GetHash().ToString());
-    if (!CheckBlock(block, state, chainparams.GetConsensus(), !fJustCheck, !fJustCheck, pindex->nHeight, false)) {
+    if (!CheckBlock(block, state, chainparams.GetConsensus(), !fJustCheck, !fJustCheck, pindex->nHeight, false, true)) {
         LogPrintf("--> failed\n");
         return error("%s: Consensus::CheckBlock: %s", __func__, FormatStateMessage(state));
     }
@@ -4142,7 +4142,7 @@ bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, const 
     return true;
 }
 
-bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW, bool fCheckMerkleRoot, int nHeight, bool isVerifyDB) {
+bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW, bool fCheckMerkleRoot, int nHeight, bool isVerifyDB, bool fDeferSparkSpendProofVerification) {
     // CheckBlock not only checks the block, but also fills up sparkTxInfo.
     if (!block.sparkTxInfo)
         block.sparkTxInfo = std::make_shared<spark::CSparkTxInfo>();
@@ -4200,9 +4200,16 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
         nHeight = GetNHeight(block.GetBlockHeader());
     LogPrintf("CheckBlock() nHeight=%d, blockHash=%s, isVerifyDB=%d\n", nHeight, block.GetHash().ToString(), isVerifyDB);
 
+    // Only callers that immediately run stateful Spark checks may defer this expensive proof.
+    // VerifyDB keeps its explicit proof-verification request.
+    const bool fVerifySparkSpendProof = isVerifyDB || !fDeferSparkSpendProofVerification;
+    bool fHasSparkSpend = false;
     for (CTransactionRef tx : block.vtx) {
+        if (tx->IsSparkSpend())
+            fHasSparkSpend = true;
+
         // We don't check transactions against sigma/lelantus state here, we'll check it again later in ConnectBlock
-        if (!CheckTransaction(*tx, state, false, tx->GetHash(), isVerifyDB, nHeight, false, false, NULL))
+        if (!CheckTransaction(*tx, state, false, tx->GetHash(), isVerifyDB, nHeight, false, false, NULL, fVerifySparkSpendProof))
             return state.Invalid(false, state.GetRejectCode(), state.GetRejectReason(),
                                 strprintf("Transaction check failed (tx hash %s) %s", tx->GetHash().ToString(), state.GetDebugMessage()));
 
@@ -4218,7 +4225,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
     if (!spark::CheckSparkBlock(state, block, nHeight))
         return false;
 
-    if (fCheckPOW && fCheckMerkleRoot)
+    if (fCheckPOW && fCheckMerkleRoot && fVerifySparkSpendProof && !fHasSparkSpend)
         block.fChecked = true;
 
     return true;
@@ -4629,7 +4636,7 @@ static bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidation
     }
     if (fNewBlock) *fNewBlock = true;
 
-    if (!CheckBlock(block, state, chainparams.GetConsensus(), true, true, pindex->nHeight, false) ||
+    if (!CheckBlock(block, state, chainparams.GetConsensus(), true, true, pindex->nHeight, false, false) ||
         !ContextualCheckBlock(block, state, chainparams.GetConsensus(), pindex->pprev)) {
         if (state.IsInvalid() && !state.CorruptionPossible()) {
             pindex->nStatus |= BLOCK_FAILED_VALID;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2806,6 +2806,21 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 
     block.sparkTxInfo->Complete();
 
+    // Batched Spark proofs must finish before any persistent block, index, or
+    // Spark state is updated below.
+    if (batchProofContainer->fCollectProofs) {
+        try {
+            batchProofContainer->finalize();
+            batchProofContainer->verify();
+        }
+        catch (const std::exception& e) {
+            batchProofContainer->clear();
+            return state.DoS(100,
+                             error("ConnectBlock(): Spark batch verification failed: %s", e.what()),
+                             REJECT_INVALID, "bad-txns-sparkproof");
+        }
+    }
+
     int64_t nTime3 = GetTimeMicros(); nTimeConnect += nTime3 - nTime2;
     LogPrint("bench", "      - Connect %u transactions: %.2fms (%.3fms/tx, %.3fms/txin) [%.2fs]\n", (unsigned)block.vtx.size(), 0.001 * (nTime3 - nTime2), 0.001 * (nTime3 - nTime2) / block.vtx.size(), nInputs <= 1 ? 0 : 0.001 * (nTime3 - nTime2) / (nInputs-1), nTimeConnect * 0.000001);
 
@@ -2955,9 +2970,6 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 
     // add this block to the view's block chain
     view.SetBestBlock(pindex->GetBlockHash());
-
-    // do batch verification if remains a day or collect proofs
-    batchProofContainer->finalize();
 
     int64_t nTime5 = GetTimeMicros(); nTimeIndex += nTime5 - nTime4;
     LogPrint("bench", "    - Index writing: %.2fms [%.2fs]\n", 0.001 * (nTime5 - nTime4), nTimeIndex * 0.000001);
@@ -4203,10 +4215,12 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
     // Only callers that immediately run stateful Spark checks may defer this expensive proof.
     // VerifyDB keeps its explicit proof-verification request.
     const bool fVerifySparkSpendProof = isVerifyDB || !fDeferSparkSpendProofVerification;
-    bool fHasSparkSpend = false;
+    // CheckBlock passes no Spark tx info, so verified Spark spend proofs complete
+    // synchronously here; deferred import blocks are deliberately not cached.
+    bool fSparkSpendProofsComplete = true;
     for (CTransactionRef tx : block.vtx) {
         if (tx->IsSparkSpend())
-            fHasSparkSpend = true;
+            fSparkSpendProofsComplete = fSparkSpendProofsComplete && fVerifySparkSpendProof;
 
         // We don't check transactions against sigma/lelantus state here, we'll check it again later in ConnectBlock
         if (!CheckTransaction(*tx, state, false, tx->GetHash(), isVerifyDB, nHeight, false, false, NULL, fVerifySparkSpendProof))
@@ -4225,7 +4239,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
     if (!spark::CheckSparkBlock(state, block, nHeight))
         return false;
 
-    if (fCheckPOW && fCheckMerkleRoot && (!fHasSparkSpend || fVerifySparkSpendProof))
+    if (fCheckPOW && fCheckMerkleRoot && fSparkSpendProofsComplete)
         block.fChecked = true;
 
     return true;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2759,7 +2759,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                 return state.DoS(100, false, REJECT_INVALID, "bad-txns-fee-outofrange");
 
             // Check transaction against signa/lelantus state
-            if (!CheckTransaction(tx, state, false, txHash, false, pindex->nHeight, false, true, block.sparkTxInfo.get()))
+            if (!CheckTransaction(tx, state, false, txHash, false, pindex->nHeight, false, true, block.sparkTxInfo.get(), true))
                 return state.DoS(100, error("stateful zerocoin check failed"),
                                  REJECT_INVALID, "bad-txns-zerocoin");
         }
@@ -4636,7 +4636,10 @@ static bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidation
     }
     if (fNewBlock) *fNewBlock = true;
 
-    if (!CheckBlock(block, state, chainparams.GetConsensus(), true, true, pindex->nHeight, false, false) ||
+    // During import/reindex, defer Spark spend proof verification to the
+    // stateful ConnectBlock check that runs before chain state is updated.
+    const bool fDeferSparkSpendProofVerification = dbp != NULL;
+    if (!CheckBlock(block, state, chainparams.GetConsensus(), true, true, pindex->nHeight, false, fDeferSparkSpendProofVerification) ||
         !ContextualCheckBlock(block, state, chainparams.GetConsensus(), pindex->pprev)) {
         if (state.IsInvalid() && !state.CorruptionPossible()) {
             pindex->nStatus |= BLOCK_FAILED_VALID;

--- a/src/validation.h
+++ b/src/validation.h
@@ -52,6 +52,10 @@ struct ChainTxData;
 
 struct PrecomputedTransactionData;
 struct LockPoints;
+namespace spark {
+class CSparkTxInfo;
+enum class SparkSpendProofVerificationResult;
+} // namespace spark
 
 /** btzc: update Firo config */
 /** Default for DEFAULT_WHITELISTRELAY. */
@@ -418,7 +422,7 @@ void UpdateCoins(const CTransaction& tx, CCoinsViewCache& inputs, int nHeight);
 /** Transaction validation functions */
 
 /** Context-independent validity checks */
-bool CheckTransaction(const CTransaction& tx, CValidationState& state, bool fCheckDuplicateInputs, uint256 hashTx, bool isVerifyDB, int nHeight = INT_MAX, bool isCheckWallet = false, bool fStatefulZerocoinCheck = true, spark::CSparkTxInfo* sparkTxInfo = NULL, bool fVerifySparkSpendProof = true);
+bool CheckTransaction(const CTransaction& tx, CValidationState& state, bool fCheckDuplicateInputs, uint256 hashTx, bool isVerifyDB, int nHeight = INT_MAX, bool isCheckWallet = false, bool fStatefulZerocoinCheck = true, spark::CSparkTxInfo* sparkTxInfo = NULL, bool fVerifySparkSpendProof = true, spark::SparkSpendProofVerificationResult* sparkSpendProofResult = NULL);
 
 namespace Consensus {
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -418,7 +418,7 @@ void UpdateCoins(const CTransaction& tx, CCoinsViewCache& inputs, int nHeight);
 /** Transaction validation functions */
 
 /** Context-independent validity checks */
-bool CheckTransaction(const CTransaction& tx, CValidationState& state, bool fCheckDuplicateInputs, uint256 hashTx, bool isVerifyDB, int nHeight = INT_MAX, bool isCheckWallet = false, bool fStatefulZerocoinCheck = true, spark::CSparkTxInfo* sparkTxInfo = NULL);
+bool CheckTransaction(const CTransaction& tx, CValidationState& state, bool fCheckDuplicateInputs, uint256 hashTx, bool isVerifyDB, int nHeight = INT_MAX, bool isCheckWallet = false, bool fStatefulZerocoinCheck = true, spark::CSparkTxInfo* sparkTxInfo = NULL, bool fVerifySparkSpendProof = true);
 
 namespace Consensus {
 
@@ -533,7 +533,7 @@ bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus
 
 /** Context-independent validity checks */
 bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true);
-bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true, bool fCheckMerkleRoot = true, int nHeight = INT_MAX, bool isVerifyDB = false);
+bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true, bool fCheckMerkleRoot = true, int nHeight = INT_MAX, bool isVerifyDB = false, bool fDeferSparkSpendProofVerification = false);
 
 bool IsTransactionInChain(const uint256& txId, int& nHeightTx, CTransactionRef & tx);
 bool IsTransactionInChain(const uint256& txId, int& nHeightTx);

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -433,7 +433,7 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             CWalletTx wtx;
             ssValue >> wtx;
             CValidationState state;
-            if (!(CheckTransaction(wtx, state, true, wtx.GetHash(), true, INT_MAX, false, false) && (wtx.GetHash() == hash) && state.IsValid()))
+            if (!(CheckTransaction(wtx, state, true, wtx.GetHash(), true, INT_MAX, false, false, NULL, false) && (wtx.GetHash() == hash) && state.IsValid()))
                 return false;
 
             // Undo serialize changes in 31600

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -433,7 +433,7 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             CWalletTx wtx;
             ssValue >> wtx;
             CValidationState state;
-            if (!(CheckTransaction(wtx, state, true, wtx.GetHash(), true, INT_MAX, false, false, NULL, false) && (wtx.GetHash() == hash) && state.IsValid()))
+            if (!(CheckTransaction(wtx, state, true, wtx.GetHash(), true, INT_MAX, true, false, NULL, false) && (wtx.GetHash() == hash) && state.IsValid()))
                 return false;
 
             // Undo serialize changes in 31600


### PR DESCRIPTION
This patch speeds up reindex after Spark activation by removing duplicate Spark spend proof verification and making the remaining Grootle proof verification cheaper. During reindex/import, Spark spend proofs no longer need to be fully verified in the early CheckBlock path and then verified again during ConnectBlock; instead, the expensive proof check is deferred to the ConnectBlock path before Spark state is committed, while mempool, wallet, and VerifyDB proof checks remain enforced. The Grootle verifier is also optimized by avoiding a large intermediate commitment list and feeding the equivalent multi-scalar multiplication terms directly into secp256k1. In the 855k-860k Spark-heavy window, reindex time dropped from 1:26:13 to about 13:12, a 6.5x speedup and 84.7% wall-time reduction.