### PR TITLE
Speed up DIP3 and Spark reindex validation safely

### DIFF
--- a/qa/rpc-tests/dip3-deterministicmns.py
+++ b/qa/rpc-tests/dip3-deterministicmns.py
@@ -179,7 +179,7 @@ class DIP3Test(BitcoinTestFramework):
         for i in range(spend_mns_count):
             self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
             mns_tmp.append(mns[spend_mns_count - 1 - i])
-            self.assert_mnlist(self.nodes[0], mns_tmp)
+            self.assert_mnlist_now(self.nodes[0], mns_tmp)
 
         # self.log.info("cause a reorg with a double spend and check that mnlists are still correct on all nodes")
         # self.mine_double_spend(self.nodes[0], dummy_txins, self.nodes[0].getnewaddress(), use_mnmerkleroot_from_tip=True)
@@ -307,6 +307,16 @@ class DIP3Test(BitcoinTestFramework):
             if time.time() >= deadline:
                 break
             time.sleep(0.1)
+        expected = []
+        for mn in mns:
+            expected.append('%s, %d' % (mn.collateral_txid, mn.collateral_vout))
+        self.log.error('mnlist: ' + str(node.evoznode('list', 'status')))
+        self.log.error('expected: ' + str(expected))
+        raise AssertionError("mnlists does not match provided mns")
+
+    def assert_mnlist_now(self, node, mns):
+        if self.compare_mnlist(node, mns):
+            return
         expected = []
         for mn in mns:
             expected.append('%s, %d' % (mn.collateral_txid, mn.collateral_vout))

--- a/src/batchproof_container.cpp
+++ b/src/batchproof_container.cpp
@@ -50,10 +50,15 @@ void BatchProofContainer::finalize() {
 }
 
 void BatchProofContainer::verify() {
-    if (!fCollectProofs) {
-        batch_spark();
+    try {
+        if (!fCollectProofs) {
+            batch_spark();
+        }
+        fCollectProofs = false;
+    } catch (...) {
+        clear();
+        throw;
     }
-    fCollectProofs = false;
 }
 
 void BatchProofContainer::add(const spark::SpendTransaction& tx) {

--- a/src/batchproof_container.cpp
+++ b/src/batchproof_container.cpp
@@ -2,6 +2,8 @@
 #include "ui_interface.h"
 #include "spark/state.h"
 
+#include <secp256k1/include/MultiExponent.h>
+
 #include <limits>
 #include <stdexcept>
 #include <unordered_map>
@@ -138,6 +140,8 @@ void BatchProofContainer::batch_spark() {
     bool passed;
     try {
         passed = spark::SpendTransaction::verify(params, sparkTransactions, cover_sets);
+    } catch (const secp_primitives::MultiExponentRuntimeError&) {
+        throw;
     } catch (const std::exception &) {
         passed = false;
     }

--- a/src/batchproof_container.cpp
+++ b/src/batchproof_container.cpp
@@ -91,7 +91,7 @@ void BatchProofContainer::batch_spark() {
                 throw std::invalid_argument("Spark batch verification missing cover set ancestry");
 
             if (index->GetBlockHash() != idAndHash.second)
-                index = coinGroup.firstBlock;
+                throw std::invalid_argument("Spark batch verification missing cover set block");
 
             auto& selection = cover_set_selections[idAndHash.first];
             if (index->nHeight > selection.maxHeight)

--- a/src/batchproof_container.cpp
+++ b/src/batchproof_container.cpp
@@ -2,6 +2,7 @@
 #include "ui_interface.h"
 #include "spark/state.h"
 
+#include <limits>
 #include <stdexcept>
 #include <unordered_map>
 
@@ -12,6 +13,13 @@ namespace
 struct SparkBatchCoverSetSelection {
     int maxHeight = -1;
 };
+
+int ToSparkCoinGroupId(uint64_t groupId)
+{
+    if (groupId > static_cast<uint64_t>(std::numeric_limits<int>::max()))
+        throw std::invalid_argument("Spark batch verification cover set id out of range");
+    return static_cast<int>(groupId);
+}
 } // namespace
 
 BatchProofContainer* BatchProofContainer::get_instance() {
@@ -77,7 +85,7 @@ void BatchProofContainer::batch_spark() {
     for (auto& itr : sparkTransactions) {
         auto& idAndBlockHashes = itr.getBlockHashes();
         for (const auto& idAndHash : idAndBlockHashes) {
-            int cover_set_id = idAndHash.first;
+            const int cover_set_id = ToSparkCoinGroupId(idAndHash.first);
             spark::CSparkState::SparkCoinGroupInfo coinGroup;
             if (!sparkState->GetCoinGroupInfo(cover_set_id, coinGroup))
                 throw std::invalid_argument("Spark batch verification missing cover set");
@@ -106,10 +114,11 @@ void BatchProofContainer::batch_spark() {
         uint256 blockHash;
         std::vector<unsigned char> setHash;
         std::vector<spark::Coin> cover_set;
+        const int cover_set_id = ToSparkCoinGroupId(selection.first);
         const int nCoins = sparkState->GetCoinSetForSpend(
                 &chainActive,
                 selection.second.maxHeight,
-                static_cast<int>(selection.first),
+                cover_set_id,
                 blockHash,
                 cover_set,
                 setHash);

--- a/src/batchproof_container.cpp
+++ b/src/batchproof_container.cpp
@@ -17,9 +17,16 @@ void BatchProofContainer::init() {
     tempSparkTransactions.clear();
 }
 
+void BatchProofContainer::clear() {
+    tempSparkTransactions.clear();
+    sparkTransactions.clear();
+    fCollectProofs = false;
+}
+
 void BatchProofContainer::finalize() {
     if (fCollectProofs) {
         sparkTransactions.insert(sparkTransactions.end(), tempSparkTransactions.begin(), tempSparkTransactions.end());
+        tempSparkTransactions.clear();
     }
     fCollectProofs = false;
 }

--- a/src/batchproof_container.cpp
+++ b/src/batchproof_container.cpp
@@ -81,16 +81,20 @@ void BatchProofContainer::batch_spark() {
             spark::CSparkState::SparkCoinGroupInfo coinGroup;
             if (!sparkState->GetCoinGroupInfo(cover_set_id, coinGroup))
                 throw std::invalid_argument("Spark batch verification missing cover set");
+            if (!coinGroup.firstBlock || !coinGroup.lastBlock)
+                throw std::invalid_argument("Spark batch verification invalid cover set index");
 
             CBlockIndex* index = coinGroup.lastBlock;
-            while (index != coinGroup.firstBlock && index->GetBlockHash() != idAndHash.second)
+            while (index && index != coinGroup.firstBlock && index->GetBlockHash() != idAndHash.second)
                 index = index->pprev;
+            if (!index)
+                throw std::invalid_argument("Spark batch verification missing cover set ancestry");
 
-            if (!index || index->GetBlockHash() != idAndHash.second)
-                throw std::invalid_argument("Spark batch verification missing cover set block");
+            if (index->GetBlockHash() != idAndHash.second)
+                index = coinGroup.firstBlock;
 
             auto& selection = cover_set_selections[idAndHash.first];
-            if (index && index->nHeight > selection.maxHeight)
+            if (index->nHeight > selection.maxHeight)
                 selection.maxHeight = index->nHeight;
         }
     }

--- a/src/batchproof_container.cpp
+++ b/src/batchproof_container.cpp
@@ -2,7 +2,17 @@
 #include "ui_interface.h"
 #include "spark/state.h"
 
+#include <stdexcept>
+#include <unordered_map>
+
 std::unique_ptr<BatchProofContainer> BatchProofContainer::instance;
+
+namespace
+{
+struct SparkBatchCoverSetSelection {
+    int maxHeight = -1;
+};
+} // namespace
 
 BatchProofContainer* BatchProofContainer::get_instance() {
     if (instance) {
@@ -57,6 +67,10 @@ void BatchProofContainer::batch_spark() {
         return;
     }
 
+    // Grootle batching verifies each proof against the suffix identified by
+    // its own cover-set size, so each group only needs the largest referenced
+    // historical set, not the current full group.
+    std::unordered_map<uint64_t, SparkBatchCoverSetSelection> cover_set_selections;
     std::unordered_map<uint64_t, std::vector<spark::Coin>> cover_sets;
     spark::CSparkState* sparkState = spark::CSparkState::GetState();
 
@@ -64,13 +78,43 @@ void BatchProofContainer::batch_spark() {
         auto& idAndBlockHashes = itr.getBlockHashes();
         for (const auto& idAndHash : idAndBlockHashes) {
             int cover_set_id = idAndHash.first;
-            if (!cover_sets.count(cover_set_id)) {
-                std::vector<spark::Coin> cover_set;
-                sparkState->GetCoinSet(cover_set_id, cover_set);
-                cover_sets[cover_set_id] = cover_set;
-            }
+            spark::CSparkState::SparkCoinGroupInfo coinGroup;
+            if (!sparkState->GetCoinGroupInfo(cover_set_id, coinGroup))
+                throw std::invalid_argument("Spark batch verification missing cover set");
+
+            CBlockIndex* index = coinGroup.lastBlock;
+            while (index != coinGroup.firstBlock && index->GetBlockHash() != idAndHash.second)
+                index = index->pprev;
+
+            if (!index || index->GetBlockHash() != idAndHash.second)
+                throw std::invalid_argument("Spark batch verification missing cover set block");
+
+            auto& selection = cover_set_selections[idAndHash.first];
+            if (index && index->nHeight > selection.maxHeight)
+                selection.maxHeight = index->nHeight;
         }
     }
+
+    for (const auto& selection : cover_set_selections) {
+        if (selection.second.maxHeight < 0)
+            throw std::invalid_argument("Spark batch verification missing cover set block");
+
+        uint256 blockHash;
+        std::vector<unsigned char> setHash;
+        std::vector<spark::Coin> cover_set;
+        const int nCoins = sparkState->GetCoinSetForSpend(
+                &chainActive,
+                selection.second.maxHeight,
+                static_cast<int>(selection.first),
+                blockHash,
+                cover_set,
+                setHash);
+        if (nCoins <= 0 || cover_set.empty())
+            throw std::invalid_argument("Spark batch verification empty cover set");
+
+        cover_sets[selection.first] = cover_set;
+    }
+
     auto* params = spark::Params::get_default();
 
     bool passed;

--- a/src/batchproof_container.cpp
+++ b/src/batchproof_container.cpp
@@ -61,7 +61,7 @@ void BatchProofContainer::remove(const spark::SpendTransaction& tx) {
 
 void BatchProofContainer::batch_spark() {
     if (!sparkTransactions.empty()){
-        LogPrintf("Spark batch verification started.\n");
+        LogPrint("validation", "Spark batch verification started.\n");
         uiInterface.UpdateProgressBarLabel("Batch verifying Spark Proofs...");
     } else {
         return;
@@ -134,6 +134,6 @@ void BatchProofContainer::batch_spark() {
     }
 
     if (!sparkTransactions.empty())
-        LogPrintf("Spark batch verification finished successfully.\n");
+        LogPrint("validation", "Spark batch verification finished successfully.\n");
     sparkTransactions.clear();
 }

--- a/src/batchproof_container.h
+++ b/src/batchproof_container.h
@@ -13,6 +13,8 @@ public:
 
     void init();
 
+    void clear();
+
     void finalize();
 
     void verify();

--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -199,7 +199,10 @@ ReadStatus PartiallyDownloadedBlock::FillBlock(CBlock& block, const std::vector<
         return READ_STATUS_INVALID;
 
     CValidationState state;
-    if (!CheckBlock(block, state, Params().GetConsensus())) {
+    // This is a preliminary compact-block reconstruction check. Spark spend
+    // proofs are verified before connection, where side-chain cover-set state is
+    // available.
+    if (!CheckBlock(block, state, Params().GetConsensus(), true, true, INT_MAX, false, true)) {
         // TODO: We really want to just check merkle tree manually here,
         // but that is expensive, and CheckBlock caches a block's
         // "checked-status" (in the CBlock?). CBlock should be able to

--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -36,10 +36,10 @@ void CDSNotificationInterface::NotifyHeaderTip(const CBlockIndex *pindexNew, boo
 
 void CDSNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload)
 {
+    deterministicMNManager->UpdatedBlockTip(pindexNew);
+
     if (pindexNew == pindexFork) // blocks were disconnected without any new ones
         return;
-
-    deterministicMNManager->UpdatedBlockTip(pindexNew);
 
     masternodeSync.UpdatedBlockTip(pindexNew, fInitialDownload, connman);
 

--- a/src/evo/cbtx.cpp
+++ b/src/evo/cbtx.cpp
@@ -15,6 +15,21 @@
 #include "univalue.h"
 #include "validation.h"
 
+static bool SimplifiedMNListsEqual(const CSimplifiedMNList& a, const CSimplifiedMNList& b)
+{
+    if (a.mnList.size() != b.mnList.size()) {
+        return false;
+    }
+
+    for (size_t i = 0; i < a.mnList.size(); ++i) {
+        if (*a.mnList[i] != *b.mnList[i]) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 bool CheckCbTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValidationState& state)
 {
     if (tx.nType != TRANSACTION_COINBASE) {
@@ -49,7 +64,7 @@ bool CheckCbTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValidatio
 }
 
 // This can only be done after the block has been fully processed, as otherwise we won't have the finished MN list
-bool CheckCbTxMerkleRoots(const CBlock& block, const CBlockIndex* pindex, CValidationState& state)
+bool CheckCbTxMerkleRoots(const CBlock& block, const CBlockIndex* pindex, CValidationState& state, const CDeterministicMNList* deterministicMNList, bool cbTxMerkleRootMNListChanged)
 {
     if (block.vtx[0]->nType != TRANSACTION_COINBASE) {
         return true;
@@ -71,8 +86,21 @@ bool CheckCbTxMerkleRoots(const CBlock& block, const CBlockIndex* pindex, CValid
 
     if (pindex) {
         uint256 calculatedMerkleRoot;
-        if (!CalcCbTxMerkleRootMNList(block, pindex->pprev, calculatedMerkleRoot, state)) {
-            return state.DoS(100, false, REJECT_INVALID, "bad-cbtx-mnmerkleroot");
+        const CDeterministicMNList* mnListForMerkleRoot = nullptr;
+        if (deterministicMNList && deterministicMNList->GetHeight() == pindex->nHeight) {
+            if (deterministicMNList->GetBlockHash() == block.GetHash()) {
+                mnListForMerkleRoot = deterministicMNList;
+            }
+        }
+
+        if (mnListForMerkleRoot) {
+            if (!CalcCbTxMerkleRootMNList(*mnListForMerkleRoot, calculatedMerkleRoot, pindex->pprev, cbTxMerkleRootMNListChanged)) {
+                return state.DoS(100, false, REJECT_INVALID, "bad-cbtx-mnmerkleroot");
+            }
+        } else {
+            if (!CalcCbTxMerkleRootMNList(block, pindex->pprev, calculatedMerkleRoot, state)) {
+                return state.DoS(100, false, REJECT_INVALID, "bad-cbtx-mnmerkleroot");
+            }
         }
         if (calculatedMerkleRoot != cbTx.merkleRootMNList) {
             return state.DoS(100, false, REJECT_INVALID, "bad-cbtx-mnmerkleroot");
@@ -103,8 +131,6 @@ bool CalcCbTxMerkleRootMNList(const CBlock& block, const CBlockIndex* pindexPrev
     LOCK(deterministicMNManager->cs);
 
     static int64_t nTimeDMN = 0;
-    static int64_t nTimeSMNL = 0;
-    static int64_t nTimeMerkle = 0;
 
     int64_t nTime1 = GetTimeMicros();
 
@@ -116,16 +142,43 @@ bool CalcCbTxMerkleRootMNList(const CBlock& block, const CBlockIndex* pindexPrev
     int64_t nTime2 = GetTimeMicros(); nTimeDMN += nTime2 - nTime1;
     LogPrint("bench", "            - BuildNewListFromBlock: %.2fms [%.2fs]\n", 0.001 * (nTime2 - nTime1), nTimeDMN * 0.000001);
 
-    CSimplifiedMNList sml(tmpMNList);
+    return CalcCbTxMerkleRootMNList(tmpMNList, merkleRootRet);
+}
 
-    int64_t nTime3 = GetTimeMicros(); nTimeSMNL += nTime3 - nTime2;
-    LogPrint("bench", "            - CSimplifiedMNList: %.2fms [%.2fs]\n", 0.001 * (nTime3 - nTime2), nTimeSMNL * 0.000001);
+bool CalcCbTxMerkleRootMNList(const CDeterministicMNList& deterministicMNList, uint256& merkleRootRet, const CBlockIndex* pindexPrev, bool cbTxMerkleRootMNListChanged)
+{
+    LOCK(deterministicMNManager->cs);
 
-    static CSimplifiedMNList smlCached;
+    static int64_t nTimeSMNL = 0;
+    static int64_t nTimeMerkle = 0;
+    static CDeterministicMNList deterministicMNListCached;
     static uint256 merkleRootCached;
     static bool mutatedCached{false};
+    static bool hasCached{false};
 
-    if (sml.mnList == smlCached.mnList) {
+    if (!cbTxMerkleRootMNListChanged && pindexPrev && hasCached && deterministicMNListCached.GetBlockHash() == pindexPrev->GetBlockHash()) {
+        deterministicMNListCached = deterministicMNList;
+        merkleRootRet = merkleRootCached;
+        return !mutatedCached;
+    }
+
+    if (hasCached && deterministicMNList.HasSameMNMap(deterministicMNListCached)) {
+        merkleRootRet = merkleRootCached;
+        return !mutatedCached;
+    }
+
+    int64_t nTime1 = GetTimeMicros();
+
+    CSimplifiedMNList sml(deterministicMNList);
+
+    int64_t nTime2 = GetTimeMicros(); nTimeSMNL += nTime2 - nTime1;
+    LogPrint("bench", "            - CSimplifiedMNList: %.2fms [%.2fs]\n", 0.001 * (nTime2 - nTime1), nTimeSMNL * 0.000001);
+
+    static CSimplifiedMNList smlCached;
+
+    if (SimplifiedMNListsEqual(sml, smlCached)) {
+        deterministicMNListCached = deterministicMNList;
+        hasCached = true;
         merkleRootRet = merkleRootCached;
         return !mutatedCached;
     }
@@ -133,12 +186,14 @@ bool CalcCbTxMerkleRootMNList(const CBlock& block, const CBlockIndex* pindexPrev
     bool mutated = false;
     merkleRootRet = sml.CalcMerkleRoot(&mutated);
 
-    int64_t nTime4 = GetTimeMicros(); nTimeMerkle += nTime4 - nTime3;
-    LogPrint("bench", "            - CalcMerkleRoot: %.2fms [%.2fs]\n", 0.001 * (nTime4 - nTime3), nTimeMerkle * 0.000001);
+    int64_t nTime3 = GetTimeMicros(); nTimeMerkle += nTime3 - nTime2;
+    LogPrint("bench", "            - CalcMerkleRoot: %.2fms [%.2fs]\n", 0.001 * (nTime3 - nTime2), nTimeMerkle * 0.000001);
 
     smlCached = std::move(sml);
+    deterministicMNListCached = deterministicMNList;
     merkleRootCached = merkleRootRet;
     mutatedCached = mutated;
+    hasCached = true;
 
     return !mutated;
 }

--- a/src/evo/cbtx.h
+++ b/src/evo/cbtx.h
@@ -10,6 +10,7 @@
 
 class CBlock;
 class CBlockIndex;
+class CDeterministicMNList;
 class UniValue;
 
 // coinbase transaction
@@ -45,8 +46,9 @@ public:
 
 bool CheckCbTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValidationState& state);
 
-bool CheckCbTxMerkleRoots(const CBlock& block, const CBlockIndex* pindex, CValidationState& state);
+bool CheckCbTxMerkleRoots(const CBlock& block, const CBlockIndex* pindex, CValidationState& state, const CDeterministicMNList* deterministicMNList = nullptr, bool cbTxMerkleRootMNListChanged = true);
 bool CalcCbTxMerkleRootMNList(const CBlock& block, const CBlockIndex* pindexPrev, uint256& merkleRootRet, CValidationState& state);
+bool CalcCbTxMerkleRootMNList(const CDeterministicMNList& deterministicMNList, uint256& merkleRootRet, const CBlockIndex* pindexPrev = nullptr, bool cbTxMerkleRootMNListChanged = true);
 bool CalcCbTxMerkleRootQuorums(const CBlock& block, const CBlockIndex* pindexPrev, uint256& merkleRootRet, CValidationState& state);
 
 bool CbtxToJson(const CTransaction& tx, UniValue& obj);

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -503,6 +503,22 @@ CDeterministicMNManager::CDeterministicMNManager(CEvoDB& _evoDb) :
 {
 }
 
+CDeterministicMNManager::ScopedCacheRestorer::ScopedCacheRestorer(CDeterministicMNManager& manager) :
+    manager(manager)
+{
+    LOCK(manager.cs);
+    savedMnListsCache = manager.mnListsCache;
+    ++manager.scopedCacheRestorerDepth;
+}
+
+CDeterministicMNManager::ScopedCacheRestorer::~ScopedCacheRestorer()
+{
+    LOCK(manager.cs);
+    assert(manager.scopedCacheRestorerDepth > 0);
+    --manager.scopedCacheRestorerDepth;
+    manager.mnListsCache = savedMnListsCache;
+}
+
 bool CDeterministicMNManager::ProcessBlock(const CBlock& block, const CBlockIndex* pindex, CValidationState& _state, bool fJustCheck, CDeterministicMNList* newListRet, bool* cbTxMerkleRootMNListChangedRet)
 {
     AssertLockHeld(cs_main);
@@ -537,6 +553,9 @@ bool CDeterministicMNManager::ProcessBlock(const CBlock& block, const CBlockInde
         if (fJustCheck) {
             if (newListRet) {
                 *newListRet = newList;
+            }
+            if (scopedCacheRestorerDepth > 0) {
+                mnListsCache[block.GetHash()] = newList;
             }
             return true;
         }

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -503,9 +503,13 @@ CDeterministicMNManager::CDeterministicMNManager(CEvoDB& _evoDb) :
 {
 }
 
-bool CDeterministicMNManager::ProcessBlock(const CBlock& block, const CBlockIndex* pindex, CValidationState& _state, bool fJustCheck)
+bool CDeterministicMNManager::ProcessBlock(const CBlock& block, const CBlockIndex* pindex, CValidationState& _state, bool fJustCheck, CDeterministicMNList* newListRet, bool* cbTxMerkleRootMNListChangedRet)
 {
     AssertLockHeld(cs_main);
+
+    if (cbTxMerkleRootMNListChangedRet) {
+        *cbTxMerkleRootMNListChangedRet = true;
+    }
 
     const auto& consensusParams = Params().GetConsensus();
     bool fDIP0003Active = pindex->nHeight >= consensusParams.DIP0003Height;
@@ -525,18 +529,27 @@ bool CDeterministicMNManager::ProcessBlock(const CBlock& block, const CBlockInde
             return false;
         }
 
-        if (fJustCheck) {
-            return true;
-        }
-
         if (newList.GetHeight() == -1) {
             newList.SetHeight(nHeight);
         }
-
         newList.SetBlockHash(block.GetHash());
+
+        if (fJustCheck) {
+            if (newListRet) {
+                *newListRet = newList;
+            }
+            return true;
+        }
+
+        if (newListRet) {
+            *newListRet = newList;
+        }
 
         oldList = GetListForBlock(pindex->pprev);
         diff = oldList.BuildDiff(newList);
+        if (cbTxMerkleRootMNListChangedRet) {
+            *cbTxMerkleRootMNListChangedRet = diff.HasCbTxMerkleRootChanges();
+        }
 
         evoDb.Write(std::make_pair(DB_LIST_DIFF, newList.GetBlockHash()), diff);
         if ((nHeight % SNAPSHOT_LIST_PERIOD) == 0 || oldList.GetHeight() == -1) {

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -665,9 +665,24 @@ private:
     CEvoDB& evoDb;
 
     std::map<uint256, CDeterministicMNList> mnListsCache;
+    int scopedCacheRestorerDepth{0};
     const CBlockIndex* tipIndex{nullptr};
 
 public:
+    class ScopedCacheRestorer
+    {
+    public:
+        explicit ScopedCacheRestorer(CDeterministicMNManager& manager);
+        ~ScopedCacheRestorer();
+
+        ScopedCacheRestorer(const ScopedCacheRestorer&) = delete;
+        ScopedCacheRestorer& operator=(const ScopedCacheRestorer&) = delete;
+
+    private:
+        CDeterministicMNManager& manager;
+        std::map<uint256, CDeterministicMNList> savedMnListsCache;
+    };
+
     CDeterministicMNManager(CEvoDB& _evoDb);
 
     bool ProcessBlock(const CBlock& block, const CBlockIndex* pindex, CValidationState& state, bool fJustCheck, CDeterministicMNList* newListRet = nullptr, bool* cbTxMerkleRootMNListChangedRet = nullptr);

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -336,6 +336,11 @@ public:
         return mnMap.size();
     }
 
+    bool HasSameMNMap(const CDeterministicMNList& other) const
+    {
+        return mnMap.identity() == other.mnMap.identity();
+    }
+
     size_t GetValidMNsCount() const
     {
         size_t count = 0;
@@ -591,6 +596,30 @@ public:
     {
         return !addedMNs.empty() || !updatedMNs.empty() || !removedMns.empty();
     }
+
+    bool HasCbTxMerkleRootChanges() const
+    {
+        if (!addedMNs.empty() || !removedMns.empty()) {
+            return true;
+        }
+
+        // Keep this in sync with the CDeterministicMNState fields serialized by
+        // CSimplifiedMNListEntry, which defines cbTx.merkleRootMNList leaves.
+        static constexpr uint32_t relevantFields =
+            CDeterministicMNStateDiff::Field_nPoSeBanHeight |
+            CDeterministicMNStateDiff::Field_confirmedHash |
+            CDeterministicMNStateDiff::Field_pubKeyOperator |
+            CDeterministicMNStateDiff::Field_keyIDVoting |
+            CDeterministicMNStateDiff::Field_addr;
+
+        for (const auto& p : updatedMNs) {
+            if (p.second.fields & relevantFields) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 };
 
 // TODO can be removed in a future version
@@ -641,7 +670,7 @@ private:
 public:
     CDeterministicMNManager(CEvoDB& _evoDb);
 
-    bool ProcessBlock(const CBlock& block, const CBlockIndex* pindex, CValidationState& state, bool fJustCheck);
+    bool ProcessBlock(const CBlock& block, const CBlockIndex* pindex, CValidationState& state, bool fJustCheck, CDeterministicMNList* newListRet = nullptr, bool* cbTxMerkleRootMNListChangedRet = nullptr);
     bool UndoBlock(const CBlock& block, const CBlockIndex* pindex);
 
     void UpdatedBlockTip(const CBlockIndex* pindex);

--- a/src/evo/specialtx.cpp
+++ b/src/evo/specialtx.cpp
@@ -141,14 +141,18 @@ bool ProcessSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, CV
     int64_t nTime3 = GetTimeMicros(); nTimeQuorum += nTime3 - nTime2;
     LogPrint("bench", "        - quorumBlockProcessor: %.2fms [%.2fs]\n", 0.001 * (nTime3 - nTime2), nTimeQuorum * 0.000001);
 
-    if (!deterministicMNManager->ProcessBlock(block, pindex, state, fJustCheck)) {
+    CDeterministicMNList newMNList;
+    CDeterministicMNList* newMNListRet = fCheckCbTxMerleRoots ? &newMNList : nullptr;
+    bool cbTxMerkleRootMNListChanged = true;
+    bool* cbTxMerkleRootMNListChangedRet = fCheckCbTxMerleRoots ? &cbTxMerkleRootMNListChanged : nullptr;
+    if (!deterministicMNManager->ProcessBlock(block, pindex, state, fJustCheck, newMNListRet, cbTxMerkleRootMNListChangedRet)) {
         return false;
     }
 
     int64_t nTime4 = GetTimeMicros(); nTimeDMN += nTime4 - nTime3;
     LogPrint("bench", "        - deterministicMNManager: %.2fms [%.2fs]\n", 0.001 * (nTime4 - nTime3), nTimeDMN * 0.000001);
 
-    if (fCheckCbTxMerleRoots && !CheckCbTxMerkleRoots(block, pindex, state)) {
+    if (fCheckCbTxMerleRoots && !CheckCbTxMerkleRoots(block, pindex, state, newMNListRet, cbTxMerkleRootMNListChanged)) {
         return false;
     }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -41,7 +41,6 @@
 #include "validationinterface.h"
 #include "validation.h"
 #include "mtpstate.h"
-#include "batchproof_container.h"
 #include <crypto/progpow/include/ethash/progpow.hpp>
 #include "leveldb/env.h"
 
@@ -264,8 +263,12 @@ void Shutdown()
     StopHTTPServer();
     llmq::StopLLMQSystem();
 
-    BatchProofContainer::get_instance()->finalize();
-    BatchProofContainer::get_instance()->verify();
+    {
+        LOCK(cs_main);
+        CValidationState sparkBatchState;
+        if (!VerifyPendingSparkBatch(sparkBatchState, "shutdown"))
+            LogPrintf("Shutdown continuing after Spark batch verification failure: %s\n", FormatStateMessage(sparkBatchState));
+    }
 
 #ifdef ENABLE_WALLET
     if (pwalletMain)
@@ -761,8 +764,19 @@ void ThreadImport(std::vector <boost::filesystem::path> vImportFiles) {
             LoadExternalBlockFile(chainparams, file, &pos);
             nFile++;
         }
-        pblocktree->WriteReindexing(false);
-        fReindex = false;
+        {
+            LOCK(cs_main);
+            CValidationState state;
+            if (!VerifyPendingSparkBatch(state, "clearing reindex flag")) {
+                LogPrintf("Reindexing stopped before clearing reindex flag: %s\n", FormatStateMessage(state));
+                return;
+            }
+            if (!pblocktree->WriteReindexing(false)) {
+                LogPrintf("Reindexing stopped because clearing reindex flag failed\n");
+                return;
+            }
+            fReindex = false;
+        }
         LogPrintf("Reindexing finished\n");
         // To avoid ending up in a situation without genesis block, re-try initializing (no-op if reindexing worked):
         InitBlockIndex(chainparams);
@@ -1924,7 +1938,10 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                 llmq::InitLLMQSystem(*evoDb, &scheduler, false, fReindex || fReindexChainState);
 
                 if (fReindex) {
-                    pblocktree->WriteReindexing(true);
+                    if (!pblocktree->WriteReindexing(true)) {
+                        strLoadError = _("Error writing reindexing flag to block database");
+                        break;
+                    }
                     //If we're reindexing in prune mode, wipe away unusable block files and all undo data files
                     if (fPruneMode)
                         CleanupBlockRevFiles();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -668,8 +668,18 @@ static void BlockNotifyCallback(bool initialSync, const CBlockIndex *pBlockIndex
 }
 
 static bool fHaveGenesis = false;
+static bool fGenesisWaitFailed = false;
 static boost::mutex cs_GenesisWait;
 static CConditionVariable condvar_GenesisWait;
+
+static void NotifyGenesisWaitFailure()
+{
+    {
+        boost::unique_lock<boost::mutex> lock_GenesisWait(cs_GenesisWait);
+        fGenesisWaitFailed = true;
+    }
+    condvar_GenesisWait.notify_all();
+}
 
 static void BlockNotifyGenesisWait(bool, const CBlockIndex *pBlockIndex)
 {
@@ -767,10 +777,12 @@ void ThreadImport(std::vector <boost::filesystem::path> vImportFiles) {
         CValidationState activateState;
         if (!ActivateBestChain(activateState, chainparams)) {
             LogPrintf("Reindexing stopped before clearing reindex flag: %s\n", FormatStateMessage(activateState));
+            NotifyGenesisWaitFailure();
             return;
         }
         if (ShutdownRequested()) {
             LogPrintf("Reindexing stopped before clearing reindex flag: shutdown requested\n");
+            NotifyGenesisWaitFailure();
             return;
         }
         {
@@ -778,10 +790,12 @@ void ThreadImport(std::vector <boost::filesystem::path> vImportFiles) {
             CValidationState state;
             if (!VerifyPendingSparkBatch(state, "clearing reindex flag")) {
                 LogPrintf("Reindexing stopped before clearing reindex flag: %s\n", FormatStateMessage(state));
+                NotifyGenesisWaitFailure();
                 return;
             }
             if (!pblocktree->WriteReindexing(false)) {
                 LogPrintf("Reindexing stopped because clearing reindex flag failed\n");
+                NotifyGenesisWaitFailure();
                 return;
             }
             fReindex = false;
@@ -820,6 +834,7 @@ void ThreadImport(std::vector <boost::filesystem::path> vImportFiles) {
     CValidationState state;
     if (!ActivateBestChain(state, chainparams)) {
         LogPrintf("Failed to connect best block");
+        NotifyGenesisWaitFailure();
         StartShutdown();
     }
 
@@ -2211,11 +2226,14 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
         return false;
 
     // Either install a handler to notify us when genesis activates, or set fHaveGenesis directly.
-    // No locking, as this happens before any background thread is started.
-    if (chainActive.Tip() == NULL) {
+    const bool fWaitForGenesis = chainActive.Tip() == NULL;
+    {
+        boost::unique_lock<boost::mutex> lock_GenesisWait(cs_GenesisWait);
+        fHaveGenesis = !fWaitForGenesis;
+        fGenesisWaitFailed = false;
+    }
+    if (fWaitForGenesis) {
         uiInterface.NotifyBlockTip.connect(BlockNotifyGenesisWait);
-    } else {
-        fHaveGenesis = true;
     }
 
     if (IsArgSet("-blocknotify"))
@@ -2231,12 +2249,19 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     threadGroup.create_thread(boost::bind(&ThreadImport, vImportFiles));
 
     // Wait for genesis block to be processed
+    bool fGenesisProcessed = false;
     {
         boost::unique_lock<boost::mutex> lock(cs_GenesisWait);
-        while (!fHaveGenesis) {
+        while (!fHaveGenesis && !fGenesisWaitFailed) {
             condvar_GenesisWait.wait(lock);
         }
+        fGenesisProcessed = fHaveGenesis;
         uiInterface.NotifyBlockTip.disconnect(&BlockNotifyGenesisWait);
+    }
+    if (!fGenesisProcessed) {
+        if (ShutdownRequested())
+            return false;
+        return InitError(_("Block import failed before the genesis block was processed"));
     }
 
     // ********************************************************* Step 12: start node

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -764,6 +764,15 @@ void ThreadImport(std::vector <boost::filesystem::path> vImportFiles) {
             LoadExternalBlockFile(chainparams, file, &pos);
             nFile++;
         }
+        CValidationState activateState;
+        if (!ActivateBestChain(activateState, chainparams)) {
+            LogPrintf("Reindexing stopped before clearing reindex flag: %s\n", FormatStateMessage(activateState));
+            return;
+        }
+        if (ShutdownRequested()) {
+            LogPrintf("Reindexing stopped before clearing reindex flag: shutdown requested\n");
+            return;
+        }
         {
             LOCK(cs_main);
             CValidationState state;

--- a/src/libspark/grootle.cpp
+++ b/src/libspark/grootle.cpp
@@ -432,13 +432,6 @@ bool Grootle::verify(
         bind_weight.randomize();
     }
 
-    // Bind the commitment lists
-    std::vector<GroupElement> commits;
-    commits.reserve(S.size());
-    for (std::size_t i = 0; i < S.size(); i++) {
-        commits.emplace_back(S[i] + V[i]*bind_weight);
-    }
-
     // Final batch multiscalar multiplication
     Scalar H_scalar;
     std::vector<Scalar> Gi_scalars;
@@ -446,25 +439,17 @@ bool Grootle::verify(
     std::vector<Scalar> commit_scalars;
     Gi_scalars.resize(n*m);
     Hi_scalars.resize(n*m);
-    commit_scalars.resize(commits.size());
+    commit_scalars.resize(S.size());
 
     // Set up the final batch elements
     std::vector<GroupElement> points;
     std::vector<Scalar> scalars;
-    std::size_t final_size = 1 + 2*m*n + commits.size(); // F, (Gi), (Hi), (commits)
+    std::size_t final_size = 1 + 2*m*n + 2*S.size(); // F, (Gi), (Hi), (S), (V)
     for (std::size_t t = 0; t < M; t++) {
         final_size += 2 + proofs[t].X.size() + proofs[t].X1.size(); // A, B, (Gs), (Gv)
     }
     points.reserve(final_size);
     scalars.reserve(final_size);
-
-    // Index decomposition, which is common among all proofs
-    std::vector<std::vector<std::size_t> > I_;
-    I_.reserve(commits.size());
-    I_.resize(commits.size());
-    for (std::size_t i = 0; i < commits.size(); i++) {
-        I_[i] = decompose(i, n, m);
-    }
 
     // Process all proofs
     for (std::size_t t = 0; t < M; t++) {
@@ -500,6 +485,11 @@ bool Grootle::verify(
 
         // Effective set size
         const std::size_t size = sizes[t];
+        if (size == 0 || size > S.size()) {
+            LogPrintf("Invalid effective set size");
+            return false;
+        }
+        const std::vector<std::size_t> I_last = decompose(size - 1, n, m);
 
         // A, B (and associated commitments)
         points.emplace_back(proof.A);
@@ -518,27 +508,27 @@ bool Grootle::verify(
 
         Scalar f_sum;
         Scalar f_i(uint64_t(1));
-        std::vector<Scalar>::iterator ptr = commit_scalars.begin() + commits.size() - size;
+        std::vector<Scalar>::iterator ptr = commit_scalars.begin() + S.size() - size;
         compute_batch_fis(f_sum, f_i, m, f_, w2, ptr, ptr, ptr + size - 1, n);
 
         Scalar pow(uint64_t(1));
         std::vector<Scalar> f_part_product;
         for (std::ptrdiff_t j = m - 1; j >= 0; j--) {
             f_part_product.push_back(pow);
-            pow *= f_[j*n + I_[size - 1][j]];
+            pow *= f_[j*n + I_last[j]];
         }
 
         Scalar x_powers(uint64_t(1));
         for (std::size_t j = 0; j < m; j++) {
             Scalar fi_sum(uint64_t(0));
-            for (std::size_t i = I_[size - 1][j] + 1; i < n; i++)
+            for (std::size_t i = I_last[j] + 1; i < n; i++)
                 fi_sum += f_[j*n + i];
             pow += fi_sum * x_powers * f_part_product[m - j - 1];
             x_powers *= x;
         }
 
         f_sum += pow;
-        commit_scalars[commits.size() - 1] += pow * w2;
+        commit_scalars[S.size() - 1] += pow * w2;
 
         // S1, V1
         points.emplace_back(S1[t] + V1[t] * bind_weight);
@@ -566,9 +556,11 @@ bool Grootle::verify(
         points.emplace_back(Hi[i]);
         scalars.emplace_back(Hi_scalars[i]);
     }
-    for (std::size_t i = 0; i < commits.size(); i++) {
-        points.emplace_back(commits[i]);
+    for (std::size_t i = 0; i < S.size(); i++) {
+        points.emplace_back(S[i]);
         scalars.emplace_back(commit_scalars[i]);
+        points.emplace_back(V[i]);
+        scalars.emplace_back(commit_scalars[i] * bind_weight);
     }
 
     // Verify the batch

--- a/src/libspark/spend_transaction.cpp
+++ b/src/libspark/spend_transaction.cpp
@@ -391,10 +391,12 @@ bool SpendTransaction::verify(
             if (!cover_sets.count(cover_set_id))
                 throw std::invalid_argument("Cover set missing");
 			// Because we assume all proofs in this list share a monotonic cover set, the largest such set is the one to use for verification
-            if (!tx.cover_set_sizes.count(cover_set_id))
-                throw std::invalid_argument("Cover set size missing");
+			if (!tx.cover_set_sizes.count(cover_set_id))
+				throw std::invalid_argument("Cover set size missing");
 
 			std::size_t this_cover_set_size = tx.cover_set_sizes.at(cover_set_id);
+            if (this_cover_set_size == 0 || this_cover_set_size > full_cover_set_size)
+                throw std::invalid_argument("Bad cover set size");
 
 			// We always use the other elements
 			S1.emplace_back(tx.S1[proof_index.second]);

--- a/src/libspark/test/grootle_test.cpp
+++ b/src/libspark/test/grootle_test.cpp
@@ -14,6 +14,15 @@ static std::vector<GroupElement> random_group_vector(const std::size_t n) {
     return result;
 }
 
+static std::vector<unsigned char> random_root() {
+    Scalar temp;
+    temp.randomize();
+    std::vector<unsigned char> root;
+    root.resize(SCALAR_ENCODING);
+    temp.serialize(root.data());
+    return root;
+}
+
 BOOST_FIXTURE_TEST_SUITE(spark_grootle_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(batch)
@@ -166,6 +175,112 @@ BOOST_AUTO_TEST_CASE(invalid_batch)
     sizes.emplace_back(sizes.back());
 
     BOOST_CHECK(!grootle.verify(S, S1, V, V1, roots, sizes, proofs));
+}
+
+BOOST_AUTO_TEST_CASE(boundary_sizes_and_mutations)
+{
+    // Parameters
+    const std::size_t n = 4;
+    const std::size_t m = 3;
+
+    // Generators
+    GroupElement H;
+    H.randomize();
+    std::vector<GroupElement> Gi = random_group_vector(n*m);
+    std::vector<GroupElement> Hi = random_group_vector(n*m);
+
+    // Commitments
+    const std::size_t commit_size = 60; // require padding
+    std::vector<GroupElement> S = random_group_vector(commit_size);
+    std::vector<GroupElement> V = random_group_vector(commit_size);
+
+    // Cover every verifier boundary: full set, truncated suffixes, and size == 1.
+    std::vector<std::size_t> indexes = { 0, 3, 44, 58, 59 };
+    std::vector<std::size_t> sizes = { 60, 59, 16, 2, 1 };
+    std::vector<GroupElement> S1, V1;
+    std::vector<std::vector<unsigned char>> roots;
+    std::vector<Scalar> s, v;
+    for (std::size_t index : indexes) {
+        Scalar s_, v_;
+        s_.randomize();
+        v_.randomize();
+        s.emplace_back(s_);
+        v.emplace_back(v_);
+
+        S1.emplace_back(S[index]);
+        V1.emplace_back(V[index]);
+
+        S[index] += H*s_;
+        V[index] += H*v_;
+        roots.emplace_back(random_root());
+    }
+
+    Grootle grootle(H, Gi, Hi, n, m);
+    std::vector<GrootleProof> proofs;
+    for (std::size_t i = 0; i < indexes.size(); i++) {
+        proofs.emplace_back();
+        std::vector<GroupElement> S_(S.begin() + commit_size - sizes[i], S.end());
+        std::vector<GroupElement> V_(V.begin() + commit_size - sizes[i], V.end());
+        grootle.prove(
+            indexes[i] - (commit_size - sizes[i]),
+            s[i],
+            S_,
+            S1[i],
+            v[i],
+            V_,
+            V1[i],
+            roots[i],
+            proofs.back()
+        );
+
+        BOOST_CHECK(grootle.verify(S, S1[i], V, V1[i], roots[i], sizes[i], proofs.back()));
+    }
+
+    BOOST_CHECK(grootle.verify(S, S1, V, V1, roots, sizes, proofs));
+
+    std::vector<std::size_t> bad_sizes = sizes;
+    bad_sizes[0] = 0;
+    BOOST_CHECK(!grootle.verify(S, S1, V, V1, roots, bad_sizes, proofs));
+
+    bad_sizes = sizes;
+    bad_sizes[0] = S.size() + 1;
+    BOOST_CHECK(!grootle.verify(S, S1, V, V1, roots, bad_sizes, proofs));
+
+    bad_sizes = sizes;
+    bad_sizes.pop_back();
+    BOOST_CHECK(!grootle.verify(S, S1, V, V1, roots, bad_sizes, proofs));
+
+    std::vector<std::vector<unsigned char>> bad_roots = roots;
+    bad_roots[0][0] ^= 1;
+    BOOST_CHECK(!grootle.verify(S, S1, V, V1, bad_roots, sizes, proofs));
+
+    bad_roots = roots;
+    bad_roots.pop_back();
+    BOOST_CHECK(!grootle.verify(S, S1, V, V1, bad_roots, sizes, proofs));
+
+    std::vector<GroupElement> bad_S = S;
+    bad_S[indexes[0]].randomize();
+    BOOST_CHECK(!grootle.verify(bad_S, S1, V, V1, roots, sizes, proofs));
+
+    std::vector<GroupElement> bad_V = V;
+    bad_V[indexes[0]].randomize();
+    BOOST_CHECK(!grootle.verify(S, S1, bad_V, V1, roots, sizes, proofs));
+
+    std::vector<GroupElement> bad_S1 = S1;
+    bad_S1[0].randomize();
+    BOOST_CHECK(!grootle.verify(S, bad_S1, V, V1, roots, sizes, proofs));
+
+    std::vector<GroupElement> bad_V1 = V1;
+    bad_V1[0].randomize();
+    BOOST_CHECK(!grootle.verify(S, S1, V, bad_V1, roots, sizes, proofs));
+
+    std::vector<GrootleProof> bad_proofs = proofs;
+    bad_proofs[0].f[0] += Scalar(uint64_t(1));
+    BOOST_CHECK(!grootle.verify(S, S1, V, V1, roots, sizes, bad_proofs));
+
+    bad_proofs = proofs;
+    bad_proofs[0].X[0].randomize();
+    BOOST_CHECK(!grootle.verify(S, S1, V, V1, roots, sizes, bad_proofs));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/secp256k1/include/MultiExponent.h
+++ b/src/secp256k1/include/MultiExponent.h
@@ -1,11 +1,20 @@
 #ifndef SECP_MULTIEXPONENT_H
 #define SECP_MULTIEXPONENT_H
 
+#include <stdexcept>
 #include <vector>
 #include "../include/GroupElement.h"
 #include "../include/Scalar.h"
 
 namespace secp_primitives {
+
+class MultiExponentRuntimeError : public std::runtime_error {
+public:
+    explicit MultiExponentRuntimeError(const std::string& what_arg)
+        : std::runtime_error(what_arg)
+    {
+    }
+};
 
 class MultiExponent {
 public:

--- a/src/secp256k1/src/cpp/MultiExponent.cpp
+++ b/src/secp256k1/src/cpp/MultiExponent.cpp
@@ -12,6 +12,8 @@
 #include "../src/scratch_impl.h"
 #include "../src/ecmult_impl.h"
 
+#include <stdexcept>
+
 
 typedef struct {
     secp256k1_scalar *sc;
@@ -74,7 +76,14 @@ GroupElement MultiExponent::get_multiple() {
 
     secp256k1_ecmult_context ctx;
 
-    secp256k1_ecmult_multi_var(&ctx, scratch, &r, NULL, ecmult_multi_callback, &data, n_points);
+    if (scratch == NULL) {
+        throw std::runtime_error("MultiExponent scratch allocation failed");
+    }
+
+    if (!secp256k1_ecmult_multi_var(&ctx, scratch, &r, NULL, ecmult_multi_callback, &data, n_points)) {
+        secp256k1_scratch_destroy(scratch);
+        throw std::runtime_error("MultiExponent computation failed");
+    }
 
     secp256k1_scratch_destroy(scratch);
 

--- a/src/secp256k1/src/cpp/MultiExponent.cpp
+++ b/src/secp256k1/src/cpp/MultiExponent.cpp
@@ -77,12 +77,12 @@ GroupElement MultiExponent::get_multiple() {
     secp256k1_ecmult_context ctx;
 
     if (scratch == NULL) {
-        throw std::runtime_error("MultiExponent scratch allocation failed");
+        throw MultiExponentRuntimeError("MultiExponent scratch allocation failed");
     }
 
     if (!secp256k1_ecmult_multi_var(&ctx, scratch, &r, NULL, ecmult_multi_callback, &data, n_points)) {
         secp256k1_scratch_destroy(scratch);
-        throw std::runtime_error("MultiExponent computation failed");
+        throw MultiExponentRuntimeError("MultiExponent computation failed");
     }
 
     secp256k1_scratch_destroy(scratch);

--- a/src/spark/state.cpp
+++ b/src/spark/state.cpp
@@ -655,7 +655,7 @@ bool CheckSparkMintTransaction(
         bool fStatefulSigmaCheck,
         CSparkTxInfo* sparkTxInfo) {
 
-    LogPrintf("CheckSparkMintTransaction txHash = %s\n", hashTx.GetHex());
+    LogPrint("validation", "CheckSparkMintTransaction txHash = %s\n", hashTx.GetHex());
     const spark::Params* params = spark::Params::get_default();
     std::vector<CScript> scripts;
     for (const auto& txOut : txOuts) {
@@ -721,7 +721,7 @@ bool CheckSparkSMintTransaction(
         std::vector<Coin>& out_coins,
         CSparkTxInfo* sparkTxInfo) {
 
-    LogPrintf("CheckSparkSMintTransaction txHash = %s\n", hashTx.ToString());
+    LogPrint("validation", "CheckSparkSMintTransaction txHash = %s\n", hashTx.ToString());
     for (const auto& out : vout) {
         const auto& script = out.scriptPubKey;
         if (script.IsSparkSMint()) {
@@ -816,7 +816,7 @@ bool CheckSparkSpendTransaction(
     }
     txHashForMetadata = txTemp.GetHash();
 
-    LogPrintf("CheckSparkSpendTransaction: tx metadata hash=%s\n", txHashForMetadata.ToString());
+    LogPrint("validation", "CheckSparkSpendTransaction: tx metadata hash=%s\n", txHashForMetadata.ToString());
 
     bool passVerify = false;
 
@@ -953,13 +953,13 @@ bool CheckSparkSpendTransaction(
             if (it != gCheckedSparkSpendTransactions.end()) {
                 auto& checkState = it->second;
                 if (checkState.proofInputHash != proofInputHash) {
-                    LogPrintf("CheckSparkSpendTransaction: cached proof inputs changed for tx %s\n", hashTx.ToString());
+                    LogPrint("validation", "CheckSparkSpendTransaction: cached proof inputs changed for tx %s\n", hashTx.ToString());
                     gCheckedSparkSpendTransactions.erase(it);
                 } else if (checkState.fChecked) {
                     if (!checkState.fResult)
                         return state.DoS(100, false, REJECT_INVALID, "CheckSparkSpendTransaction: previously checked and failed");
 
-                    LogPrintf("CheckSparkSpendTransaction: already checked tx %s\n", hashTx.ToString());
+                    LogPrint("validation", "CheckSparkSpendTransaction: already checked tx %s\n", hashTx.ToString());
                     fChecked = true;
                 }
             }

--- a/src/spark/state.cpp
+++ b/src/spark/state.cpp
@@ -881,15 +881,12 @@ bool CheckSparkSpendTransaction(
         }
 
         CBlockIndex *index = coinGroup.lastBlock;
-        // find index for block with hash of accumulatorBlockHash or set index to the coinGroup.firstBlock if not found
-        while (index != coinGroup.firstBlock && index->GetBlockHash() != idAndHash.second)
+        while (index && index != coinGroup.firstBlock && index->GetBlockHash() != idAndHash.second)
             index = index->pprev;
 
-        if (index->GetBlockHash() != idAndHash.second && !fRequireProofInputs) {
-            // if fStatefulSigmaCheck is false, we are in the mempool acceptance code, it's a soft error
-            // just return true. If fStatefulSigmaCheck is true, use coinGroup.firstBlock as a reference block
-            setProofResult(SparkSpendProofVerificationResult::Deferred);
-            return true;
+        if (!index || index->GetBlockHash() != idAndHash.second) {
+            return state.DoS(100, false, REJECT_INVALID,
+                             "CheckSparkSpendTransaction: referenced cover set block not found");
         }
 
         // take the hash from last block of anonymity set

--- a/src/spark/state.cpp
+++ b/src/spark/state.cpp
@@ -1,9 +1,9 @@
-#include "threadpool.h"
 #include "state.h"
 #include "compat_layer.h"
 #include "sparkname.h"
 #include "../validation.h"
 #include "../batchproof_container.h"
+#include "../hash.h"
 
 #include <memory>
 #include <set>
@@ -11,23 +11,51 @@
 namespace spark {
 
 struct ProofCheckState {
+    ProofCheckState() : fChecked(false), fResult(false) {}
+
     // if this is true, then the proof was already checked, no need to check again
     bool fChecked;
 
     // result of the check (if fChecked is true)
     bool fResult;
 
-    // if this is non-null, then the proof is being checked right now
-    std::shared_ptr<boost::future<bool>> checkInProgress;
+    // Spark spend proofs are valid only for the exact anonymity-set inputs used.
+    uint256 proofInputHash;
 };
 
 // map from transaction hash to the state of checking its proofs
 static std::map<uint256, ProofCheckState> gCheckedSparkSpendTransactions;
 static CCriticalSection cs_checkedSparkSpendTransactions;
-
-static ParallelOpThreadPool<bool> gCheckProofThreadPool(std::min(boost::thread::hardware_concurrency(), 4u));
+static const std::size_t MAX_CACHED_SPARK_SPEND_PROOFS = 10000;
 
 static CSparkState sparkState;
+
+static uint256 GetSparkSpendProofInputHash(
+        const uint256& hashTx,
+        const std::map<uint64_t, uint256>& idAndBlockHashes,
+        const std::unordered_map<uint64_t, CoverSetData>& coverSetData,
+        const std::unordered_map<uint64_t, std::vector<Coin>>& coverSets) {
+    CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
+    ss << hashTx;
+    ss << idAndBlockHashes;
+
+    std::map<uint64_t, CoverSetData> orderedCoverSetData(
+            coverSetData.begin(), coverSetData.end());
+    for (const auto& item : orderedCoverSetData) {
+        ss << item.first;
+        ss << static_cast<uint64_t>(item.second.cover_set_size);
+        ss << item.second.cover_set_representation;
+    }
+
+    std::map<uint64_t, std::vector<Coin>> orderedCoverSets(
+            coverSets.begin(), coverSets.end());
+    for (const auto& item : orderedCoverSets) {
+        ss << item.first;
+        ss << item.second;
+    }
+
+    return ss.GetHash();
+}
 
 static bool CheckLTag(
         CValidationState &state,
@@ -622,7 +650,8 @@ bool CheckSparkSpendTransaction(
         int nHeight,
         bool isCheckWallet,
         bool fStatefulSigmaCheck,
-        CSparkTxInfo* sparkTxInfo) {
+        CSparkTxInfo* sparkTxInfo,
+        bool fVerifySparkSpendProof) {
 
     std::unordered_set<GroupElement, spark::CLTagHash> txLTags;
 
@@ -702,17 +731,30 @@ bool CheckSparkSpendTransaction(
     if (!CheckSparkSMintTransaction(tx.vout, state, hashTx, fStatefulSigmaCheck, out_coins, sparkTxInfo))
         return false;
     spend->setOutCoins(out_coins);
+    spend->setVout(Vout);
+
+    const bool fVerifyProofNow = fVerifySparkSpendProof || fStatefulSigmaCheck;
+    if (!fVerifyProofNow)
+        return true;
+
     std::unordered_map<uint64_t, std::vector<Coin>> cover_sets;
     std::unordered_map<uint64_t, CoverSetData> cover_set_data;
     const auto idAndBlockHashes = spend->getBlockHashes();
 
+    const bool fRequireProofInputs = fStatefulSigmaCheck || isVerifyDB;
     BatchProofContainer* batchProofContainer = BatchProofContainer::get_instance();
-    bool useBatching = batchProofContainer->fCollectProofs && !isVerifyDB && !isCheckWallet && sparkTxInfo && !sparkTxInfo->fInfoIsComplete;
+    const bool fMustVerifyBeforeStateUpdate = fStatefulSigmaCheck;
+    bool useBatching = batchProofContainer->fCollectProofs &&
+        !fMustVerifyBeforeStateUpdate &&
+        !isVerifyDB &&
+        !isCheckWallet &&
+        sparkTxInfo &&
+        !sparkTxInfo->fInfoIsComplete;
 
     for (const auto& idAndHash : idAndBlockHashes) {
         CSparkState::SparkCoinGroupInfo coinGroup;
         if (!sparkState.GetCoinGroupInfo(idAndHash.first, coinGroup)) {
-            if (fStatefulSigmaCheck)
+            if (fRequireProofInputs)
                 return state.DoS(100, false, NO_MINT_ZEROCOIN,
                                  "CheckSparkSpendTransaction: Error: no coins were minted with such parameters");
             else
@@ -725,7 +767,7 @@ bool CheckSparkSpendTransaction(
         while (index != coinGroup.firstBlock && index->GetBlockHash() != idAndHash.second)
             index = index->pprev;
 
-        if (index->GetBlockHash() != idAndHash.second && !fStatefulSigmaCheck)
+        if (index->GetBlockHash() != idAndHash.second && !fRequireProofInputs)
             // if fStatefulSigmaCheck is false, we are in the mempool acceptance code, it's a soft error
             // just return true. If fStatefulSigmaCheck is true, use coinGroup.firstBlock as a reference block
             return true;
@@ -773,14 +815,15 @@ bool CheckSparkSpendTransaction(
         cover_set_data [idAndHash.first] = setData;
     }
     spend->setCoverSets(cover_set_data);
-    spend->setVout(Vout);
 
     const std::vector<uint64_t>& ids = spend->getCoinGroupIds();
     for (const auto& id : ids) {
         if (!cover_sets.count(id) || !cover_set_data.count(id))
-            return fStatefulSigmaCheck ? state.DoS(100,
+            return fRequireProofInputs ? state.DoS(100,
                              error("CheckSparkSpendTransaction: No cover set found.")) : true;
     }
+
+    const uint256 proofInputHash = GetSparkSpendProofInputHash(hashTx, idAndBlockHashes, cover_set_data, cover_sets);
     
     // if we are collecting proofs, skip verification and collect proofs
     // add proofs into container
@@ -789,101 +832,48 @@ bool CheckSparkSpendTransaction(
         batchProofContainer->add(*spend);
     } else {
         bool fChecked = false;
-        bool scheduledAsync = false;
 
         try {
-            bool fRecheckNeeded;
-            do {
-                fRecheckNeeded = false;
-
+            {
                 LOCK(cs_checkedSparkSpendTransactions);
-                if (gCheckedSparkSpendTransactions.count(hashTx)) {
-                    auto& checkState = gCheckedSparkSpendTransactions[hashTx];
+                auto it = gCheckedSparkSpendTransactions.find(hashTx);
+                if (it != gCheckedSparkSpendTransactions.end()) {
+                    auto& checkState = it->second;
                     if (checkState.fChecked) {
-                        if (!checkState.fResult)
+                        if (checkState.proofInputHash != proofInputHash) {
+                            LogPrintf("CheckSparkSpendTransaction: cached proof inputs changed for tx %s\n", hashTx.ToString());
+                            gCheckedSparkSpendTransactions.erase(it);
+                        } else if (!checkState.fResult) {
                             return state.DoS(100, false, REJECT_INVALID, "CheckSparkSpendTransaction: previously checked and failed");
-                        else {
+                        } else {
                             LogPrintf("CheckSparkSpendTransaction: already checked tx %s\n", hashTx.ToString());
                             fChecked = true;
                         }
                     }
-                    // If the check is in progress and we are doing a stateful check, we need to wait
-                    else if (checkState.checkInProgress && fStatefulSigmaCheck) {
-                        // wait for the check to complete
-                        auto future = checkState.checkInProgress;
-                        cs_checkedSparkSpendTransactions.unlock();
-                        bool result = future->get();
-                        cs_checkedSparkSpendTransactions.lock();
-
-                        // Entry may have been erased by DisconnectTipSpark during the unlock window
-                        auto it = gCheckedSparkSpendTransactions.find(hashTx);
-                        if (it == gCheckedSparkSpendTransactions.end()) {
-                            fRecheckNeeded = true;
-                            continue;
-                        }
-                        ProofCheckState& checkStateAfterWait = it->second;
-
-                        checkStateAfterWait.fChecked = true;
-                        checkStateAfterWait.fResult = result;
-                        checkStateAfterWait.checkInProgress = nullptr;
-
-                        if (!result) {
-                            // unfortunately, it's possible that the proof was checked and failed
-                            // because the anonymity set was incomplete at the time of checking. We need
-                            // to recheck the proof again
-                            fRecheckNeeded = true;
-                            gCheckedSparkSpendTransactions.erase(hashTx);
-                        }
-                        else
-                            fChecked = true;
-                    }
-                }
-                else if (!fStatefulSigmaCheck && !gCheckProofThreadPool.IsPoolShutdown()) {
-                    // not an urgent check, put the proof into the thread pool for verification
-                    // don't post a request if there are too many tasks already
-                    if (gCheckProofThreadPool.GetPendingTaskCount() < (std::size_t)gCheckProofThreadPool.GetNumberOfThreads()/2) {
-                        auto future = gCheckProofThreadPool.PostTask([spend, cover_sets]() mutable {
-                            try {
-                                bool result = spark::SpendTransaction::verify(*spend, cover_sets);
-                                spend.reset();
-                                cover_sets.clear();
-                                return result;
-                            } catch (const std::exception &) {
-                                return false;
-                            }
-                        });
-                        auto &checkState = gCheckedSparkSpendTransactions[hashTx];
-                        checkState.fChecked = false;
-                        checkState.fResult = false;
-                        checkState.checkInProgress = std::make_shared<boost::future<bool>>(std::move(future));
-                        scheduledAsync = true;
-                    }
                 }
             }
-            while (fRecheckNeeded);
 
             if (fChecked) {
                 // if we are here, then the proof was already checked and it passed
                 passVerify = true;
             }
             else {
-                if (fStatefulSigmaCheck) {
-                    // we need the answer now, so verify and execute
-                    passVerify = spark::SpendTransaction::verify(*spend, cover_sets);
-                }
-                else {
-                    if (scheduledAsync) {
-                        // result will be processed later by the async task
-                        passVerify = true;
-                    } else {
-                        // Pool was busy so verification was not scheduled; verify synchronously for defense-in-depth
-                        passVerify = spark::SpendTransaction::verify(*spend, cover_sets);
-                    }
-                }
+                passVerify = spark::SpendTransaction::verify(*spend, cover_sets);
             }
         }
         catch (const std::exception &) {
             passVerify = false;
+        }
+
+        if (passVerify) {
+            LOCK(cs_checkedSparkSpendTransactions);
+            if (gCheckedSparkSpendTransactions.size() >= MAX_CACHED_SPARK_SPEND_PROOFS)
+                gCheckedSparkSpendTransactions.clear();
+
+            auto& checkState = gCheckedSparkSpendTransactions[hashTx];
+            checkState.fChecked = true;
+            checkState.fResult = true;
+            checkState.proofInputHash = proofInputHash;
         }
 
     }
@@ -951,7 +941,8 @@ bool CheckSparkTransaction(
         int nHeight,
         bool isCheckWallet,
         bool fStatefulSigmaCheck,
-        CSparkTxInfo* sparkTxInfo)
+        CSparkTxInfo* sparkTxInfo,
+        bool fVerifySparkSpendProof)
 {
     Consensus::Params const & consensus = ::Params().GetConsensus();
 
@@ -996,14 +987,14 @@ bool CheckSparkTransaction(
                              "bad-txns-spend-invalid");
         }
 
-        if (!isVerifyDB) {
-            try {
-                if (!CheckSparkSpendTransaction(
-                        tx, state, hashTx, isVerifyDB, nHeight,
-                        isCheckWallet, fStatefulSigmaCheck, sparkTxInfo)) {
-                    return false;
-                }
+        try {
+            if (!CheckSparkSpendTransaction(
+                    tx, state, hashTx, isVerifyDB, nHeight,
+                    isCheckWallet, fStatefulSigmaCheck, sparkTxInfo, fVerifySparkSpendProof)) {
+                return false;
+            }
 
+            if (!isVerifyDB) {
                 CSparkNameManager *sparkNameManager = CSparkNameManager::GetInstance();
                 CSparkNameTxData sparkTxData;
                 if (sparkNameManager->CheckSparkNameTx(tx, nRealHeight, state, &sparkTxData)) {
@@ -1021,11 +1012,10 @@ bool CheckSparkTransaction(
                 else {
                     return false;
                 }
-
             }
-            catch (const std::exception &x) {
-                return state.Error(x.what());
-            }
+        }
+        catch (const std::exception &x) {
+            return state.Error(x.what());
         }
     }
 
@@ -1033,7 +1023,6 @@ bool CheckSparkTransaction(
 }
 
 void ShutdownSparkState() {
-    gCheckProofThreadPool.Shutdown();
 }
 
 uint256 GetTxHashFromCoin(const spark::Coin& coin) {

--- a/src/spark/state.cpp
+++ b/src/spark/state.cpp
@@ -5,6 +5,8 @@
 #include "../batchproof_container.h"
 #include "../hash.h"
 
+#include <secp256k1/include/MultiExponent.h>
+
 #include <limits>
 #include <memory>
 #include <set>
@@ -992,6 +994,9 @@ bool CheckSparkSpendTransaction(
             if (passVerify)
                 setProofResult(SparkSpendProofVerificationResult::Verified);
         }
+    }
+    catch (const secp_primitives::MultiExponentRuntimeError&) {
+        throw;
     }
     catch (const std::exception &) {
         passVerify = false;

--- a/src/spark/state.cpp
+++ b/src/spark/state.cpp
@@ -5,6 +5,7 @@
 #include "../batchproof_container.h"
 #include "../hash.h"
 
+#include <limits>
 #include <memory>
 #include <set>
 
@@ -42,6 +43,15 @@ static CSparkNameManager* GetValidationSparkNameManager(CSparkValidationContext*
     if (sparkValidationContext && sparkValidationContext->sparkNameManager)
         return sparkValidationContext->sparkNameManager;
     return CSparkNameManager::GetInstance();
+}
+
+static bool TryGetSparkCoinGroupId(uint64_t groupId, int& result)
+{
+    if (groupId > static_cast<uint64_t>(std::numeric_limits<int>::max()))
+        return false;
+
+    result = static_cast<int>(groupId);
+    return true;
 }
 
 static bool SparkNameBlockIndexDataEqual(const CSparkNameBlockIndexData& a, const CSparkNameBlockIndexData& b)
@@ -868,8 +878,13 @@ bool CheckSparkSpendTransaction(
     const bool fNeedFullCoverSets = !useBatching;
 
     for (const auto& idAndHash : idAndBlockHashes) {
+        int coverSetId = 0;
+        if (!TryGetSparkCoinGroupId(idAndHash.first, coverSetId))
+            return state.DoS(100, false, REJECT_INVALID,
+                             "CheckSparkSpendTransaction: cover set id out of range");
+
         CSparkState::SparkCoinGroupInfo coinGroup;
-        if (!GetValidationSparkState(sparkValidationContext).GetCoinGroupInfo(idAndHash.first, coinGroup)) {
+        if (!GetValidationSparkState(sparkValidationContext).GetCoinGroupInfo(coverSetId, coinGroup)) {
             if (fRequireProofInputs)
                 return state.DoS(100, false, NO_MINT_ZEROCOIN,
                                  "CheckSparkSpendTransaction: Error: no coins were minted with such parameters");
@@ -890,7 +905,7 @@ bool CheckSparkSpendTransaction(
         }
 
         // take the hash from last block of anonymity set
-        std::vector<unsigned char> set_hash = GetAnonymitySetHash(index, idAndHash.first, false, sparkValidationContext);
+        std::vector<unsigned char> set_hash = GetAnonymitySetHash(index, coverSetId, false, sparkValidationContext);
 
         std::vector<Coin> cover_set;
         cover_set.reserve(coinGroup.nCoins);
@@ -900,10 +915,10 @@ bool CheckSparkSpendTransaction(
         // This list of public coins is required by function "Verify" of spend.
         while (true) {
             int id = 0;
-            if (CountCoinInBlock(index, idAndHash.first)) {
-                id = idAndHash.first;
-            } else if (CountCoinInBlock(index, idAndHash.first - 1)) {
-                id = idAndHash.first - 1;
+            if (CountCoinInBlock(index, coverSetId)) {
+                id = coverSetId;
+            } else if (coverSetId > 0 && CountCoinInBlock(index, coverSetId - 1)) {
+                id = coverSetId - 1;
             }
             if (id) {
                 if (index->sparkMintedCoins.count(id) > 0) {

--- a/src/spark/state.cpp
+++ b/src/spark/state.cpp
@@ -30,6 +30,97 @@ static const std::size_t MAX_CACHED_SPARK_SPEND_PROOFS = 10000;
 
 static CSparkState sparkState;
 
+static CSparkState& GetValidationSparkState(CSparkValidationContext* sparkValidationContext)
+{
+    if (sparkValidationContext && sparkValidationContext->sparkState)
+        return *sparkValidationContext->sparkState;
+    return sparkState;
+}
+
+static CSparkNameManager* GetValidationSparkNameManager(CSparkValidationContext* sparkValidationContext)
+{
+    if (sparkValidationContext && sparkValidationContext->sparkNameManager)
+        return sparkValidationContext->sparkNameManager;
+    return CSparkNameManager::GetInstance();
+}
+
+static bool SparkNameBlockIndexDataEqual(const CSparkNameBlockIndexData& a, const CSparkNameBlockIndexData& b)
+{
+    return a.name == b.name &&
+           a.sparkAddress == b.sparkAddress &&
+           a.sparkNameValidityHeight == b.sparkNameValidityHeight &&
+           a.additionalInfo == b.additionalInfo;
+}
+
+static bool SparkNameBlockIndexMapEqual(
+        const std::map<std::string, CSparkNameBlockIndexData>& a,
+        const std::map<std::string, CSparkNameBlockIndexData>& b)
+{
+    if (a.size() != b.size())
+        return false;
+
+    for (const auto& entry : a) {
+        auto it = b.find(entry.first);
+        if (it == b.end() || !SparkNameBlockIndexDataEqual(entry.second, it->second))
+            return false;
+    }
+    return true;
+}
+
+struct SparkBlockIndexDataBackup {
+    explicit SparkBlockIndexDataBackup(CBlockIndex* pindexIn)
+        : pindex(pindexIn),
+          sparkMintedCoins(pindexIn->sparkMintedCoins),
+          sparkSetHash(pindexIn->sparkSetHash),
+          sparkTxHashContext(pindexIn->sparkTxHashContext),
+          spentLTags(pindexIn->spentLTags),
+          ltagTxhash(pindexIn->ltagTxhash),
+          addedSparkNames(pindexIn->addedSparkNames),
+          removedSparkNames(pindexIn->removedSparkNames)
+    {
+    }
+
+    ~SparkBlockIndexDataBackup()
+    {
+        Restore();
+    }
+
+    bool MatchesGeneratedData() const
+    {
+        return pindex->sparkMintedCoins == sparkMintedCoins &&
+               pindex->sparkSetHash == sparkSetHash &&
+               pindex->sparkTxHashContext == sparkTxHashContext &&
+               pindex->spentLTags == spentLTags &&
+               pindex->ltagTxhash == ltagTxhash &&
+               SparkNameBlockIndexMapEqual(pindex->addedSparkNames, addedSparkNames) &&
+               SparkNameBlockIndexMapEqual(pindex->removedSparkNames, removedSparkNames);
+    }
+
+    void Restore()
+    {
+        if (restored)
+            return;
+        pindex->sparkMintedCoins = sparkMintedCoins;
+        pindex->sparkSetHash = sparkSetHash;
+        pindex->sparkTxHashContext = sparkTxHashContext;
+        pindex->spentLTags = spentLTags;
+        pindex->ltagTxhash = ltagTxhash;
+        pindex->addedSparkNames = addedSparkNames;
+        pindex->removedSparkNames = removedSparkNames;
+        restored = true;
+    }
+
+    CBlockIndex* pindex;
+    std::map<int, std::vector<spark::Coin>> sparkMintedCoins;
+    std::map<int, std::vector<unsigned char>> sparkSetHash;
+    std::unordered_map<GroupElement, std::pair<uint256, std::vector<unsigned char>>> sparkTxHashContext;
+    std::unordered_map<GroupElement, int> spentLTags;
+    std::unordered_map<uint256, uint256> ltagTxhash;
+    std::map<std::string, CSparkNameBlockIndexData> addedSparkNames;
+    std::map<std::string, CSparkNameBlockIndexData> removedSparkNames;
+    bool restored = false;
+};
+
 static uint256 GetSparkSpendProofInputHash(
         const uint256& hashTx,
         const std::map<uint64_t, uint256>& idAndBlockHashes,
@@ -62,7 +153,8 @@ static bool CheckLTag(
         CSparkTxInfo *sparkTxInfo,
         const GroupElement& lTag,
         int nHeight,
-        bool fConnectTip) {
+        bool fConnectTip,
+        CSparkValidationContext* sparkValidationContext) {
     // check for Spark transaction in this block as well
     if (sparkTxInfo &&
         !sparkTxInfo->fInfoIsComplete &&
@@ -70,7 +162,7 @@ static bool CheckLTag(
         return state.DoS(0, error("CTransaction::CheckTransaction() : two or more spends with same linking tag in the same block"));
 
     // check for used linking tags in state
-    if (sparkState.IsUsedLTag(lTag)) {
+    if (GetValidationSparkState(sparkValidationContext).IsUsedLTag(lTag)) {
         // Proceed with checks ONLY if we're accepting tx into the memory pool or connecting block to the existing blockchain
         if (nHeight == INT_MAX || fConnectTip) {
             return state.DoS(0, error("CTransaction::CheckTransaction() : The Spark coin has been used"));
@@ -138,17 +230,17 @@ size_t CountCoinInBlock(CBlockIndex *index, int id) {
            ? index->sparkMintedCoins[id].size() : 0;
 }
 
-std::vector<unsigned char> GetAnonymitySetHash(CBlockIndex *index, int group_id, bool generation = false) {
+std::vector<unsigned char> GetAnonymitySetHash(CBlockIndex *index, int group_id, bool generation = false, CSparkValidationContext* sparkValidationContext = nullptr) {
     std::vector<unsigned char> out_hash;
 
     CSparkState::SparkCoinGroupInfo coinGroup;
-    if (!sparkState.GetCoinGroupInfo(group_id, coinGroup))
+    if (!GetValidationSparkState(sparkValidationContext).GetCoinGroupInfo(group_id, coinGroup))
         return out_hash;
 
     if ((coinGroup.firstBlock == coinGroup.lastBlock && generation) || (coinGroup.nCoins == 0))
         return out_hash;
 
-    while (index != coinGroup.firstBlock) {
+    while (index && index != coinGroup.firstBlock) {
         if (index->sparkSetHash.count(group_id) > 0) {
             out_hash = index->sparkSetHash[group_id];
             break;
@@ -291,16 +383,26 @@ bool ConnectBlockSpark(
         const CChainParams &chainparams,
         CBlockIndex *pindexNew,
         const CBlock *pblock,
-        bool fJustCheck) {
+        bool fJustCheck,
+        bool fVerifyDB,
+        CSparkValidationContext* sparkValidationContext) {
 
     bool fBackupRewrittenSparkNames = false;
+    const bool fScratchCheck = fJustCheck && sparkValidationContext;
+    std::unique_ptr<SparkBlockIndexDataBackup> sparkBlockIndexDataBackup;
     
     // Add spark transaction information to index
     if (pblock && pblock->sparkTxInfo) {
-        if (!fJustCheck) {
+        if (!fJustCheck || fScratchCheck) {
+            if (fScratchCheck)
+                sparkBlockIndexDataBackup.reset(new SparkBlockIndexDataBackup(pindexNew));
             pindexNew->sparkMintedCoins.clear();
             pindexNew->spentLTags.clear();
             pindexNew->sparkSetHash.clear();
+            pindexNew->sparkTxHashContext.clear();
+            pindexNew->ltagTxhash.clear();
+            pindexNew->addedSparkNames.clear();
+            pindexNew->removedSparkNames.clear();
         }
 
         if (!CheckSparkBlock(state, *pblock, pindexNew->nHeight)) {
@@ -313,21 +415,22 @@ bool ConnectBlockSpark(
                     pblock->sparkTxInfo.get(),
                     lTag.first,
                     pindexNew->nHeight,
-                    true /* fConnectTip */
+                    sparkValidationContext != nullptr || !fVerifyDB /* fConnectTip */,
+                    sparkValidationContext
             )) {
                 return false;
             }
         }
 
-        if (!fJustCheck) {
+        if (!fJustCheck || fScratchCheck) {
             BOOST_FOREACH (auto& lTag, pblock->sparkTxInfo->spentLTags) {
                 pindexNew->spentLTags.insert(lTag);
-                sparkState.AddSpend(lTag.first, lTag.second);
+                GetValidationSparkState(sparkValidationContext).AddSpend(lTag.first, lTag.second);
             }
             if (GetBoolArg("-mobile", false)) {
                 BOOST_FOREACH (auto& lTag, pblock->sparkTxInfo->ltagTxhash) {
                     pindexNew->ltagTxhash.insert(lTag);
-                    sparkState.AddLTagTxHash(lTag.first, lTag.second);
+                    GetValidationSparkState(sparkValidationContext).AddLTagTxHash(lTag.first, lTag.second);
                 }
             }
         }
@@ -340,17 +443,17 @@ bool ConnectBlockSpark(
         bool updateHash = false;
 
         if (!pblock->sparkTxInfo->mints.empty()) {
-            sparkState.AddMintsToStateAndBlockIndex(pindexNew, pblock);
-            int latestCoinId  = sparkState.GetLatestCoinID();
+            GetValidationSparkState(sparkValidationContext).AddMintsToStateAndBlockIndex(pindexNew, pblock);
+            int latestCoinId  = GetValidationSparkState(sparkValidationContext).GetLatestCoinID();
             // add  coins into hasher, for generating set hash
             updateHash = true;
             // get previous hash of the set, if there is no such, don't write anything
-            std::vector<unsigned char> prev_hash = GetAnonymitySetHash(pindexNew->pprev, latestCoinId, true);
+            std::vector<unsigned char> prev_hash = GetAnonymitySetHash(pindexNew->pprev, latestCoinId, true, sparkValidationContext);
             if (!prev_hash.empty())
                 hash.Write(prev_hash.data(), 32);
             else {
                 if (latestCoinId > 1) {
-                    prev_hash = GetAnonymitySetHash(pindexNew->pprev, latestCoinId - 1, true);
+                    prev_hash = GetAnonymitySetHash(pindexNew->pprev, latestCoinId - 1, true, sparkValidationContext);
                     hash.Write(prev_hash.data(), 32);
                 }
             }
@@ -364,7 +467,7 @@ bool ConnectBlockSpark(
         }
 
         if (!pblock->sparkTxInfo->sparkNames.empty()) {
-            CSparkNameManager *sparkNameManager = CSparkNameManager::GetInstance();
+            CSparkNameManager *sparkNameManager = GetValidationSparkNameManager(sparkValidationContext);
 
             try {
                 for (const auto &sparkName : pblock->sparkTxInfo->sparkNames) {
@@ -436,22 +539,25 @@ bool ConnectBlockSpark(
         if (updateHash) {
             unsigned char hash_result[CSHA256::OUTPUT_SIZE];
             hash.Finalize(hash_result);
-            auto &out_hash = pindexNew->sparkSetHash[sparkState.GetLatestCoinID()];
+            auto &out_hash = pindexNew->sparkSetHash[GetValidationSparkState(sparkValidationContext).GetLatestCoinID()];
             out_hash.clear();
             out_hash.insert(out_hash.begin(), std::begin(hash_result), std::end(hash_result));
         }
     }
     else if (!fJustCheck) {
-        sparkState.AddBlock(pindexNew);
+        GetValidationSparkState(sparkValidationContext).AddBlock(pindexNew);
     }
 
-    CSparkNameManager *sparkNameManager = CSparkNameManager::GetInstance();
+    CSparkNameManager *sparkNameManager = GetValidationSparkNameManager(sparkValidationContext);
 
     auto removedNames = sparkNameManager->RemoveSparkNamesLosingValidity(pindexNew->nHeight);
     for (const auto &name: removedNames)
         pindexNew->removedSparkNames[name.first] = name.second;
     
-    sparkNameManager->AddBlock(pindexNew, fBackupRewrittenSparkNames);
+    sparkNameManager->AddBlock(pindexNew, fBackupRewrittenSparkNames, !fScratchCheck);
+
+    if (fScratchCheck && sparkBlockIndexDataBackup && !sparkBlockIndexDataBackup->MatchesGeneratedData())
+        return state.DoS(100, error("ConnectBlockSpark: Spark block index metadata mismatch"));
 
     return true;
 }
@@ -652,7 +758,8 @@ bool CheckSparkSpendTransaction(
         bool fStatefulSigmaCheck,
         CSparkTxInfo* sparkTxInfo,
         bool fVerifySparkSpendProof,
-        SparkSpendProofVerificationResult* sparkSpendProofResult) {
+        SparkSpendProofVerificationResult* sparkSpendProofResult,
+        CSparkValidationContext* sparkValidationContext) {
 
     auto setProofResult = [sparkSpendProofResult](SparkSpendProofVerificationResult result) {
         if (sparkSpendProofResult)
@@ -762,7 +869,7 @@ bool CheckSparkSpendTransaction(
 
     for (const auto& idAndHash : idAndBlockHashes) {
         CSparkState::SparkCoinGroupInfo coinGroup;
-        if (!sparkState.GetCoinGroupInfo(idAndHash.first, coinGroup)) {
+        if (!GetValidationSparkState(sparkValidationContext).GetCoinGroupInfo(idAndHash.first, coinGroup)) {
             if (fRequireProofInputs)
                 return state.DoS(100, false, NO_MINT_ZEROCOIN,
                                  "CheckSparkSpendTransaction: Error: no coins were minted with such parameters");
@@ -786,7 +893,7 @@ bool CheckSparkSpendTransaction(
         }
 
         // take the hash from last block of anonymity set
-        std::vector<unsigned char> set_hash = GetAnonymitySetHash(index, idAndHash.first);
+        std::vector<unsigned char> set_hash = GetAnonymitySetHash(index, idAndHash.first, false, sparkValidationContext);
 
         std::vector<Coin> cover_set;
         cover_set.reserve(coinGroup.nCoins);
@@ -839,7 +946,7 @@ bool CheckSparkSpendTransaction(
     }
 
     const uint256 proofInputHash = GetSparkSpendProofInputHash(hashTx, idAndBlockHashes, cover_set_data, cover_sets);
-    
+
     bool fChecked = false;
 
     try {
@@ -903,7 +1010,7 @@ bool CheckSparkSpendTransaction(
         // do not check for duplicates in case we've seen exact copy of this tx in this block before
         if (!(sparkTxInfo && sparkTxInfo->spTransactions.count(hashTx) > 0)) {
             for (size_t i = 0; i < lTags.size(); ++i) {
-                    if (!CheckLTag(state, sparkTxInfo, lTags[i], nHeight, false)) {
+                    if (!CheckLTag(state, sparkTxInfo, lTags[i], nHeight, sparkValidationContext != nullptr, sparkValidationContext)) {
                         LogPrintf("CheckSparkSpendTransaction: lTag check failed, ltag=%s\n", lTags[i]);
                         return false;
                     }
@@ -918,7 +1025,7 @@ bool CheckSparkSpendTransaction(
             }
         }
 
-        if (!isVerifyDB && !isCheckWallet) {
+        if ((!isVerifyDB || sparkValidationContext) && !isCheckWallet) {
             // add spend information to the index
             if (sparkTxInfo && !sparkTxInfo->fInfoIsComplete) {
                 for (size_t i = 0; i < lTags.size(); i++) {
@@ -935,7 +1042,7 @@ bool CheckSparkSpendTransaction(
         return false;
     }
 
-    if (!isVerifyDB && !isCheckWallet) {
+    if ((!isVerifyDB || sparkValidationContext) && !isCheckWallet) {
         if (sparkTxInfo && !sparkTxInfo->fInfoIsComplete) {
             sparkTxInfo->spTransactions.insert(hashTx);
         }
@@ -954,7 +1061,8 @@ bool CheckSparkTransaction(
         bool fStatefulSigmaCheck,
         CSparkTxInfo* sparkTxInfo,
         bool fVerifySparkSpendProof,
-        SparkSpendProofVerificationResult* sparkSpendProofResult)
+        SparkSpendProofVerificationResult* sparkSpendProofResult,
+        CSparkValidationContext* sparkValidationContext)
 {
     if (sparkSpendProofResult)
         *sparkSpendProofResult = SparkSpendProofVerificationResult::NotApplicable;
@@ -964,7 +1072,7 @@ bool CheckSparkTransaction(
     bool const allowSpark = IsSparkAllowed();
 
     // Check Spark Mint Transaction
-    if (allowSpark && !isVerifyDB && tx.IsSparkMint()) {
+    if (allowSpark && (!isVerifyDB || sparkValidationContext) && tx.IsSparkMint()) {
         std::vector<CTxOut> txOuts;
         for (const CTxOut &txout : tx.vout) {
             if (!txout.scriptPubKey.empty() && txout.scriptPubKey.IsSparkMint()) {
@@ -1006,12 +1114,12 @@ bool CheckSparkTransaction(
             if (!CheckSparkSpendTransaction(
                     tx, state, hashTx, isVerifyDB, nHeight,
                     isCheckWallet, fStatefulSigmaCheck, sparkTxInfo, fVerifySparkSpendProof,
-                    sparkSpendProofResult)) {
+                    sparkSpendProofResult, sparkValidationContext)) {
                 return false;
             }
 
-            if (!isVerifyDB) {
-                CSparkNameManager *sparkNameManager = CSparkNameManager::GetInstance();
+            if (!isVerifyDB || sparkValidationContext) {
+                CSparkNameManager *sparkNameManager = GetValidationSparkNameManager(sparkValidationContext);
                 CSparkNameTxData sparkTxData;
                 if (sparkNameManager->CheckSparkNameTx(tx, nRealHeight, state, &sparkTxData)) {
                     if (!sparkTxData.name.empty() && sparkTxInfo && !sparkTxInfo->fInfoIsComplete) {
@@ -1152,16 +1260,18 @@ FIRO_UNUSED static bool CheckSparkSpendTAg(
 
 CSparkState::CSparkState(
         size_t maxCoinInGroup,
-        size_t startGroupSize)
+        size_t startGroupSize,
+        bool fShutdownWalletOnReset)
         :
         maxCoinInGroup(maxCoinInGroup),
         startGroupSize(startGroupSize)
 {
-    Reset();
+    Reset(fShutdownWalletOnReset);
 }
 
-void CSparkState::Reset() {
-    ShutdownWallet();
+void CSparkState::Reset(bool fShutdownWallet) {
+    if (fShutdownWallet)
+        ShutdownWallet();
     coinGroups.clear();
     latestCoinId = 0;
     mintedCoins.clear();

--- a/src/spark/state.cpp
+++ b/src/spark/state.cpp
@@ -743,9 +743,8 @@ bool CheckSparkSpendTransaction(
 
     const bool fRequireProofInputs = fStatefulSigmaCheck || isVerifyDB;
     BatchProofContainer* batchProofContainer = BatchProofContainer::get_instance();
-    const bool fMustVerifyBeforeStateUpdate = fStatefulSigmaCheck;
+    // ConnectBlock completes this batch before persistent block/Spark state updates.
     bool useBatching = batchProofContainer->fCollectProofs &&
-        !fMustVerifyBeforeStateUpdate &&
         !isVerifyDB &&
         !isCheckWallet &&
         sparkTxInfo &&

--- a/src/spark/state.cpp
+++ b/src/spark/state.cpp
@@ -651,7 +651,13 @@ bool CheckSparkSpendTransaction(
         bool isCheckWallet,
         bool fStatefulSigmaCheck,
         CSparkTxInfo* sparkTxInfo,
-        bool fVerifySparkSpendProof) {
+        bool fVerifySparkSpendProof,
+        SparkSpendProofVerificationResult* sparkSpendProofResult) {
+
+    auto setProofResult = [sparkSpendProofResult](SparkSpendProofVerificationResult result) {
+        if (sparkSpendProofResult)
+            *sparkSpendProofResult = result;
+    };
 
     std::unordered_set<GroupElement, spark::CLTagHash> txLTags;
 
@@ -734,8 +740,10 @@ bool CheckSparkSpendTransaction(
     spend->setVout(Vout);
 
     const bool fVerifyProofNow = fVerifySparkSpendProof || fStatefulSigmaCheck;
-    if (!fVerifyProofNow)
+    if (!fVerifyProofNow) {
+        setProofResult(SparkSpendProofVerificationResult::Deferred);
         return true;
+    }
 
     std::unordered_map<uint64_t, std::vector<Coin>> cover_sets;
     std::unordered_map<uint64_t, CoverSetData> cover_set_data;
@@ -743,12 +751,14 @@ bool CheckSparkSpendTransaction(
 
     const bool fRequireProofInputs = fStatefulSigmaCheck || isVerifyDB;
     BatchProofContainer* batchProofContainer = BatchProofContainer::get_instance();
-    // ConnectBlock completes this batch before persistent block/Spark state updates.
+    // ConnectBlock finalizes and verifies this batch before persistent block,
+    // index, or Spark state updates.
     bool useBatching = batchProofContainer->fCollectProofs &&
         !isVerifyDB &&
         !isCheckWallet &&
         sparkTxInfo &&
         !sparkTxInfo->fInfoIsComplete;
+    const bool fNeedFullCoverSets = !useBatching;
 
     for (const auto& idAndHash : idAndBlockHashes) {
         CSparkState::SparkCoinGroupInfo coinGroup;
@@ -756,9 +766,11 @@ bool CheckSparkSpendTransaction(
             if (fRequireProofInputs)
                 return state.DoS(100, false, NO_MINT_ZEROCOIN,
                                  "CheckSparkSpendTransaction: Error: no coins were minted with such parameters");
-            else
+            else {
                 // soft error, will check the proof later
+                setProofResult(SparkSpendProofVerificationResult::Deferred);
                 return true;
+            }
         }
 
         CBlockIndex *index = coinGroup.lastBlock;
@@ -766,10 +778,12 @@ bool CheckSparkSpendTransaction(
         while (index != coinGroup.firstBlock && index->GetBlockHash() != idAndHash.second)
             index = index->pprev;
 
-        if (index->GetBlockHash() != idAndHash.second && !fRequireProofInputs)
+        if (index->GetBlockHash() != idAndHash.second && !fRequireProofInputs) {
             // if fStatefulSigmaCheck is false, we are in the mempool acceptance code, it's a soft error
             // just return true. If fStatefulSigmaCheck is true, use coinGroup.firstBlock as a reference block
+            setProofResult(SparkSpendProofVerificationResult::Deferred);
             return true;
+        }
 
         // take the hash from last block of anonymity set
         std::vector<unsigned char> set_hash = GetAnonymitySetHash(index, idAndHash.first);
@@ -793,7 +807,7 @@ bool CheckSparkSpendTransaction(
                     const auto& coin,
                     index->sparkMintedCoins[id]) {
                         set_size++;
-                        if (!useBatching)
+                        if (fNeedFullCoverSets)
                             cover_set.push_back(coin);
                     }
                 }
@@ -817,64 +831,62 @@ bool CheckSparkSpendTransaction(
 
     const std::vector<uint64_t>& ids = spend->getCoinGroupIds();
     for (const auto& id : ids) {
-        if (!cover_sets.count(id) || !cover_set_data.count(id))
+        if (!cover_sets.count(id) || !cover_set_data.count(id)) {
+            setProofResult(SparkSpendProofVerificationResult::Deferred);
             return fRequireProofInputs ? state.DoS(100,
                              error("CheckSparkSpendTransaction: No cover set found.")) : true;
+        }
     }
 
     const uint256 proofInputHash = GetSparkSpendProofInputHash(hashTx, idAndBlockHashes, cover_set_data, cover_sets);
     
-    // if we are collecting proofs, skip verification and collect proofs
-    // add proofs into container
-    if (useBatching) {
-        passVerify = true;
-        batchProofContainer->add(*spend);
-    } else {
-        bool fChecked = false;
+    bool fChecked = false;
 
-        try {
-            {
-                LOCK(cs_checkedSparkSpendTransactions);
-                auto it = gCheckedSparkSpendTransactions.find(hashTx);
-                if (it != gCheckedSparkSpendTransactions.end()) {
-                    auto& checkState = it->second;
-                    if (checkState.fChecked) {
-                        if (checkState.proofInputHash != proofInputHash) {
-                            LogPrintf("CheckSparkSpendTransaction: cached proof inputs changed for tx %s\n", hashTx.ToString());
-                            gCheckedSparkSpendTransactions.erase(it);
-                        } else if (!checkState.fResult) {
-                            return state.DoS(100, false, REJECT_INVALID, "CheckSparkSpendTransaction: previously checked and failed");
-                        } else {
-                            LogPrintf("CheckSparkSpendTransaction: already checked tx %s\n", hashTx.ToString());
-                            fChecked = true;
-                        }
-                    }
+    try {
+        {
+            LOCK(cs_checkedSparkSpendTransactions);
+            auto it = gCheckedSparkSpendTransactions.find(hashTx);
+            if (it != gCheckedSparkSpendTransactions.end()) {
+                auto& checkState = it->second;
+                if (checkState.proofInputHash != proofInputHash) {
+                    LogPrintf("CheckSparkSpendTransaction: cached proof inputs changed for tx %s\n", hashTx.ToString());
+                    gCheckedSparkSpendTransactions.erase(it);
+                } else if (checkState.fChecked) {
+                    if (!checkState.fResult)
+                        return state.DoS(100, false, REJECT_INVALID, "CheckSparkSpendTransaction: previously checked and failed");
+
+                    LogPrintf("CheckSparkSpendTransaction: already checked tx %s\n", hashTx.ToString());
+                    fChecked = true;
                 }
             }
-
-            if (fChecked) {
-                // if we are here, then the proof was already checked and it passed
-                passVerify = true;
-            }
-            else {
-                passVerify = spark::SpendTransaction::verify(*spend, cover_sets);
-            }
-        }
-        catch (const std::exception &) {
-            passVerify = false;
         }
 
-        if (passVerify) {
-            LOCK(cs_checkedSparkSpendTransactions);
-            if (gCheckedSparkSpendTransactions.size() >= MAX_CACHED_SPARK_SPEND_PROOFS)
-                gCheckedSparkSpendTransactions.clear();
-
-            auto& checkState = gCheckedSparkSpendTransactions[hashTx];
-            checkState.fChecked = true;
-            checkState.fResult = true;
-            checkState.proofInputHash = proofInputHash;
+        if (fChecked) {
+            passVerify = true;
+            setProofResult(SparkSpendProofVerificationResult::Verified);
+        } else if (useBatching) {
+            passVerify = true;
+            batchProofContainer->add(*spend);
+            setProofResult(SparkSpendProofVerificationResult::Batched);
+        } else {
+            passVerify = spark::SpendTransaction::verify(*spend, cover_sets);
+            if (passVerify)
+                setProofResult(SparkSpendProofVerificationResult::Verified);
         }
+    }
+    catch (const std::exception &) {
+        passVerify = false;
+    }
 
+    if (passVerify && !useBatching) {
+        LOCK(cs_checkedSparkSpendTransactions);
+        if (gCheckedSparkSpendTransactions.size() >= MAX_CACHED_SPARK_SPEND_PROOFS)
+            gCheckedSparkSpendTransactions.clear();
+
+        auto& checkState = gCheckedSparkSpendTransactions[hashTx];
+        checkState.fChecked = true;
+        checkState.fResult = true;
+        checkState.proofInputHash = proofInputHash;
     }
 
     if (!fStatefulSigmaCheck)
@@ -941,8 +953,12 @@ bool CheckSparkTransaction(
         bool isCheckWallet,
         bool fStatefulSigmaCheck,
         CSparkTxInfo* sparkTxInfo,
-        bool fVerifySparkSpendProof)
+        bool fVerifySparkSpendProof,
+        SparkSpendProofVerificationResult* sparkSpendProofResult)
 {
+    if (sparkSpendProofResult)
+        *sparkSpendProofResult = SparkSpendProofVerificationResult::NotApplicable;
+
     Consensus::Params const & consensus = ::Params().GetConsensus();
 
     bool const allowSpark = IsSparkAllowed();
@@ -989,7 +1005,8 @@ bool CheckSparkTransaction(
         try {
             if (!CheckSparkSpendTransaction(
                     tx, state, hashTx, isVerifyDB, nHeight,
-                    isCheckWallet, fStatefulSigmaCheck, sparkTxInfo, fVerifySparkSpendProof)) {
+                    isCheckWallet, fStatefulSigmaCheck, sparkTxInfo, fVerifySparkSpendProof,
+                    sparkSpendProofResult)) {
                 return false;
             }
 

--- a/src/spark/state.cpp
+++ b/src/spark/state.cpp
@@ -739,7 +739,7 @@ bool CheckSparkSpendTransaction(
     spend->setOutCoins(out_coins);
     spend->setVout(Vout);
 
-    const bool fVerifyProofNow = fVerifySparkSpendProof || fStatefulSigmaCheck;
+    const bool fVerifyProofNow = fVerifySparkSpendProof || fStatefulSigmaCheck || (isVerifyDB && !isCheckWallet);
     if (!fVerifyProofNow) {
         setProofResult(SparkSpendProofVerificationResult::Deferred);
         return true;

--- a/src/spark/state.h
+++ b/src/spark/state.h
@@ -81,7 +81,8 @@ bool CheckSparkTransaction(
         int nHeight,
         bool isCheckWallet,
         bool fStatefulSigmaCheck,
-        CSparkTxInfo* sparkTxInfo);
+        CSparkTxInfo* sparkTxInfo,
+        bool fVerifySparkSpendProof = true);
 
 // call this on shutdown
 void ShutdownSparkState();

--- a/src/spark/state.h
+++ b/src/spark/state.h
@@ -42,6 +42,13 @@ public:
     void Complete();
 };
 
+enum class SparkSpendProofVerificationResult {
+    NotApplicable,
+    Verified,
+    Deferred,
+    Batched
+};
+
 // check if spark activation block is passed
 bool IsSparkAllowed();
 bool IsSparkAllowed(int height);
@@ -82,7 +89,8 @@ bool CheckSparkTransaction(
         bool isCheckWallet,
         bool fStatefulSigmaCheck,
         CSparkTxInfo* sparkTxInfo,
-        bool fVerifySparkSpendProof = true);
+        bool fVerifySparkSpendProof = true,
+        SparkSpendProofVerificationResult* sparkSpendProofResult = nullptr);
 
 // call this on shutdown
 void ShutdownSparkState();

--- a/src/spark/state.h
+++ b/src/spark/state.h
@@ -17,6 +17,16 @@ namespace spark_mintspend { struct spark_mintspend_test; }
 
 namespace spark {
 
+class CSparkState;
+
+struct CSparkValidationContext {
+    CSparkState* sparkState;
+    CSparkNameManager* sparkNameManager;
+
+    CSparkValidationContext(CSparkState* sparkStateIn = nullptr, CSparkNameManager* sparkNameManagerIn = nullptr)
+        : sparkState(sparkStateIn), sparkNameManager(sparkNameManagerIn) {}
+};
+
 // Spark transaction info, added to the CBlock to ensure spark mint/spend transactions got their info stored into index
 class CSparkTxInfo {
 public:
@@ -75,7 +85,9 @@ bool ConnectBlockSpark(
         const CChainParams& chainparams,
         CBlockIndex* pindexNew,
         const CBlock *pblock,
-        bool fJustCheck=false);
+        bool fJustCheck=false,
+        bool fVerifyDB=false,
+        CSparkValidationContext* sparkValidationContext=nullptr);
 
 void DisconnectTipSpark(CBlock &block, CBlockIndex *pindexDelete);
 
@@ -90,7 +102,8 @@ bool CheckSparkTransaction(
         bool fStatefulSigmaCheck,
         CSparkTxInfo* sparkTxInfo,
         bool fVerifySparkSpendProof = true,
-        SparkSpendProofVerificationResult* sparkSpendProofResult = nullptr);
+        SparkSpendProofVerificationResult* sparkSpendProofResult = nullptr,
+        CSparkValidationContext* sparkValidationContext = nullptr);
 
 // call this on shutdown
 void ShutdownSparkState();
@@ -151,10 +164,11 @@ public:
 public:
     CSparkState(
             size_t maxCoinInGroup = ZC_SPARK_MAX_MINT_NUM,
-            size_t startGroupSize = ZC_SPARK_SET_START_SIZE);
+            size_t startGroupSize = ZC_SPARK_SET_START_SIZE,
+            bool fShutdownWalletOnReset = true);
 
     // Reset to initial values
-    void Reset();
+    void Reset(bool fShutdownWallet = true);
 
     // Query if the coin linking tag was previously used
     bool IsUsedLTag(const GroupElement& lTag);

--- a/src/sparkname.cpp
+++ b/src/sparkname.cpp
@@ -11,13 +11,14 @@
 
 CSparkNameManager *CSparkNameManager::sharedSparkNameManager = new CSparkNameManager();
 
-bool CSparkNameManager::AddBlock(CBlockIndex *pindex, bool fBackupRewrittenEntries)
+bool CSparkNameManager::AddBlock(CBlockIndex *pindex, bool fBackupRewrittenEntries, bool fNotify)
 {
     LOCK(cs_spark_name);
     for (const auto &entry : pindex->removedSparkNames) {
         sparkNameAddresses.erase(entry.second.sparkAddress);
         sparkNames.erase(ToUpper(entry.first));
-        uiInterface.NotifySparkNameRemoved(entry.second);
+        if (fNotify)
+            uiInterface.NotifySparkNameRemoved(entry.second);
     }
 
     for (const auto &entry : pindex->addedSparkNames) {
@@ -26,25 +27,28 @@ bool CSparkNameManager::AddBlock(CBlockIndex *pindex, bool fBackupRewrittenEntri
             pindex->removedSparkNames[upperName] = sparkNames[upperName];
         sparkNames[upperName] = entry.second;
         sparkNameAddresses[entry.second.sparkAddress] = upperName;
-        uiInterface.NotifySparkNameAdded(entry.second);
+        if (fNotify)
+            uiInterface.NotifySparkNameAdded(entry.second);
     }
 
     return true;
 }
 
-bool CSparkNameManager::RemoveBlock(CBlockIndex *pindex)
+bool CSparkNameManager::RemoveBlock(CBlockIndex *pindex, bool fNotify)
 {
     LOCK(cs_spark_name);
     for (const auto &entry : pindex->addedSparkNames) {
         sparkNames.erase(ToUpper(entry.first));
         sparkNameAddresses.erase(entry.second.sparkAddress);
-        uiInterface.NotifySparkNameRemoved(entry.second);
+        if (fNotify)
+            uiInterface.NotifySparkNameRemoved(entry.second);
     }
 
     for (const auto &entry : pindex->removedSparkNames) {
         sparkNames[ToUpper(entry.first)] = entry.second;
         sparkNameAddresses[entry.second.sparkAddress] = ToUpper(entry.first);
-        uiInterface.NotifySparkNameAdded(entry.second);
+        if (fNotify)
+            uiInterface.NotifySparkNameAdded(entry.second);
     }
 
     return true;

--- a/src/sparkname.h
+++ b/src/sparkname.h
@@ -194,8 +194,8 @@ public:
 
     std::map<std::string, CSparkNameBlockIndexData> RemoveSparkNamesLosingValidity(int nHeight);
 
-    bool AddBlock(CBlockIndex *pindex, bool fBackupRewrittenEntries = false);
-    bool RemoveBlock(CBlockIndex *pindex);
+    bool AddBlock(CBlockIndex *pindex, bool fBackupRewrittenEntries = false, bool fNotify = true);
+    bool RemoveBlock(CBlockIndex *pindex, bool fNotify = true);
 
     static std::string ToUpper(const std::string &sparkName);
 

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -12,12 +12,16 @@
 #include "netbase.h"
 #include "messagesigner.h"
 #include "keystore.h"
+#include "validationinterface.h"
 
+#include "dsnotificationinterface.h"
 #include "evo/specialtx.h"
 #include "evo/providertx.h"
 #include "evo/deterministicmns.h"
 
+#include <atomic>
 #include <boost/test/unit_test.hpp>
+#include <boost/thread.hpp>
 
 static const CBitcoinAddress payoutAddress  ("TTJW6FsYqLbSiF3ZUwMXRghgQuXK7XTodR");
 //static const std::string payoutKey          ("cV3qrPWzDcnhzRMV4MqtTH4LhNPqPo26ZntGvfJhc8nqCi8Ae5xR");
@@ -197,6 +201,118 @@ static CScript GenerateRandomAddress()
     CKey key;
     key.MakeNewKey(false);
     return GetScriptForDestination(key.GetPubKey().GetID());
+}
+
+static CScript GetCoinbaseKeyScript(const CKey& coinbaseKey)
+{
+    return GetScriptForDestination(coinbaseKey.GetPubKey().GetID());
+}
+
+static CMutableTransaction CreateCollateralSpendTx(const COutPoint& collateralOutpoint, const CScript& scriptPayout, const CKey& coinbaseKey)
+{
+    CMutableTransaction tx;
+    tx.vin.emplace_back(CTxIn(collateralOutpoint));
+    tx.vout.emplace_back(CTxOut(999 * COIN, scriptPayout));
+    SignTransaction(tx, coinbaseKey);
+
+    return tx;
+}
+
+static void ProcessBlockAndUpdateMNManager(TestChain100Setup& setup, const std::vector<CMutableTransaction>& txns, const CKey& coinbaseKey)
+{
+    bool processed = false;
+    setup.CreateAndProcessBlock(txns, coinbaseKey, &processed);
+    BOOST_REQUIRE(processed);
+    deterministicMNManager->UpdatedBlockTip(chainActive.Tip());
+}
+
+static void InvalidateBlockAndUpdateMNManager(const uint256& blockHash)
+{
+    CValidationState state;
+    LOCK(cs_main);
+
+    auto it = mapBlockIndex.find(blockHash);
+    BOOST_REQUIRE(it != mapBlockIndex.end());
+    BOOST_REQUIRE(InvalidateBlock(state, Params(), it->second));
+    BOOST_REQUIRE(state.IsValid());
+    deterministicMNManager->UpdatedBlockTip(chainActive.Tip());
+}
+
+static void InvalidateBlockUsingValidationSignals(const uint256& blockHash)
+{
+    CValidationState state;
+    LOCK(cs_main);
+
+    auto it = mapBlockIndex.find(blockHash);
+    BOOST_REQUIRE(it != mapBlockIndex.end());
+    BOOST_REQUIRE(InvalidateBlock(state, Params(), it->second));
+    BOOST_REQUIRE(state.IsValid());
+}
+
+class DeterministicMNManagerTipSignalBridge : public CValidationInterface
+{
+protected:
+    void UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex*, bool) override
+    {
+        deterministicMNManager->UpdatedBlockTip(pindexNew);
+    }
+};
+
+class ExposedDSNotificationInterface : public CDSNotificationInterface
+{
+public:
+    using CDSNotificationInterface::CDSNotificationInterface;
+
+    void UpdatedBlockTipForTest(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload)
+    {
+        CDSNotificationInterface::UpdatedBlockTip(pindexNew, pindexFork, fInitialDownload);
+    }
+};
+
+class ScopedValidationInterfaceRegistration
+{
+public:
+    explicit ScopedValidationInterfaceRegistration(CValidationInterface& validationInterface) :
+        validationInterface(validationInterface)
+    {
+        RegisterValidationInterface(&validationInterface);
+    }
+
+    ~ScopedValidationInterfaceRegistration()
+    {
+        UnregisterValidationInterface(&validationInterface);
+    }
+
+private:
+    CValidationInterface& validationInterface;
+};
+
+static std::vector<uint256> RegisterDeterministicMNs(TestChain100Setup& setup, SimpleUTXOMap& utxos, size_t count, int& port, const CScript& payoutScript)
+{
+    std::vector<uint256> dmnHashes;
+    dmnHashes.reserve(count);
+
+    for (size_t i = 0; i < count; ++i) {
+        CKey ownerKey;
+        CBLSSecretKey operatorKey;
+        auto tx = CreateProRegTx(utxos, port++, payoutScript, setup.coinbaseKey, ownerKey, operatorKey);
+        auto proTxHash = tx.GetHash();
+        ProcessBlockAndUpdateMNManager(setup, {tx}, setup.coinbaseKey);
+
+        BOOST_REQUIRE(deterministicMNManager->GetListAtChainTip().HasMN(proTxHash));
+        dmnHashes.emplace_back(proTxHash);
+    }
+
+    return dmnHashes;
+}
+
+static void AssertTipMNSet(const std::vector<uint256>& expectedDmnHashes)
+{
+    auto mnList = deterministicMNManager->GetListAtChainTip();
+    BOOST_REQUIRE_EQUAL(mnList.GetAllMNsCount(), expectedDmnHashes.size());
+    for (const auto& proTxHash : expectedDmnHashes) {
+        BOOST_CHECK(mnList.HasMN(proTxHash));
+    }
 }
 
 static CDeterministicMNCPtr FindPayoutDmn(const CBlock& block)
@@ -406,5 +522,179 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChainDIP3Setup)
     BOOST_ASSERT(foundRevived);
 
     const_cast<Consensus::Params&>(Params().GetConsensus()).DIP0003EnforcementHeight = DIP0003EnforcementHeightBackup;
+}
+
+BOOST_FIXTURE_TEST_CASE(dip3_invalidate_restores_single_collateral_spend_immediately, TestChainDIP3Setup)
+{
+    auto utxos = BuildSimpleUtxoMap(coinbaseTxns);
+    auto payoutScript = GetCoinbaseKeyScript(coinbaseKey);
+    int port = 10000;
+
+    auto dmnHashes = RegisterDeterministicMNs(*this, utxos, 3, port, payoutScript);
+    AssertTipMNSet(dmnHashes);
+
+    auto spendTx = CreateCollateralSpendTx(COutPoint(dmnHashes[0], 0), payoutScript, coinbaseKey);
+    ProcessBlockAndUpdateMNManager(*this, {spendTx}, coinbaseKey);
+
+    std::vector<uint256> afterSpend{dmnHashes.begin() + 1, dmnHashes.end()};
+    AssertTipMNSet(afterSpend);
+
+    auto removedTipHash = chainActive.Tip()->GetBlockHash();
+    InvalidateBlockAndUpdateMNManager(removedTipHash);
+
+    AssertTipMNSet(dmnHashes);
+}
+
+BOOST_FIXTURE_TEST_CASE(dip3_invalidate_restores_multiple_collateral_spends_immediately, TestChainDIP3Setup)
+{
+    auto utxos = BuildSimpleUtxoMap(coinbaseTxns);
+    auto payoutScript = GetCoinbaseKeyScript(coinbaseKey);
+    int port = 11000;
+
+    auto dmnHashes = RegisterDeterministicMNs(*this, utxos, 5, port, payoutScript);
+    AssertTipMNSet(dmnHashes);
+
+    uint256 firstRemovalBlockHash;
+    std::vector<uint256> expectedAfterSpends = dmnHashes;
+    for (size_t i = 0; i < 3; ++i) {
+        auto spendTx = CreateCollateralSpendTx(COutPoint(dmnHashes[i], 0), payoutScript, coinbaseKey);
+        ProcessBlockAndUpdateMNManager(*this, {spendTx}, coinbaseKey);
+        if (i == 0) {
+            firstRemovalBlockHash = chainActive.Tip()->GetBlockHash();
+        }
+        expectedAfterSpends.erase(expectedAfterSpends.begin());
+        AssertTipMNSet(expectedAfterSpends);
+    }
+
+    InvalidateBlockAndUpdateMNManager(firstRemovalBlockHash);
+
+    AssertTipMNSet(dmnHashes);
+}
+
+BOOST_FIXTURE_TEST_CASE(dip3_invalidate_does_not_reuse_cached_descendant_mn_list, TestChainDIP3Setup)
+{
+    auto utxos = BuildSimpleUtxoMap(coinbaseTxns);
+    auto payoutScript = GetCoinbaseKeyScript(coinbaseKey);
+    int port = 12000;
+
+    auto dmnHashes = RegisterDeterministicMNs(*this, utxos, 4, port, payoutScript);
+    AssertTipMNSet(dmnHashes);
+
+    auto preRemovalTip = chainActive.Tip();
+    auto spendTx = CreateCollateralSpendTx(COutPoint(dmnHashes[0], 0), payoutScript, coinbaseKey);
+    ProcessBlockAndUpdateMNManager(*this, {spendTx}, coinbaseKey);
+    auto descendantTip = chainActive.Tip();
+
+    std::vector<uint256> afterSpend{dmnHashes.begin() + 1, dmnHashes.end()};
+    AssertTipMNSet(afterSpend);
+
+    // Populate manager caches for both sides of the rollback boundary before
+    // invalidating, then assert the active tip list cannot be served from the
+    // stale descendant entry after disconnect.
+    BOOST_CHECK_EQUAL(deterministicMNManager->GetListForBlock(preRemovalTip).GetAllMNsCount(), dmnHashes.size());
+    BOOST_CHECK_EQUAL(deterministicMNManager->GetListForBlock(descendantTip).GetAllMNsCount(), afterSpend.size());
+
+    InvalidateBlockAndUpdateMNManager(descendantTip->GetBlockHash());
+
+    BOOST_CHECK_EQUAL(chainActive.Tip()->GetBlockHash().ToString(), preRemovalTip->GetBlockHash().ToString());
+    AssertTipMNSet(dmnHashes);
+    BOOST_CHECK_EQUAL(deterministicMNManager->GetListForBlock(chainActive.Tip()).GetAllMNsCount(), dmnHashes.size());
+}
+
+BOOST_FIXTURE_TEST_CASE(dip3_invalidate_pure_disconnect_notification_updates_tip_list, TestChainDIP3Setup)
+{
+    auto utxos = BuildSimpleUtxoMap(coinbaseTxns);
+    auto payoutScript = GetCoinbaseKeyScript(coinbaseKey);
+    int port = 13000;
+
+    auto dmnHashes = RegisterDeterministicMNs(*this, utxos, 3, port, payoutScript);
+    AssertTipMNSet(dmnHashes);
+
+    auto preRemovalTip = chainActive.Tip();
+    auto spendTx = CreateCollateralSpendTx(COutPoint(dmnHashes[0], 0), payoutScript, coinbaseKey);
+    ProcessBlockAndUpdateMNManager(*this, {spendTx}, coinbaseKey);
+
+    std::vector<uint256> afterSpend{dmnHashes.begin() + 1, dmnHashes.end()};
+    AssertTipMNSet(afterSpend);
+
+    ExposedDSNotificationInterface notificationInterface(*connman);
+    notificationInterface.UpdatedBlockTipForTest(preRemovalTip, preRemovalTip, false);
+    AssertTipMNSet(dmnHashes);
+}
+
+BOOST_FIXTURE_TEST_CASE(dip3_repeated_invalidate_signal_restores_each_intermediate_tip, TestChainDIP3Setup)
+{
+    DeterministicMNManagerTipSignalBridge tipSignalBridge;
+    ScopedValidationInterfaceRegistration bridgeRegistration(tipSignalBridge);
+
+    auto utxos = BuildSimpleUtxoMap(coinbaseTxns);
+    auto payoutScript = GetCoinbaseKeyScript(coinbaseKey);
+    int port = 14000;
+
+    auto dmnHashes = RegisterDeterministicMNs(*this, utxos, 5, port, payoutScript);
+    AssertTipMNSet(dmnHashes);
+
+    std::vector<std::vector<uint256>> expectedAfterDisconnect;
+    std::vector<uint256> expectedAfterSpends = dmnHashes;
+
+    for (size_t i = 0; i < 3; ++i) {
+        auto spendTx = CreateCollateralSpendTx(COutPoint(dmnHashes[i], 0), payoutScript, coinbaseKey);
+        ProcessBlockAndUpdateMNManager(*this, {spendTx}, coinbaseKey);
+        expectedAfterSpends.erase(expectedAfterSpends.begin());
+        AssertTipMNSet(expectedAfterSpends);
+
+        std::vector<uint256> restored{dmnHashes.begin() + i, dmnHashes.end()};
+        expectedAfterDisconnect.emplace(expectedAfterDisconnect.begin(), std::move(restored));
+    }
+
+    for (size_t i = 0; i < expectedAfterDisconnect.size(); ++i) {
+        InvalidateBlockUsingValidationSignals(chainActive.Tip()->GetBlockHash());
+        AssertTipMNSet(expectedAfterDisconnect[i]);
+    }
+}
+
+BOOST_FIXTURE_TEST_CASE(dip3_invalidate_tip_list_remains_consistent_for_parallel_readers, TestChainDIP3Setup)
+{
+    DeterministicMNManagerTipSignalBridge tipSignalBridge;
+    ScopedValidationInterfaceRegistration bridgeRegistration(tipSignalBridge);
+
+    auto utxos = BuildSimpleUtxoMap(coinbaseTxns);
+    auto payoutScript = GetCoinbaseKeyScript(coinbaseKey);
+    int port = 15000;
+
+    auto dmnHashes = RegisterDeterministicMNs(*this, utxos, 6, port, payoutScript);
+    AssertTipMNSet(dmnHashes);
+
+    for (size_t i = 0; i < 3; ++i) {
+        auto spendTx = CreateCollateralSpendTx(COutPoint(dmnHashes[i], 0), payoutScript, coinbaseKey);
+        ProcessBlockAndUpdateMNManager(*this, {spendTx}, coinbaseKey);
+    }
+
+    InvalidateBlockUsingValidationSignals(chainActive.Tip()->GetBlockHash());
+    std::vector<uint256> expectedAfterOneDisconnect{dmnHashes.begin() + 2, dmnHashes.end()};
+    AssertTipMNSet(expectedAfterOneDisconnect);
+
+    std::atomic<bool> failed{false};
+    boost::thread_group readers;
+    for (size_t i = 0; i < 8; ++i) {
+        readers.create_thread([&]() {
+            for (size_t j = 0; j < 100; ++j) {
+                auto mnList = deterministicMNManager->GetListAtChainTip();
+                if (mnList.GetAllMNsCount() != expectedAfterOneDisconnect.size()) {
+                    failed = true;
+                    return;
+                }
+                for (const auto& proTxHash : expectedAfterOneDisconnect) {
+                    if (!mnList.HasMN(proTxHash)) {
+                        failed = true;
+                        return;
+                    }
+                }
+            }
+        });
+    }
+    readers.join_all();
+
+    BOOST_CHECK(!failed);
 }
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -601,6 +601,31 @@ BOOST_FIXTURE_TEST_CASE(dip3_invalidate_does_not_reuse_cached_descendant_mn_list
     BOOST_CHECK_EQUAL(deterministicMNManager->GetListForBlock(chainActive.Tip()).GetAllMNsCount(), dmnHashes.size());
 }
 
+BOOST_FIXTURE_TEST_CASE(dip3_verifydb_level4_reconnect_keeps_mn_cache_consistent, TestChainDIP3Setup)
+{
+    auto utxos = BuildSimpleUtxoMap(coinbaseTxns);
+    auto payoutScript = GetCoinbaseKeyScript(coinbaseKey);
+    int port = 12500;
+
+    auto dmnHashes = RegisterDeterministicMNs(*this, utxos, 6, port, payoutScript);
+    AssertTipMNSet(dmnHashes);
+
+    std::vector<uint256> expectedAfterSpends = dmnHashes;
+    for (size_t i = 0; i < 3; ++i) {
+        auto spendTx = CreateCollateralSpendTx(COutPoint(dmnHashes[i], 0), payoutScript, coinbaseKey);
+        ProcessBlockAndUpdateMNManager(*this, {spendTx}, coinbaseKey);
+        expectedAfterSpends.erase(expectedAfterSpends.begin());
+        AssertTipMNSet(expectedAfterSpends);
+    }
+
+    auto tipBeforeVerifyDB = chainActive.Tip();
+    BOOST_REQUIRE(CVerifyDB().VerifyDB(::Params(), pcoinsTip, 4, 3));
+
+    BOOST_CHECK_EQUAL(chainActive.Tip()->GetBlockHash().ToString(), tipBeforeVerifyDB->GetBlockHash().ToString());
+    AssertTipMNSet(expectedAfterSpends);
+    BOOST_CHECK_EQUAL(deterministicMNManager->GetListForBlock(chainActive.Tip()).GetAllMNsCount(), expectedAfterSpends.size());
+}
+
 BOOST_FIXTURE_TEST_CASE(dip3_invalidate_pure_disconnect_notification_updates_tip_list, TestChainDIP3Setup)
 {
     auto utxos = BuildSimpleUtxoMap(coinbaseTxns);

--- a/src/test/evo_simplifiedmns_tests.cpp
+++ b/src/test/evo_simplifiedmns_tests.cpp
@@ -5,12 +5,58 @@
 #include "test/test_bitcoin.h"
 
 #include "bls/bls.h"
+#include "evo/deterministicmns.h"
 #include "evo/simplifiedmns.h"
 #include "netbase.h"
+#include "script/script.h"
 
 #include <boost/test/unit_test.hpp>
 
+#include <functional>
+
 BOOST_FIXTURE_TEST_SUITE(evo_simplifiedmns_tests, BasicTestingSetup)
+
+static CBLSPublicKey MakeTestBLSPublicKey(unsigned char value)
+{
+    std::vector<unsigned char> bytes{value};
+    bytes.resize(CBLSSecretKey::SerSize);
+    return CBLSSecretKey(bytes).GetPublicKey();
+}
+
+static CService MakeTestService(uint16_t port)
+{
+    CService service;
+    BOOST_REQUIRE(Lookup("127.0.0.1", service, port, false));
+    return service;
+}
+
+static CDeterministicMNState MakeTestMNState()
+{
+    CDeterministicMNState state;
+    state.nRegisteredHeight = 1;
+    state.nLastPaidHeight = 2;
+    state.nPoSePenalty = 3;
+    state.nPoSeRevivedHeight = 4;
+    state.nPoSeBanHeight = -1;
+    state.nRevocationReason = 5;
+    state.confirmedHash.SetHex(strprintf("%064x", 6));
+    state.confirmedHashWithProRegTxHash.SetHex(strprintf("%064x", 7));
+    state.keyIDOwner.SetHex(strprintf("%040x", 8));
+    state.pubKeyOperator.Set(MakeTestBLSPublicKey(9));
+    state.keyIDVoting.SetHex(strprintf("%040x", 10));
+    state.addr = MakeTestService(11000);
+    state.scriptPayout = CScript() << OP_1;
+    state.scriptOperatorPayout = CScript() << OP_2;
+    return state;
+}
+
+static CDeterministicMN MakeTestMN(const CDeterministicMNState& state)
+{
+    CDeterministicMN dmn;
+    dmn.proTxHash.SetHex(strprintf("%064x", 1));
+    dmn.pdmnState = std::make_shared<CDeterministicMNState>(state);
+    return dmn;
+}
 
 BOOST_AUTO_TEST_CASE(simplifiedmns_merkleroots)
 {
@@ -66,5 +112,51 @@ BOOST_AUTO_TEST_CASE(simplifiedmns_merkleroots)
     //printf("merkleRoot=\"%s\",\n", calculatedMerkleRoot.c_str());
 
     BOOST_CHECK(expectedMerkleRoot == calculatedMerkleRoot);
+}
+
+BOOST_AUTO_TEST_CASE(deterministicmn_diff_cbtx_merkle_relevance)
+{
+    CDeterministicMNListDiff diff;
+    BOOST_CHECK(!diff.HasCbTxMerkleRootChanges());
+
+    auto checkUpdatedField = [](uint32_t field, const std::function<void(CDeterministicMNState&)>& update) {
+        CDeterministicMNState oldState = MakeTestMNState();
+        CDeterministicMNState newState = oldState;
+        update(newState);
+
+        const CDeterministicMN oldDmn = MakeTestMN(oldState);
+        const CDeterministicMN newDmn = MakeTestMN(newState);
+        const bool changesMerkleEntry = CSimplifiedMNListEntry(oldDmn) != CSimplifiedMNListEntry(newDmn);
+
+        CDeterministicMNListDiff diff;
+        CDeterministicMNStateDiff stateDiff(oldState, newState);
+        BOOST_CHECK_EQUAL(stateDiff.fields, field);
+        diff.updatedMNs.emplace(1, stateDiff);
+        BOOST_CHECK_EQUAL(diff.HasCbTxMerkleRootChanges(), changesMerkleEntry);
+    };
+
+    checkUpdatedField(CDeterministicMNStateDiff::Field_nRegisteredHeight, [](auto& state) { state.nRegisteredHeight = 11; });
+    checkUpdatedField(CDeterministicMNStateDiff::Field_nLastPaidHeight, [](auto& state) { state.nLastPaidHeight = 12; });
+    checkUpdatedField(CDeterministicMNStateDiff::Field_nPoSePenalty, [](auto& state) { state.nPoSePenalty = 13; });
+    checkUpdatedField(CDeterministicMNStateDiff::Field_nPoSeRevivedHeight, [](auto& state) { state.nPoSeRevivedHeight = 14; });
+    checkUpdatedField(CDeterministicMNStateDiff::Field_nRevocationReason, [](auto& state) { state.nRevocationReason = 15; });
+    checkUpdatedField(CDeterministicMNStateDiff::Field_confirmedHashWithProRegTxHash, [](auto& state) { state.confirmedHashWithProRegTxHash.SetHex(strprintf("%064x", 16)); });
+    checkUpdatedField(CDeterministicMNStateDiff::Field_keyIDOwner, [](auto& state) { state.keyIDOwner.SetHex(strprintf("%040x", 17)); });
+    checkUpdatedField(CDeterministicMNStateDiff::Field_scriptPayout, [](auto& state) { state.scriptPayout = CScript() << OP_3; });
+    checkUpdatedField(CDeterministicMNStateDiff::Field_scriptOperatorPayout, [](auto& state) { state.scriptOperatorPayout = CScript() << OP_4; });
+
+    checkUpdatedField(CDeterministicMNStateDiff::Field_nPoSeBanHeight, [](auto& state) { state.nPoSeBanHeight = 18; });
+    checkUpdatedField(CDeterministicMNStateDiff::Field_confirmedHash, [](auto& state) { state.confirmedHash.SetHex(strprintf("%064x", 19)); });
+    checkUpdatedField(CDeterministicMNStateDiff::Field_pubKeyOperator, [](auto& state) { state.pubKeyOperator.Set(MakeTestBLSPublicKey(20)); });
+    checkUpdatedField(CDeterministicMNStateDiff::Field_keyIDVoting, [](auto& state) { state.keyIDVoting.SetHex(strprintf("%040x", 21)); });
+    checkUpdatedField(CDeterministicMNStateDiff::Field_addr, [](auto& state) { state.addr = MakeTestService(12000); });
+
+    diff.updatedMNs.clear();
+    diff.addedMNs.emplace_back();
+    BOOST_CHECK(diff.HasCbTxMerkleRootChanges());
+
+    diff.addedMNs.clear();
+    diff.removedMns.emplace(1);
+    BOOST_CHECK(diff.HasCbTxMerkleRootChanges());
 }
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/spark_tests.cpp
+++ b/src/test/spark_tests.cpp
@@ -652,29 +652,54 @@ BOOST_AUTO_TEST_CASE(checktransaction)
     CMutableTransaction missingReferenceSpendTx = replaceSparkSpendBlockHashes(spendTx, uint256());
     CTransaction missingReferenceSpend(missingReferenceSpendTx);
 
-    SparkSpendProofVerificationResult missingReferenceDirectProofResult;
+    SparkSpendProofVerificationResult missingReferenceDirectProofResult = SparkSpendProofVerificationResult::NotApplicable;
     CSparkTxInfo missingReferenceDirectInfo;
     CValidationState missingReferenceDirectState;
-    BOOST_CHECK(CheckSparkTransaction(
+    BOOST_CHECK(!CheckSparkTransaction(
             missingReferenceSpend, missingReferenceDirectState, missingReferenceSpend.GetHash(),
             false, chainActive.Height(), false, true, &missingReferenceDirectInfo,
             true, &missingReferenceDirectProofResult));
-    BOOST_CHECK(missingReferenceDirectProofResult == SparkSpendProofVerificationResult::Verified);
+    BOOST_CHECK(missingReferenceDirectProofResult != SparkSpendProofVerificationResult::Verified);
+
+    SparkSpendProofVerificationResult missingReferenceNonStatefulProofResult = SparkSpendProofVerificationResult::NotApplicable;
+    CValidationState missingReferenceNonStatefulState;
+    BOOST_CHECK(!CheckSparkTransaction(
+            missingReferenceSpend, missingReferenceNonStatefulState, missingReferenceSpend.GetHash(),
+            false, chainActive.Height(), false, false, NULL,
+            true, &missingReferenceNonStatefulProofResult));
+    BOOST_CHECK(missingReferenceNonStatefulProofResult != SparkSpendProofVerificationResult::Deferred);
+
+    CBlock missingReferenceDeferredBlock = CreateBlock({missingReferenceSpendTx}, script);
+    CValidationState missingReferenceDeferredBlockState;
+    BOOST_CHECK(CheckBlock(
+            missingReferenceDeferredBlock, missingReferenceDeferredBlockState, consensus, true, true, chainActive.Height() + 1, false, true));
+    BOOST_CHECK(!missingReferenceDeferredBlock.fChecked);
+
+    CBlock missingReferenceVerifiedBlock = CreateBlock({missingReferenceSpendTx}, script);
+    CValidationState missingReferenceVerifiedBlockState;
+    BOOST_CHECK(!CheckBlock(
+            missingReferenceVerifiedBlock, missingReferenceVerifiedBlockState, consensus, true, true, chainActive.Height() + 1, false));
+    BOOST_CHECK(!missingReferenceVerifiedBlock.fChecked);
 
     batchProofContainer->clear();
     batchProofContainer->fCollectProofs = true;
     batchProofContainer->init();
 
-    SparkSpendProofVerificationResult missingReferenceBatchedProofResult;
+    SparkSpendProofVerificationResult missingReferenceBatchedProofResult = SparkSpendProofVerificationResult::NotApplicable;
     CSparkTxInfo missingReferenceBatchedInfo;
     CValidationState missingReferenceBatchedState;
-    BOOST_CHECK(CheckSparkTransaction(
+    BOOST_CHECK(!CheckSparkTransaction(
             missingReferenceSpend, missingReferenceBatchedState, missingReferenceSpend.GetHash(),
             false, chainActive.Height(), false, true, &missingReferenceBatchedInfo,
             true, &missingReferenceBatchedProofResult));
-    BOOST_CHECK(missingReferenceBatchedProofResult == SparkSpendProofVerificationResult::Batched);
+    BOOST_CHECK(missingReferenceBatchedProofResult != SparkSpendProofVerificationResult::Batched);
+    batchProofContainer->clear();
+
+    batchProofContainer->fCollectProofs = true;
+    batchProofContainer->init();
+    batchProofContainer->add(ParseSparkSpend(missingReferenceSpend));
     batchProofContainer->finalize();
-    BOOST_CHECK_NO_THROW(batchProofContainer->verify());
+    BOOST_CHECK_THROW(batchProofContainer->verify(), std::invalid_argument);
     batchProofContainer->clear();
 
     std::vector<CMutableTransaction> laterMintTxs;

--- a/src/test/spark_tests.cpp
+++ b/src/test/spark_tests.cpp
@@ -94,12 +94,12 @@ BOOST_AUTO_TEST_CASE(import_spark_proof_deferral_policy)
     CBlockIndex sideParent;
 
     BOOST_CHECK(CanDeferSparkSpendProofVerificationOnImport(&diskPos, &activeParent, &activeParent, true, false));
+    BOOST_CHECK(CanDeferSparkSpendProofVerificationOnImport(&diskPos, &sideParent, &activeParent, true, false));
+    BOOST_CHECK(CanDeferSparkSpendProofVerificationOnImport(&diskPos, &activeParent, nullptr, true, false));
     BOOST_CHECK(!CanDeferSparkSpendProofVerificationOnImport(&diskPos, &activeParent, &activeParent, false, false));
     BOOST_CHECK(!CanDeferSparkSpendProofVerificationOnImport(&diskPos, &activeParent, &activeParent, true, true));
     BOOST_CHECK(!CanDeferSparkSpendProofVerificationOnImport(nullptr, &activeParent, &activeParent, true, false));
     BOOST_CHECK(!CanDeferSparkSpendProofVerificationOnImport(&diskPos, nullptr, nullptr, true, false));
-    BOOST_CHECK(!CanDeferSparkSpendProofVerificationOnImport(&diskPos, &activeParent, nullptr, true, false));
-    BOOST_CHECK(!CanDeferSparkSpendProofVerificationOnImport(&diskPos, &sideParent, &activeParent, true, false));
 }
 
 BOOST_AUTO_TEST_CASE(parse_spark_mintscript)

--- a/src/test/spark_tests.cpp
+++ b/src/test/spark_tests.cpp
@@ -557,7 +557,11 @@ BOOST_AUTO_TEST_CASE(checktransaction)
 
     CValidationState walletLoadState;
     BOOST_CHECK(CheckTransaction(
-            tamperedSpend, walletLoadState, true, tamperedSpend.GetHash(), true, INT_MAX, false, false, NULL, false));
+            tamperedSpend, walletLoadState, true, tamperedSpend.GetHash(), true, INT_MAX, true, false, NULL, false));
+
+    CValidationState directVerifyDBState;
+    BOOST_CHECK(!CheckTransaction(
+            tamperedSpend, directVerifyDBState, true, tamperedSpend.GetHash(), true, INT_MAX, false, false, NULL, false));
 
     CSparkTxInfo statefulDeferredInfo;
     CValidationState statefulDeferredState;

--- a/src/test/spark_tests.cpp
+++ b/src/test/spark_tests.cpp
@@ -87,6 +87,21 @@ BOOST_AUTO_TEST_CASE(is_spark_allowed)
     BOOST_CHECK(IsSparkAllowed(start + 1));
 }
 
+BOOST_AUTO_TEST_CASE(import_spark_proof_deferral_policy)
+{
+    CDiskBlockPos diskPos(0, 0);
+    CBlockIndex activeParent;
+    CBlockIndex sideParent;
+
+    BOOST_CHECK(CanDeferSparkSpendProofVerificationOnImport(&diskPos, &activeParent, &activeParent, true, false));
+    BOOST_CHECK(!CanDeferSparkSpendProofVerificationOnImport(&diskPos, &activeParent, &activeParent, false, false));
+    BOOST_CHECK(!CanDeferSparkSpendProofVerificationOnImport(&diskPos, &activeParent, &activeParent, true, true));
+    BOOST_CHECK(!CanDeferSparkSpendProofVerificationOnImport(nullptr, &activeParent, &activeParent, true, false));
+    BOOST_CHECK(!CanDeferSparkSpendProofVerificationOnImport(&diskPos, nullptr, nullptr, true, false));
+    BOOST_CHECK(!CanDeferSparkSpendProofVerificationOnImport(&diskPos, &activeParent, nullptr, true, false));
+    BOOST_CHECK(!CanDeferSparkSpendProofVerificationOnImport(&diskPos, &sideParent, &activeParent, true, false));
+}
+
 BOOST_AUTO_TEST_CASE(parse_spark_mintscript)
 {
     auto params = Params::get_default();

--- a/src/test/spark_tests.cpp
+++ b/src/test/spark_tests.cpp
@@ -1,6 +1,7 @@
 #include "../chainparams.h"
 #include "../batchproof_container.h"
 #include "../script/standard.h"
+#include "../util.h"
 #include "../utiltime.h"
 #include "../validation.h"
 #include "../wallet/coincontrol.h"
@@ -517,6 +518,19 @@ BOOST_AUTO_TEST_CASE(checktransaction)
 
     CMutableTransaction spendTx(wtx);
     auto spend = ParseSparkSpend(spendTx);
+    auto replaceSparkSpendBlockHashes = [](CMutableTransaction tx, const uint256& blockHash) {
+        spark::SpendTransaction sparkSpend = ParseSparkSpend(tx);
+        std::map<uint64_t, uint256> idAndBlockHashes;
+        for (const auto& idAndHash : sparkSpend.getBlockHashes()) {
+            idAndBlockHashes[idAndHash.first] = blockHash;
+        }
+        sparkSpend.setBlockHashes(idAndBlockHashes);
+
+        CDataStream serialized(SER_NETWORK, PROTOCOL_VERSION);
+        serialized << sparkSpend;
+        tx.vExtraPayload.assign(serialized.begin(), serialized.end());
+        return tx;
+    };
 
     // test get join split amounts
     BOOST_CHECK_EQUAL(1, GetSpendInputs(spendTx));
@@ -633,12 +647,40 @@ BOOST_AUTO_TEST_CASE(checktransaction)
 
     BOOST_CHECK(BuildSparkStateFromIndex(&chainActive));
 
+    BatchProofContainer* batchProofContainer = BatchProofContainer::get_instance();
+
+    CMutableTransaction missingReferenceSpendTx = replaceSparkSpendBlockHashes(spendTx, uint256());
+    CTransaction missingReferenceSpend(missingReferenceSpendTx);
+
+    SparkSpendProofVerificationResult missingReferenceDirectProofResult;
+    CSparkTxInfo missingReferenceDirectInfo;
+    CValidationState missingReferenceDirectState;
+    BOOST_CHECK(CheckSparkTransaction(
+            missingReferenceSpend, missingReferenceDirectState, missingReferenceSpend.GetHash(),
+            false, chainActive.Height(), false, true, &missingReferenceDirectInfo,
+            true, &missingReferenceDirectProofResult));
+    BOOST_CHECK(missingReferenceDirectProofResult == SparkSpendProofVerificationResult::Verified);
+
+    batchProofContainer->clear();
+    batchProofContainer->fCollectProofs = true;
+    batchProofContainer->init();
+
+    SparkSpendProofVerificationResult missingReferenceBatchedProofResult;
+    CSparkTxInfo missingReferenceBatchedInfo;
+    CValidationState missingReferenceBatchedState;
+    BOOST_CHECK(CheckSparkTransaction(
+            missingReferenceSpend, missingReferenceBatchedState, missingReferenceSpend.GetHash(),
+            false, chainActive.Height(), false, true, &missingReferenceBatchedInfo,
+            true, &missingReferenceBatchedProofResult));
+    BOOST_CHECK(missingReferenceBatchedProofResult == SparkSpendProofVerificationResult::Batched);
+    batchProofContainer->finalize();
+    BOOST_CHECK_NO_THROW(batchProofContainer->verify());
+    batchProofContainer->clear();
+
     std::vector<CMutableTransaction> laterMintTxs;
     GenerateMints({2 * COIN, 3 * COIN}, laterMintTxs);
     mempool.clear();
     BOOST_CHECK(GenerateBlock(laterMintTxs));
-
-    BatchProofContainer* batchProofContainer = BatchProofContainer::get_instance();
 
     batchProofContainer->fCollectProofs = true;
     batchProofContainer->init();
@@ -690,6 +732,29 @@ BOOST_AUTO_TEST_CASE(checktransaction)
         BOOST_CHECK(!sparkState->IsUsedLTag(lTag));
     }
 
+    CMutableTransaction missingInputTx;
+    missingInputTx.vin.push_back(CTxIn(COutPoint(uint256S("1"), 0)));
+    missingInputTx.vout.push_back(CTxOut(CENT, script));
+
+    CBlock connectEarlyFailureBlock = CreateBlock({batchedTamperedSpendTx, missingInputTx}, script);
+    CBlockIndex connectEarlyFailureIndex(connectEarlyFailureBlock);
+    connectEarlyFailureIndex.pprev = chainActive.Tip();
+    connectEarlyFailureIndex.nHeight = chainActive.Height() + 1;
+    connectEarlyFailureIndex.nTime = GetSystemTimeInSeconds() - 2 * 86400;
+
+    CCoinsViewCache connectEarlyFailureView(pcoinsTip);
+    CValidationState connectEarlyFailureState;
+    BOOST_CHECK(!ConnectBlock(
+            connectEarlyFailureBlock,
+            connectEarlyFailureState,
+            &connectEarlyFailureIndex,
+            connectEarlyFailureView,
+            ::Params(),
+            true));
+    batchProofContainer->finalize();
+    BOOST_CHECK_NO_THROW(batchProofContainer->verify());
+    batchProofContainer->clear();
+
     batchProofContainer->fCollectProofs = true;
     batchProofContainer->init();
 
@@ -713,6 +778,82 @@ BOOST_AUTO_TEST_CASE(checktransaction)
     CValidationState verifiedState;
     BOOST_CHECK(!CheckSparkTransaction(
             tamperedSpend, verifiedState, tamperedSpend.GetHash(), false, chainActive.Height(), false, true, &tamperedInfo));
+
+    mempool.clear();
+    sparkState->Reset();
+}
+
+BOOST_AUTO_TEST_CASE(verifydb_level4_connected_spark_spend_preserves_spark_state)
+{
+    struct MobileArgGuard {
+        MobileArgGuard() { ForceSetArg("-mobile", "1"); }
+        ~MobileArgGuard() { ForceSetArg("-mobile", "0"); }
+    } mobileArgGuard;
+
+    auto coinGroupSnapshot = [this]() {
+        std::map<int, std::pair<int, std::pair<int, int>>> snapshot;
+        for (const auto& group : sparkState->GetCoinGroups()) {
+            const int firstHeight = group.second.firstBlock ? group.second.firstBlock->nHeight : -1;
+            const int lastHeight = group.second.lastBlock ? group.second.lastBlock->nHeight : -1;
+            snapshot[group.first] = std::make_pair(firstHeight, std::make_pair(lastHeight, group.second.nCoins));
+        }
+        return snapshot;
+    };
+
+    pwalletMain->SetBroadcastTransactions(true);
+    GenerateBlocks(500);
+
+    std::vector<CMutableTransaction> mintTxs;
+    GenerateMints({10 * COIN, 1 * COIN}, mintTxs);
+    mempool.clear();
+    BOOST_REQUIRE(GenerateBlock(mintTxs));
+    GenerateBlocks(10);
+
+    CAmount fee;
+    CWalletTx wtx = pwalletMain->SpendAndStoreSpark({{script, 1 * COIN, false}}, {}, fee);
+    CMutableTransaction spendTx(wtx);
+    spark::SpendTransaction spend = ParseSparkSpend(spendTx);
+    mempool.clear();
+    BOOST_REQUIRE(GenerateBlock({spendTx}));
+    CBlockIndex* spendIndex = chainActive.Tip();
+
+    std::vector<CMutableTransaction> metadataMintTxs;
+    GenerateMints({2 * COIN}, metadataMintTxs);
+    mempool.clear();
+    BOOST_REQUIRE(GenerateBlock(metadataMintTxs));
+    CBlockIndex* metadataMintIndex = chainActive.Tip();
+
+    for (const auto& lTag : spend.getUsedLTags()) {
+        BOOST_CHECK(sparkState->IsUsedLTag(lTag));
+    }
+
+    const auto spendsBefore = sparkState->GetSpends();
+    const auto mobileSpendsBefore = sparkState->GetSpendsMobile();
+    const auto coinGroupsBefore = coinGroupSnapshot();
+    const auto mintCountBefore = sparkState->GetMints().size();
+
+    BOOST_CHECK(CVerifyDB().VerifyDB(::Params(), pcoinsTip, 4, 1));
+
+    const auto spentLTags = spendIndex->spentLTags;
+    BOOST_REQUIRE(!spentLTags.empty());
+    spendIndex->spentLTags.clear();
+    BOOST_CHECK(!CVerifyDB().VerifyDB(::Params(), pcoinsTip, 4, 1));
+    BOOST_CHECK(spendIndex->spentLTags.empty());
+    spendIndex->spentLTags = spentLTags;
+    BOOST_CHECK(CVerifyDB().VerifyDB(::Params(), pcoinsTip, 4, 1));
+
+    const auto sparkMintedCoins = metadataMintIndex->sparkMintedCoins;
+    BOOST_REQUIRE(!sparkMintedCoins.empty());
+    metadataMintIndex->sparkMintedCoins.clear();
+    BOOST_CHECK(!CVerifyDB().VerifyDB(::Params(), pcoinsTip, 4, 1));
+    BOOST_CHECK(metadataMintIndex->sparkMintedCoins.empty());
+    metadataMintIndex->sparkMintedCoins = sparkMintedCoins;
+    BOOST_CHECK(CVerifyDB().VerifyDB(::Params(), pcoinsTip, 4, 1));
+
+    BOOST_CHECK(spendsBefore == sparkState->GetSpends());
+    BOOST_CHECK(mobileSpendsBefore == sparkState->GetSpendsMobile());
+    BOOST_CHECK(coinGroupsBefore == coinGroupSnapshot());
+    BOOST_CHECK_EQUAL(mintCountBefore, sparkState->GetMints().size());
 
     mempool.clear();
     sparkState->Reset();

--- a/src/test/spark_tests.cpp
+++ b/src/test/spark_tests.cpp
@@ -559,6 +559,13 @@ BOOST_AUTO_TEST_CASE(checktransaction)
     BOOST_CHECK(CheckTransaction(
             tamperedSpend, walletLoadState, true, tamperedSpend.GetHash(), true, INT_MAX, true, false, NULL, false));
 
+    CMutableTransaction walletLoadMalformedSpendTx(spendTx);
+    walletLoadMalformedSpendTx.vout.push_back(CTxOut(0, CScript() << OP_SPARKMINT));
+    CTransaction walletLoadMalformedSpend(walletLoadMalformedSpendTx);
+    CValidationState walletLoadMalformedState;
+    BOOST_CHECK(!CheckTransaction(
+            walletLoadMalformedSpend, walletLoadMalformedState, true, walletLoadMalformedSpend.GetHash(), true, INT_MAX, true, false, NULL, false));
+
     CValidationState directVerifyDBState;
     BOOST_CHECK(!CheckTransaction(
             tamperedSpend, directVerifyDBState, true, tamperedSpend.GetHash(), true, INT_MAX, false, false, NULL, false));
@@ -582,7 +589,16 @@ BOOST_AUTO_TEST_CASE(checktransaction)
     CValidationState verifiedValidBlockState;
     BOOST_CHECK(CheckBlock(
             verifiedValidBlock, verifiedValidBlockState, consensus, true, true, chainActive.Height() + 1, false));
-    BOOST_CHECK(verifiedValidBlock.fChecked);
+    BOOST_CHECK(!verifiedValidBlock.fChecked);
+
+    sparkState->Reset();
+
+    CValidationState verifiedValidBlockVerifyDBState;
+    BOOST_CHECK(!CheckBlock(
+            verifiedValidBlock, verifiedValidBlockVerifyDBState, consensus, true, true, chainActive.Height() + 1, true));
+    BOOST_CHECK(!verifiedValidBlock.fChecked);
+
+    BOOST_CHECK(BuildSparkStateFromIndex(&chainActive));
 
     CBlock tamperedBlock = CreateBlock({tamperedSpendTx}, script);
     CValidationState deferredBlockState;
@@ -673,6 +689,22 @@ BOOST_AUTO_TEST_CASE(checktransaction)
     for (const auto& lTag : spend.getUsedLTags()) {
         BOOST_CHECK(!sparkState->IsUsedLTag(lTag));
     }
+
+    batchProofContainer->fCollectProofs = true;
+    batchProofContainer->init();
+
+    CBlock batchedTamperedDeferredBlock = CreateBlock({batchedTamperedSpendTx}, script);
+    CValidationState batchedTamperedDeferredBlockState;
+    BOOST_CHECK(CheckBlock(
+            batchedTamperedDeferredBlock, batchedTamperedDeferredBlockState, consensus, true, true, chainActive.Height() + 1, false, true));
+    BOOST_CHECK(!batchedTamperedDeferredBlock.fChecked);
+
+    CBlock batchedTamperedVerifiedBlock = CreateBlock({batchedTamperedSpendTx}, script);
+    CValidationState batchedTamperedVerifiedBlockState;
+    BOOST_CHECK(!CheckBlock(
+            batchedTamperedVerifiedBlock, batchedTamperedVerifiedBlockState, consensus, true, true, chainActive.Height() + 1, false));
+    BOOST_CHECK(!batchedTamperedVerifiedBlock.fChecked);
+    batchProofContainer->clear();
 
     batchProofContainer->fCollectProofs = false;
     batchProofContainer->init();

--- a/src/test/spark_tests.cpp
+++ b/src/test/spark_tests.cpp
@@ -9,6 +9,7 @@
 #include "test_bitcoin.h"
 #include "fixtures.h"
 #include <iostream>
+#include <stdexcept>
 #include <boost/test/unit_test.hpp>
 
 namespace spark {
@@ -564,6 +565,18 @@ BOOST_AUTO_TEST_CASE(checktransaction)
     BOOST_CHECK(!CheckSparkTransaction(
             tamperedSpend, nonStatefulVerifiedState, tamperedSpend.GetHash(), false, chainActive.Height(), false, false, NULL));
 
+    CBlock deferredValidBlock = CreateBlock({spendTx}, script);
+    CValidationState deferredValidBlockState;
+    BOOST_CHECK(CheckBlock(
+            deferredValidBlock, deferredValidBlockState, consensus, true, true, chainActive.Height() + 1, false, true));
+    BOOST_CHECK(!deferredValidBlock.fChecked);
+
+    CBlock verifiedValidBlock = CreateBlock({spendTx}, script);
+    CValidationState verifiedValidBlockState;
+    BOOST_CHECK(CheckBlock(
+            verifiedValidBlock, verifiedValidBlockState, consensus, true, true, chainActive.Height() + 1, false));
+    BOOST_CHECK(verifiedValidBlock.fChecked);
+
     CBlock tamperedBlock = CreateBlock({tamperedSpendTx}, script);
     CValidationState deferredBlockState;
     BOOST_CHECK(CheckBlock(
@@ -586,8 +599,11 @@ BOOST_AUTO_TEST_CASE(checktransaction)
 
     CSparkTxInfo batchedTamperedInfo;
     CValidationState batchedVerifiedState;
-    BOOST_CHECK(!CheckSparkTransaction(
+    BOOST_CHECK(CheckSparkTransaction(
             tamperedSpend, batchedVerifiedState, tamperedSpend.GetHash(), false, chainActive.Height(), false, true, &batchedTamperedInfo));
+    batchProofContainer->finalize();
+    BOOST_CHECK_THROW(batchProofContainer->verify(), std::invalid_argument);
+    batchProofContainer->clear();
 
     batchProofContainer->fCollectProofs = false;
     batchProofContainer->init();

--- a/src/test/spark_tests.cpp
+++ b/src/test/spark_tests.cpp
@@ -1,6 +1,7 @@
 #include "../chainparams.h"
 #include "../batchproof_container.h"
 #include "../script/standard.h"
+#include "../utiltime.h"
 #include "../validation.h"
 #include "../wallet/coincontrol.h"
 #include "../wallet/wallet.h"
@@ -548,9 +549,11 @@ BOOST_AUTO_TEST_CASE(checktransaction)
     tamperedSpendTx.vout[0].nValue += CENT;
     CTransaction tamperedSpend(tamperedSpendTx);
 
+    SparkSpendProofVerificationResult deferredProofResult;
     CValidationState deferredState;
     BOOST_CHECK(CheckSparkTransaction(
-            tamperedSpend, deferredState, tamperedSpend.GetHash(), false, chainActive.Height(), false, false, NULL, false));
+            tamperedSpend, deferredState, tamperedSpend.GetHash(), false, chainActive.Height(), false, false, NULL, false, &deferredProofResult));
+    BOOST_CHECK(deferredProofResult == SparkSpendProofVerificationResult::Deferred);
 
     CValidationState walletLoadState;
     BOOST_CHECK(CheckTransaction(
@@ -593,17 +596,79 @@ BOOST_AUTO_TEST_CASE(checktransaction)
             tamperedBlock, verifyDBBlockState, consensus, true, true, chainActive.Height() + 1, true, true));
     BOOST_CHECK(!tamperedBlock.fChecked);
 
+    CBlock missingSparkStateBlock = CreateBlock({spendTx}, script);
+    CBlock missingSparkStateVerifyDBBlock = CreateBlock({spendTx}, script);
+
+    sparkState->Reset();
+
+    CValidationState missingSparkStateBlockState;
+    BOOST_CHECK(CheckBlock(
+            missingSparkStateBlock, missingSparkStateBlockState, consensus, true, true, chainActive.Height() + 1, false));
+    BOOST_CHECK(!missingSparkStateBlock.fChecked);
+
+    CValidationState missingSparkStateVerifyDBBlockState;
+    BOOST_CHECK(!CheckBlock(
+            missingSparkStateVerifyDBBlock, missingSparkStateVerifyDBBlockState, consensus, true, true, chainActive.Height() + 1, true));
+    BOOST_CHECK(!missingSparkStateVerifyDBBlock.fChecked);
+
+    BOOST_CHECK(BuildSparkStateFromIndex(&chainActive));
+
+    std::vector<CMutableTransaction> laterMintTxs;
+    GenerateMints({2 * COIN, 3 * COIN}, laterMintTxs);
+    mempool.clear();
+    BOOST_CHECK(GenerateBlock(laterMintTxs));
+
     BatchProofContainer* batchProofContainer = BatchProofContainer::get_instance();
+
     batchProofContainer->fCollectProofs = true;
     batchProofContainer->init();
 
+    SparkSpendProofVerificationResult batchedValidProofResult;
+    CSparkTxInfo batchedValidInfo;
+    CValidationState batchedValidState;
+    BOOST_CHECK(CheckSparkTransaction(
+            spendTx, batchedValidState, spendTx.GetHash(), false, chainActive.Height(), false, true, &batchedValidInfo, true, &batchedValidProofResult));
+    BOOST_CHECK(batchedValidProofResult == SparkSpendProofVerificationResult::Batched);
+    batchProofContainer->finalize();
+    BOOST_CHECK_NO_THROW(batchProofContainer->verify());
+    batchProofContainer->clear();
+
+    batchProofContainer->fCollectProofs = true;
+    batchProofContainer->init();
+
+    CMutableTransaction batchedTamperedSpendTx(spendTx);
+    batchedTamperedSpendTx.vout[0].nValue += 2 * CENT;
+    CTransaction batchedTamperedSpend(batchedTamperedSpendTx);
+
+    SparkSpendProofVerificationResult batchedProofResult;
     CSparkTxInfo batchedTamperedInfo;
     CValidationState batchedVerifiedState;
     BOOST_CHECK(CheckSparkTransaction(
-            tamperedSpend, batchedVerifiedState, tamperedSpend.GetHash(), false, chainActive.Height(), false, true, &batchedTamperedInfo));
+            batchedTamperedSpend, batchedVerifiedState, batchedTamperedSpend.GetHash(), false, chainActive.Height(), false, true, &batchedTamperedInfo, true, &batchedProofResult));
+    BOOST_CHECK(batchedProofResult == SparkSpendProofVerificationResult::Batched);
     batchProofContainer->finalize();
     BOOST_CHECK_THROW(batchProofContainer->verify(), std::invalid_argument);
     batchProofContainer->clear();
+
+    CBlock connectTamperedBlock = CreateBlock({batchedTamperedSpendTx}, script);
+    CBlockIndex connectTamperedIndex(connectTamperedBlock);
+    connectTamperedIndex.pprev = chainActive.Tip();
+    connectTamperedIndex.nHeight = chainActive.Height() + 1;
+    connectTamperedIndex.nTime = GetSystemTimeInSeconds() - 2 * 86400;
+
+    CCoinsViewCache connectTamperedView(pcoinsTip);
+    CValidationState connectTamperedState;
+    BOOST_CHECK(!ConnectBlock(
+            connectTamperedBlock,
+            connectTamperedState,
+            &connectTamperedIndex,
+            connectTamperedView,
+            ::Params(),
+            true));
+    BOOST_CHECK(!connectTamperedState.IsValid());
+    for (const auto& lTag : spend.getUsedLTags()) {
+        BOOST_CHECK(!sparkState->IsUsedLTag(lTag));
+    }
 
     batchProofContainer->fCollectProofs = false;
     batchProofContainer->init();

--- a/src/test/spark_tests.cpp
+++ b/src/test/spark_tests.cpp
@@ -760,13 +760,16 @@ BOOST_AUTO_TEST_CASE(checktransaction)
 
     CCoinsViewCache connectTamperedView(pcoinsTip);
     CValidationState connectTamperedState;
-    BOOST_CHECK(!ConnectBlock(
-            connectTamperedBlock,
-            connectTamperedState,
-            &connectTamperedIndex,
-            connectTamperedView,
-            ::Params(),
-            true));
+    {
+        LOCK(cs_main);
+        BOOST_CHECK(!ConnectBlock(
+                connectTamperedBlock,
+                connectTamperedState,
+                &connectTamperedIndex,
+                connectTamperedView,
+                ::Params(),
+                true));
+    }
     BOOST_CHECK(!connectTamperedState.IsValid());
     for (const auto& lTag : spend.getUsedLTags()) {
         BOOST_CHECK(!sparkState->IsUsedLTag(lTag));
@@ -784,13 +787,16 @@ BOOST_AUTO_TEST_CASE(checktransaction)
 
     CCoinsViewCache connectEarlyFailureView(pcoinsTip);
     CValidationState connectEarlyFailureState;
-    BOOST_CHECK(!ConnectBlock(
-            connectEarlyFailureBlock,
-            connectEarlyFailureState,
-            &connectEarlyFailureIndex,
-            connectEarlyFailureView,
-            ::Params(),
-            true));
+    {
+        LOCK(cs_main);
+        BOOST_CHECK(!ConnectBlock(
+                connectEarlyFailureBlock,
+                connectEarlyFailureState,
+                &connectEarlyFailureIndex,
+                connectEarlyFailureView,
+                ::Params(),
+                true));
+    }
     batchProofContainer->finalize();
     BOOST_CHECK_NO_THROW(batchProofContainer->verify());
     batchProofContainer->clear();

--- a/src/test/spark_tests.cpp
+++ b/src/test/spark_tests.cpp
@@ -1,4 +1,5 @@
 #include "../chainparams.h"
+#include "../batchproof_container.h"
 #include "../script/standard.h"
 #include "../validation.h"
 #include "../wallet/coincontrol.h"
@@ -541,6 +542,60 @@ BOOST_AUTO_TEST_CASE(checktransaction)
     info.spTransactions.clear();
     BOOST_CHECK(!CheckSparkTransaction(
             spendTx, state, spendTx.GetHash(), false, chainActive.Height(), false, true, &info));
+
+    CMutableTransaction tamperedSpendTx(spendTx);
+    tamperedSpendTx.vout[0].nValue += CENT;
+    CTransaction tamperedSpend(tamperedSpendTx);
+
+    CValidationState deferredState;
+    BOOST_CHECK(CheckSparkTransaction(
+            tamperedSpend, deferredState, tamperedSpend.GetHash(), false, chainActive.Height(), false, false, NULL, false));
+
+    CValidationState walletLoadState;
+    BOOST_CHECK(CheckTransaction(
+            tamperedSpend, walletLoadState, true, tamperedSpend.GetHash(), true, INT_MAX, false, false, NULL, false));
+
+    CSparkTxInfo statefulDeferredInfo;
+    CValidationState statefulDeferredState;
+    BOOST_CHECK(!CheckSparkTransaction(
+            tamperedSpend, statefulDeferredState, tamperedSpend.GetHash(), false, chainActive.Height(), false, true, &statefulDeferredInfo, false));
+
+    CValidationState nonStatefulVerifiedState;
+    BOOST_CHECK(!CheckSparkTransaction(
+            tamperedSpend, nonStatefulVerifiedState, tamperedSpend.GetHash(), false, chainActive.Height(), false, false, NULL));
+
+    CBlock tamperedBlock = CreateBlock({tamperedSpendTx}, script);
+    CValidationState deferredBlockState;
+    BOOST_CHECK(CheckBlock(
+            tamperedBlock, deferredBlockState, consensus, true, true, chainActive.Height() + 1, false, true));
+    BOOST_CHECK(!tamperedBlock.fChecked);
+
+    CValidationState verifiedBlockState;
+    BOOST_CHECK(!CheckBlock(
+            tamperedBlock, verifiedBlockState, consensus, true, true, chainActive.Height() + 1, false));
+    BOOST_CHECK(!tamperedBlock.fChecked);
+
+    CValidationState verifyDBBlockState;
+    BOOST_CHECK(!CheckBlock(
+            tamperedBlock, verifyDBBlockState, consensus, true, true, chainActive.Height() + 1, true, true));
+    BOOST_CHECK(!tamperedBlock.fChecked);
+
+    BatchProofContainer* batchProofContainer = BatchProofContainer::get_instance();
+    batchProofContainer->fCollectProofs = true;
+    batchProofContainer->init();
+
+    CSparkTxInfo batchedTamperedInfo;
+    CValidationState batchedVerifiedState;
+    BOOST_CHECK(!CheckSparkTransaction(
+            tamperedSpend, batchedVerifiedState, tamperedSpend.GetHash(), false, chainActive.Height(), false, true, &batchedTamperedInfo));
+
+    batchProofContainer->fCollectProofs = false;
+    batchProofContainer->init();
+
+    CSparkTxInfo tamperedInfo;
+    CValidationState verifiedState;
+    BOOST_CHECK(!CheckSparkTransaction(
+            tamperedSpend, verifiedState, tamperedSpend.GetHash(), false, chainActive.Height(), false, true, &tamperedInfo));
 
     mempool.clear();
     sparkState->Reset();

--- a/src/test/spark_tests.cpp
+++ b/src/test/spark_tests.cpp
@@ -93,6 +93,12 @@ BOOST_AUTO_TEST_CASE(import_spark_proof_deferral_policy)
     CBlockIndex activeParent;
     CBlockIndex sideParent;
 
+    BOOST_CHECK(CanDeferSparkSpendProofVerificationBeforeConnect(&activeParent, true, false));
+    BOOST_CHECK(CanDeferSparkSpendProofVerificationBeforeConnect(&sideParent, true, false));
+    BOOST_CHECK(!CanDeferSparkSpendProofVerificationBeforeConnect(nullptr, true, false));
+    BOOST_CHECK(!CanDeferSparkSpendProofVerificationBeforeConnect(&activeParent, false, false));
+    BOOST_CHECK(!CanDeferSparkSpendProofVerificationBeforeConnect(&activeParent, true, true));
+
     BOOST_CHECK(CanDeferSparkSpendProofVerificationOnImport(&diskPos, &activeParent, &activeParent, true, false));
     BOOST_CHECK(CanDeferSparkSpendProofVerificationOnImport(&diskPos, &sideParent, &activeParent, true, false));
     BOOST_CHECK(CanDeferSparkSpendProofVerificationOnImport(&diskPos, &activeParent, nullptr, true, false));

--- a/src/test/sparkname_tests.cpp
+++ b/src/test/sparkname_tests.cpp
@@ -10,6 +10,7 @@
 #include "compat_layer.h"
 #include "test_bitcoin.h"
 #include "fixtures.h"
+#include <algorithm>
 #include <iostream>
 #include <boost/test/unit_test.hpp>
 
@@ -827,6 +828,93 @@ BOOST_AUTO_TEST_CASE(validity_overflow_protection)
     GenerateBlock({txValid});
     BOOST_CHECK_EQUAL(chainActive.Height(), oldHeight + 1); // block must be accepted
     BOOST_CHECK(IsSparkNamePresent("overtest"));
+}
+
+BOOST_AUTO_TEST_CASE(verifydb_level4_spark_name_transfer_uses_readonly_mode)
+{
+    constexpr int nBlockPerYear = 365*24*24;
+
+    Initialize(2500);
+
+    std::string addrA = GenerateSparkAddress();
+    CMutableTransaction txReg = CreateSparkNameTx("verifyxfer", addrA, nBlockPerYear * 5, "original", true);
+    BOOST_CHECK(lastState.IsValid());
+    GenerateBlock({txReg});
+
+    std::string addrB = GenerateSparkAddress();
+    CSparkNameTxData transferData;
+    transferData.nVersion = CSparkNameTxData::CURRENT_VERSION;
+    transferData.name = "verifyxfer";
+    transferData.sparkAddress = addrB;
+    transferData.oldSparkAddress = addrA;
+    transferData.sparkNameValidityBlocks = nBlockPerYear;
+    transferData.operationType = (uint8_t)CSparkNameTxData::opTransfer;
+    transferData.additionalInfo = "transferred";
+
+    {
+        CHashWriter nameHash(SER_GETHASH, PROTOCOL_VERSION);
+        nameHash << transferData;
+
+        CHashWriter hashStream(SER_GETHASH, PROTOCOL_VERSION);
+        hashStream << "SparkNameTransferProof";
+        hashStream << transferData.oldSparkAddress << transferData.sparkAddress;
+        hashStream << nameHash.GetHash();
+
+        const spark::Params *sparkParams = spark::Params::get_default();
+        spark::SpendKey spendKey = pwalletMain->sparkWallet->generateSpendKey(sparkParams);
+
+        spark::Address oldAddress(sparkParams);
+        oldAddress.decode(addrA);
+
+        spark::Scalar mTransfer;
+        mTransfer.SetHex(hashStream.GetHash().ToString());
+
+        spark::OwnershipProof transferProof;
+        oldAddress.prove_own(mTransfer, spendKey, spark::FullViewKey(spendKey), transferProof);
+
+        CDataStream proofStream(SER_NETWORK, PROTOCOL_VERSION);
+        proofStream << transferProof;
+        transferData.transferOwnershipProof.assign(proofStream.begin(), proofStream.end());
+    }
+
+    CMutableTransaction txTransfer = CreateSparkNameTx(transferData, true);
+    BOOST_CHECK(lastState.IsValid());
+    GenerateBlock({txTransfer});
+    CBlockIndex* transferIndex = chainActive.Tip();
+
+    std::string resolvedAddr;
+    BOOST_CHECK(sparkNameManager->GetSparkAddress("verifyxfer", resolvedAddr));
+    BOOST_CHECK_EQUAL(resolvedAddr, addrB);
+    FlushStateToDisk();
+
+    auto sparkNameSnapshot = [this]() {
+        std::vector<std::string> snapshot;
+        for (const auto& item : sparkNameManager->DumpSparkNameData()) {
+            snapshot.push_back(
+                    item.name + "|" +
+                    item.sparkAddress + "|" +
+                    std::to_string(item.sparkNameValidityHeight) + "|" +
+                    item.additionalInfo);
+        }
+        std::sort(snapshot.begin(), snapshot.end());
+        return snapshot;
+    };
+
+    const auto sparkNamesBefore = sparkNameSnapshot();
+    BOOST_CHECK(CVerifyDB().VerifyDB(::Params(), pcoinsTip, 4, 1));
+
+    const auto addedSparkNames = transferIndex->addedSparkNames;
+    BOOST_REQUIRE(!addedSparkNames.empty());
+    transferIndex->addedSparkNames.clear();
+    BOOST_CHECK(!CVerifyDB().VerifyDB(::Params(), pcoinsTip, 4, 1));
+    BOOST_CHECK(transferIndex->addedSparkNames.empty());
+    transferIndex->addedSparkNames = addedSparkNames;
+    BOOST_CHECK(CVerifyDB().VerifyDB(::Params(), pcoinsTip, 4, 1));
+
+    const auto sparkNamesAfter = sparkNameSnapshot();
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+            sparkNamesBefore.begin(), sparkNamesBefore.end(),
+            sparkNamesAfter.begin(), sparkNamesAfter.end());
 }
 
 BOOST_AUTO_TEST_CASE(transfer_replay_protection_v21)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4295,6 +4295,11 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
     return true;
 }
 
+bool CanDeferSparkSpendProofVerificationOnImport(const CDiskBlockPos* dbp, const CBlockIndex* pindexPrev, const CBlockIndex* activeTip, bool fAllowSparkSpendProofDeferral, bool fShutdownRequested)
+{
+    return fAllowSparkSpendProofDeferral && !fShutdownRequested && dbp != nullptr && pindexPrev != nullptr && pindexPrev == activeTip;
+}
+
 static bool CheckIndexAgainstCheckpoint(const CBlockIndex* pindexPrev, CValidationState& state, const CChainParams& chainparams, const uint256& hash)
 {
     if (*pindexPrev->phashBlock == chainparams.GetConsensus().hashGenesisBlock)
@@ -4659,7 +4664,7 @@ bool ProcessNewBlockHeaders(const std::vector<CBlockHeader>& headers, CValidatio
 }
 
 /** Store block on disk. If dbp is non-NULL, the file is known to already reside on disk */
-static bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex, bool fRequested, const CDiskBlockPos* dbp, bool* fNewBlock)
+static bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex, bool fRequested, const CDiskBlockPos* dbp, bool* fNewBlock, bool fAllowSparkSpendProofDeferral = true)
 {
     const CBlock& block = *pblock;
 
@@ -4704,7 +4709,10 @@ static bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidation
     // stateful ConnectBlock check that runs immediately before chain state is
     // updated. Do not defer side-chain or out-of-order imported blocks: they can
     // remain stored without being connected, so AcceptBlock must verify them.
-    const bool fDeferSparkSpendProofVerification = dbp != NULL && pindex->pprev == chainActive.Tip();
+    // Also do not defer during shutdown: ActivateBestChain can exit without
+    // connecting the just-accepted block.
+    const bool fDeferSparkSpendProofVerification = CanDeferSparkSpendProofVerificationOnImport(
+            dbp, pindex->pprev, chainActive.Tip(), fAllowSparkSpendProofDeferral, ShutdownRequested());
     if (!CheckBlock(block, state, chainparams.GetConsensus(), true, true, pindex->nHeight, false, fDeferSparkSpendProofVerification) ||
         !ContextualCheckBlock(block, state, chainparams.GetConsensus(), pindex->pprev)) {
         if (state.IsInvalid() && !state.CorruptionPossible()) {
@@ -5542,7 +5550,7 @@ bool LoadExternalBlockFile(const CChainParams& chainparams, FILE* fileIn, CDiskB
                                     head.ToString());
                             LOCK(cs_main);
                             CValidationState dummy;
-                            if (AcceptBlock(pblockrecursive, dummy, chainparams, NULL, true, &it->second, NULL))
+                            if (AcceptBlock(pblockrecursive, dummy, chainparams, NULL, true, &it->second, NULL, false))
                             {
                                 nLoaded++;
                                 queue.push_back(pblockrecursive->GetHash());

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -574,7 +574,7 @@ int GetUTXOConfirmations(const COutPoint& outpoint)
     return (nPrevoutHeight > -1 && chainActive.Tip()) ? chainActive.Height() - nPrevoutHeight + 1 : -1;
 }
 
-bool CheckTransaction(const CTransaction &tx, CValidationState &state, bool fCheckDuplicateInputs, uint256 hashTx,  bool isVerifyDB, int nHeight, bool isCheckWallet, bool fStatefulZerocoinCheck, spark::CSparkTxInfo* sparkTxInfo, bool fVerifySparkSpendProof, spark::SparkSpendProofVerificationResult* sparkSpendProofResult)
+bool CheckTransaction(const CTransaction &tx, CValidationState &state, bool fCheckDuplicateInputs, uint256 hashTx,  bool isVerifyDB, int nHeight, bool isCheckWallet, bool fStatefulZerocoinCheck, spark::CSparkTxInfo* sparkTxInfo, bool fVerifySparkSpendProof, spark::SparkSpendProofVerificationResult* sparkSpendProofResult, spark::CSparkValidationContext* sparkValidationContext)
 {
     if (sparkSpendProofResult)
         *sparkSpendProofResult = spark::SparkSpendProofVerificationResult::NotApplicable;
@@ -703,7 +703,7 @@ bool CheckTransaction(const CTransaction &tx, CValidationState &state, bool fChe
         if (tx.IsSparkTransaction()) {
             if (hasExchangeUTXOs)
                 return state.DoS(100, false, REJECT_INVALID, "bad-exchange-address");
-            if (!CheckSparkTransaction(tx, state, hashTx, isVerifyDB, nHeight, isCheckWallet, fStatefulZerocoinCheck, sparkTxInfo, fVerifySparkSpendProof, sparkSpendProofResult))
+            if (!CheckSparkTransaction(tx, state, hashTx, isVerifyDB, nHeight, isCheckWallet, fStatefulZerocoinCheck, sparkTxInfo, fVerifySparkSpendProof, sparkSpendProofResult, sparkValidationContext))
                 return false;
         }
 
@@ -2238,6 +2238,22 @@ bool AbortNode(CValidationState& state, const std::string& strMessage, const std
     return state.Error(strMessage);
 }
 
+bool VerifyPendingSparkBatch(CValidationState& state, const std::string& reason)
+{
+    AssertLockHeld(cs_main);
+
+    try {
+        BatchProofContainer* batchProofContainer = BatchProofContainer::get_instance();
+        batchProofContainer->finalize();
+        batchProofContainer->verify();
+        return true;
+    } catch (const std::exception& e) {
+        return AbortNode(state,
+                         strprintf("Spark batch verification failed before %s: %s", reason, e.what()),
+                         _("Spark batch verification failed. Please restart with -reindex -batching=0 to identify the invalid Spark spend."));
+    }
+}
+
 enum DisconnectResult
 {
     DISCONNECT_OK,      // All good.
@@ -2508,7 +2524,7 @@ static int64_t nTimeCallbacks = 0;
 static int64_t nTimeTotal = 0;
 
 bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pindex,
-                  CCoinsViewCache& view, const CChainParams& chainparams, bool fJustCheck)
+                  CCoinsViewCache& view, const CChainParams& chainparams, bool fJustCheck, bool fVerifyDB, spark::CSparkValidationContext* sparkValidationContext)
 {
     AssertLockHeld(cs_main);
 
@@ -2516,7 +2532,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     //btzc: update nHeight, isVerifyDB
     // Check it again in case a previous version let a bad block in
     LogPrint("validation", "ConnectBlock nHeight=%d, hash=%s\n", pindex->nHeight, block.GetHash().ToString());
-    if (!CheckBlock(block, state, chainparams.GetConsensus(), !fJustCheck, !fJustCheck, pindex->nHeight, false, true)) {
+    if (!CheckBlock(block, state, chainparams.GetConsensus(), !fJustCheck, !fJustCheck, pindex->nHeight, fVerifyDB, true)) {
         LogPrintf("--> failed\n");
         return error("%s: Consensus::CheckBlock: %s", __func__, FormatStateMessage(state));
     }
@@ -2692,6 +2708,21 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     BatchProofContainer* batchProofContainer = BatchProofContainer::get_instance();
     batchProofContainer->fCollectProofs = ((GetSystemTimeInSeconds() - pindex->GetBlockTime()) > 86400) && GetBoolArg("-batching", true);
     batchProofContainer->init();
+    struct SparkBatchCleanup {
+        BatchProofContainer* batchProofContainer;
+        bool enabled;
+
+        ~SparkBatchCleanup()
+        {
+            if (enabled)
+                batchProofContainer->clear();
+        }
+
+        void dismiss()
+        {
+            enabled = false;
+        }
+    } sparkBatchCleanup{batchProofContainer, batchProofContainer->fCollectProofs};
     std::size_t nSigma = 0;
     std::size_t nLelantus = 0;
 
@@ -2763,7 +2794,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                 return state.DoS(100, false, REJECT_INVALID, "bad-txns-fee-outofrange");
 
             // Check transaction against signa/lelantus state
-            if (!CheckTransaction(tx, state, false, txHash, false, pindex->nHeight, false, true, block.sparkTxInfo.get(), true))
+            if (!CheckTransaction(tx, state, false, txHash, fVerifyDB, pindex->nHeight, false, true, block.sparkTxInfo.get(), true, nullptr, sparkValidationContext))
                 return state.DoS(100, error("stateful zerocoin check failed"),
                                  REJECT_INVALID, "bad-txns-zerocoin");
         }
@@ -2816,6 +2847,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         try {
             batchProofContainer->finalize();
             batchProofContainer->verify();
+            sparkBatchCleanup.dismiss();
         }
         catch (const std::exception& e) {
             batchProofContainer->clear();
@@ -2919,13 +2951,20 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         }
     }
 
-    if (!spark::ConnectBlockSpark(state, chainparams, pindex, &block, fJustCheck))
+    if (!spark::ConnectBlockSpark(state, chainparams, pindex, &block, fJustCheck, fVerifyDB, sparkValidationContext))
         return false;
 
     if (!sporkManager->IsBlockAllowed(block, pindex, state))
         return false;
 
     if (fJustCheck) {
+        // VerifyDB reconnects multiple blocks into a temporary view. The coins
+        // are already updated above, so the view's best-block marker must move
+        // with them even though no indexes or undo data are written.
+        view.SetBestBlock(block.GetHash());
+        if (fVerifyDB)
+            evoDb->WriteBestBlock(block.GetHash());
+
         // roll back spork set if needed
         pindex->activeDisablingSporks = sporkSetBackup;
         return true;
@@ -3100,6 +3139,8 @@ bool static FlushStateToDisk(CValidationState &state, FlushStateMode mode, int n
     bool fPeriodicFlush = mode == FLUSH_STATE_PERIODIC && nNow > nLastFlush + (int64_t)DATABASE_FLUSH_INTERVAL * 1000000;
     // Combine all conditions that result in a full cache flush.
     bool fDoFullFlush = (mode == FLUSH_STATE_ALWAYS) || fCacheLarge || fCacheCritical || fPeriodicFlush || fFlushForPrune;
+    if ((fDoFullFlush || fPeriodicWrite) && !VerifyPendingSparkBatch(state, "flushing block index or chainstate"))
+        return false;
     // Write blocks and block index to disk.
     if (fDoFullFlush || fPeriodicWrite) {
         // Depend on nMinDiskSpace to ensure we can write block index
@@ -3810,11 +3851,10 @@ bool ActivateBestChain(CValidationState &state, const CChainParams& chainparams,
                 for (unsigned int i = 0; i < block.vtx.size(); i++)
                     GetMainSignals().SyncTransaction(*block.vtx[i], pair.first, i);
             }
+
+            if (!VerifyPendingSparkBatch(state, "activating best chain"))
+                return false;
         }
-        // Do batch verification if we reach 1 day old block,
-        BatchProofContainer* batchProofContainer = BatchProofContainer::get_instance();
-        batchProofContainer->fCollectProofs = ((GetSystemTimeInSeconds() - pindexNewTip->GetBlockTime()) > 86400) && GetBoolArg("-batching", true);
-        batchProofContainer->verify();
 
         // When we reach this point, we switched to a new tip (stored in pindexNewTip).
 
@@ -4660,9 +4700,11 @@ static bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidation
     }
     if (fNewBlock) *fNewBlock = true;
 
-    // During import/reindex, defer Spark spend proof verification to the
-    // stateful ConnectBlock check that runs before chain state is updated.
-    const bool fDeferSparkSpendProofVerification = dbp != NULL;
+    // During linear import/reindex, defer Spark spend proof verification to the
+    // stateful ConnectBlock check that runs immediately before chain state is
+    // updated. Do not defer side-chain or out-of-order imported blocks: they can
+    // remain stored without being connected, so AcceptBlock must verify them.
+    const bool fDeferSparkSpendProofVerification = dbp != NULL && pindex->pprev == chainActive.Tip();
     if (!CheckBlock(block, state, chainparams.GetConsensus(), true, true, pindex->nHeight, false, fDeferSparkSpendProofVerification) ||
         !ContextualCheckBlock(block, state, chainparams.GetConsensus(), pindex->pprev)) {
         if (state.IsInvalid() && !state.CorruptionPossible()) {
@@ -5194,6 +5236,22 @@ bool CVerifyDB::VerifyDB(const CChainParams& chainparams, CCoinsView *coinsview,
 
     // check level 4: try reconnecting blocks
     if (nCheckLevel >= 4) {
+        spark::CSparkState verifyDBSparkState(
+                ZC_SPARK_MAX_MINT_NUM,
+                ZC_SPARK_SET_START_SIZE,
+                false);
+        CSparkNameManager verifyDBSparkNameManager;
+        spark::CSparkValidationContext verifyDBSparkContext(
+                &verifyDBSparkState,
+                &verifyDBSparkNameManager);
+
+        for (CBlockIndex* pindex = chainActive.Genesis(); pindex; pindex = chainActive.Next(pindex)) {
+            verifyDBSparkState.AddBlock(pindex);
+            verifyDBSparkNameManager.AddBlock(pindex, false, false);
+            if (pindex == pindexState)
+                break;
+        }
+
         CBlockIndex *pindex = pindexState;
         while (pindex != chainActive.Tip()) {
             boost::this_thread::interruption_point();
@@ -5202,7 +5260,7 @@ bool CVerifyDB::VerifyDB(const CChainParams& chainparams, CCoinsView *coinsview,
             CBlock block;
             if (!ReadBlockFromDisk(block, pindex, chainparams.GetConsensus()))
                 return error("VerifyDB(): *** ReadBlockFromDisk failed at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
-            if (!ConnectBlock(block, state, pindex, coins, chainparams))
+            if (!ConnectBlock(block, state, pindex, coins, chainparams, true, true, &verifyDBSparkContext))
                 return error("VerifyDB(): *** found unconnectable block at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
         }
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4218,9 +4218,11 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
 
     // Only callers that immediately run stateful Spark checks may defer this expensive proof.
     const bool fVerifySparkSpendProof = isVerifyDB || !fDeferSparkSpendProofVerification;
-    // CheckBlock passes no Spark tx info, so non-deferred proof checks complete
-    // synchronously here; deferred import blocks are deliberately not cached.
+    // CheckBlock passes no Spark tx info. Spark spend blocks are not cached here:
+    // non-stateful Spark checks can soft-pass on missing historical proof inputs,
+    // and ConnectBlock performs the final stateful validation before state updates.
     bool fSparkSpendProofsComplete = true;
+    bool fContainsSparkSpend = false;
     for (CTransactionRef tx : block.vtx) {
         spark::SparkSpendProofVerificationResult sparkSpendProofResult = spark::SparkSpendProofVerificationResult::NotApplicable;
 
@@ -4229,9 +4231,11 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
             return state.Invalid(false, state.GetRejectCode(), state.GetRejectReason(),
                                 strprintf("Transaction check failed (tx hash %s) %s", tx->GetHash().ToString(), state.GetDebugMessage()));
 
-        if (tx->IsSparkSpend())
+        if (tx->IsSparkSpend()) {
+            fContainsSparkSpend = true;
             fSparkSpendProofsComplete = fSparkSpendProofsComplete &&
                     sparkSpendProofResult == spark::SparkSpendProofVerificationResult::Verified;
+        }
 
     }
     unsigned int nSigOps = 0;
@@ -4245,7 +4249,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
     if (!spark::CheckSparkBlock(state, block, nHeight))
         return false;
 
-    if (fCheckPOW && fCheckMerkleRoot && fSparkSpendProofsComplete)
+    if (fCheckPOW && fCheckMerkleRoot && fSparkSpendProofsComplete && !fContainsSparkSpend)
         block.fChecked = true;
 
     return true;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4225,7 +4225,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
     if (!spark::CheckSparkBlock(state, block, nHeight))
         return false;
 
-    if (fCheckPOW && fCheckMerkleRoot && fVerifySparkSpendProof && !fHasSparkSpend)
+    if (fCheckPOW && fCheckMerkleRoot && (!fHasSparkSpend || fVerifySparkSpendProof))
         block.fChecked = true;
 
     return true;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -575,7 +575,7 @@ int GetUTXOConfirmations(const COutPoint& outpoint)
 
 bool CheckTransaction(const CTransaction &tx, CValidationState &state, bool fCheckDuplicateInputs, uint256 hashTx,  bool isVerifyDB, int nHeight, bool isCheckWallet, bool fStatefulZerocoinCheck, spark::CSparkTxInfo* sparkTxInfo)
 {
-    LogPrintf("CheckTransaction nHeight=%d, isVerifyDB=%d, isCheckWallet=%d, txHash=%s\n", nHeight, (int)isVerifyDB, (int)isCheckWallet, tx.GetHash().ToString());
+    LogPrint("validation", "CheckTransaction nHeight=%d, isVerifyDB=%d, isCheckWallet=%d, txHash=%s\n", nHeight, (int)isVerifyDB, (int)isCheckWallet, tx.GetHash().ToString());
 
     bool allowEmptyTxInOut = false;
     if (tx.nType == TRANSACTION_QUORUM_COMMITMENT) {
@@ -2511,7 +2511,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     int64_t nTimeStart = GetTimeMicros();
     //btzc: update nHeight, isVerifyDB
     // Check it again in case a previous version let a bad block in
-    LogPrintf("ConnectBlock nHeight=%d, hash=%s\n", pindex->nHeight, block.GetHash().ToString());
+    LogPrint("validation", "ConnectBlock nHeight=%d, hash=%s\n", pindex->nHeight, block.GetHash().ToString());
     if (!CheckBlock(block, state, chainparams.GetConsensus(), !fJustCheck, !fJustCheck, pindex->nHeight, false)) {
         LogPrintf("--> failed\n");
         return error("%s: Consensus::CheckBlock: %s", __func__, FormatStateMessage(state));
@@ -3155,7 +3155,7 @@ void PruneAndFlush() {
 
 /** Update chainActive and related internal data structures. */
 void static UpdateTip(CBlockIndex *pindexNew, const CChainParams &chainParams) {
-    LogPrintf("UpdateTip() pindexNew.nHeight=%d\n", pindexNew->nHeight);
+    LogPrint("validation", "UpdateTip() pindexNew.nHeight=%d\n", pindexNew->nHeight);
     chainActive.SetTip(pindexNew);
 
     // New best block
@@ -3364,7 +3364,7 @@ struct ConnectTrace {
  */
 bool static ConnectTip(CValidationState& state, const CChainParams& chainparams, CBlockIndex* pindexNew, const std::shared_ptr<const CBlock>& pblock, ConnectTrace& connectTrace)
 {
-    LogPrintf("ConnectTip() nHeight=%d\n", pindexNew->nHeight);
+    LogPrint("validation", "ConnectTip() nHeight=%d\n", pindexNew->nHeight);
     assert(pindexNew->pprev == chainActive.Tip());
     // Read block from disk.
     int64_t nTime1 = GetTimeMicros();
@@ -3606,7 +3606,7 @@ static void PruneBlockIndexCandidates() {
  */
 static bool ActivateBestChainStep(CValidationState& state, const CChainParams& chainparams, CBlockIndex* pindexMostWork, const std::shared_ptr<const CBlock>& pblock, bool& fInvalidFound, ConnectTrace& connectTrace)
 {
-    LogPrintf("ActivateBestChainStep()\n");
+    LogPrint("validation", "ActivateBestChainStep()\n");
     AssertLockHeld(cs_main);
     const CBlockIndex *pindexOldTip = chainActive.Tip();
     const CBlockIndex *pindexFork = chainActive.FindFork(pindexMostWork);
@@ -4198,7 +4198,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
     // Check transactions (when called from ProcessNewBlock, nHeight is INT_MAX and we derive it here)
     if (nHeight == INT_MAX)
         nHeight = GetNHeight(block.GetBlockHeader());
-    LogPrintf("CheckBlock() nHeight=%d, blockHash=%s, isVerifyDB=%d\n", nHeight, block.GetHash().ToString(), isVerifyDB);
+    LogPrint("validation", "CheckBlock() nHeight=%d, blockHash=%s, isVerifyDB=%d\n", nHeight, block.GetHash().ToString(), isVerifyDB);
 
     for (CTransactionRef tx : block.vtx) {
         // We don't check transactions against sigma/lelantus state here, we'll check it again later in ConnectBlock
@@ -4601,7 +4601,7 @@ static bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidation
     if (!AcceptBlockHeader(block, state, chainparams, &pindex))
         return false;
 
-    LogPrintf("AcceptBlock nHeight=%d\n", pindex->nHeight);
+    LogPrint("validation", "AcceptBlock nHeight=%d\n", pindex->nHeight);
     // Try to process all requested blocks that we don't have, but only
     // process an unrequested block if it's new and has enough work to
     // advance our tip, and isn't too many blocks ahead.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4297,7 +4297,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
 
 bool CanDeferSparkSpendProofVerificationOnImport(const CDiskBlockPos* dbp, const CBlockIndex* pindexPrev, const CBlockIndex* activeTip, bool fAllowSparkSpendProofDeferral, bool fShutdownRequested)
 {
-    return fAllowSparkSpendProofDeferral && !fShutdownRequested && dbp != nullptr && pindexPrev != nullptr && pindexPrev == activeTip;
+    return fAllowSparkSpendProofDeferral && !fShutdownRequested && dbp != nullptr && pindexPrev != nullptr;
 }
 
 static bool CheckIndexAgainstCheckpoint(const CBlockIndex* pindexPrev, CValidationState& state, const CChainParams& chainparams, const uint256& hash)
@@ -4705,12 +4705,13 @@ static bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidation
     }
     if (fNewBlock) *fNewBlock = true;
 
-    // During linear import/reindex, defer Spark spend proof verification to the
-    // stateful ConnectBlock check that runs immediately before chain state is
-    // updated. Do not defer side-chain or out-of-order imported blocks: they can
-    // remain stored without being connected, so AcceptBlock must verify them.
-    // Also do not defer during shutdown: ActivateBestChain can exit without
-    // connecting the just-accepted block.
+    // During raw block-file import/reindex, defer Spark spend proof verification
+    // to the stateful ConnectBlock check that runs immediately before chain
+    // state is updated. Imported side-chain or out-of-order blocks can reference
+    // Spark cover-set state that is not active yet; CheckBlock never caches
+    // Spark-spend blocks as fully checked, so they are verified if later
+    // connected. Do not defer during shutdown: ActivateBestChain can exit
+    // without connecting the just-accepted block.
     const bool fDeferSparkSpendProofVerification = CanDeferSparkSpendProofVerificationOnImport(
             dbp, pindex->pprev, chainActive.Tip(), fAllowSparkSpendProofDeferral, ShutdownRequested());
     if (!CheckBlock(block, state, chainparams.GetConsensus(), true, true, pindex->nHeight, false, fDeferSparkSpendProofVerification) ||
@@ -5550,7 +5551,7 @@ bool LoadExternalBlockFile(const CChainParams& chainparams, FILE* fileIn, CDiskB
                                     head.ToString());
                             LOCK(cs_main);
                             CValidationState dummy;
-                            if (AcceptBlock(pblockrecursive, dummy, chainparams, NULL, true, &it->second, NULL, false))
+                            if (AcceptBlock(pblockrecursive, dummy, chainparams, NULL, true, &it->second, NULL))
                             {
                                 nLoaded++;
                                 queue.push_back(pblockrecursive->GetHash());

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5161,6 +5161,10 @@ bool CVerifyDB::VerifyDB(const CChainParams& chainparams, CCoinsView *coinsview,
     if (chainActive.Tip() == NULL || chainActive.Tip()->pprev == NULL)
         return true;
 
+    // VerifyDB mutates EvoDB through a rollback-only transaction. Keep
+    // deterministic MN cache mutations scoped to the same speculative check.
+    CDeterministicMNManager::ScopedCacheRestorer dmnCacheRestorer(*deterministicMNManager);
+
     // begin tx and let it rollback
     auto dbTx = evoDb->BeginTransaction();
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2806,6 +2806,21 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 
     block.sparkTxInfo->Complete();
 
+    // Batched Spark proofs must finish before any persistent block, index, or
+    // Spark state is updated below.
+    if (batchProofContainer->fCollectProofs) {
+        try {
+            batchProofContainer->finalize();
+            batchProofContainer->verify();
+        }
+        catch (const std::exception& e) {
+            batchProofContainer->clear();
+            return state.DoS(100,
+                             error("ConnectBlock(): Spark batch verification failed: %s", e.what()),
+                             REJECT_INVALID, "bad-txns-sparkproof");
+        }
+    }
+
     int64_t nTime3 = GetTimeMicros(); nTimeConnect += nTime3 - nTime2;
     LogPrint("bench", "      - Connect %u transactions: %.2fms (%.3fms/tx, %.3fms/txin) [%.2fs]\n", (unsigned)block.vtx.size(), 0.001 * (nTime3 - nTime2), 0.001 * (nTime3 - nTime2) / block.vtx.size(), nInputs <= 1 ? 0 : 0.001 * (nTime3 - nTime2) / (nInputs-1), nTimeConnect * 0.000001);
 
@@ -2955,9 +2970,6 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 
     // add this block to the view's block chain
     view.SetBestBlock(pindex->GetBlockHash());
-
-    // do batch verification if remains a day or collect proofs
-    batchProofContainer->finalize();
 
     int64_t nTime5 = GetTimeMicros(); nTimeIndex += nTime5 - nTime4;
     LogPrint("bench", "    - Index writing: %.2fms [%.2fs]\n", 0.001 * (nTime5 - nTime4), nTimeIndex * 0.000001);
@@ -4203,10 +4215,12 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
     // Only callers that immediately run stateful Spark checks may defer this expensive proof.
     // VerifyDB keeps its explicit proof-verification request.
     const bool fVerifySparkSpendProof = isVerifyDB || !fDeferSparkSpendProofVerification;
-    bool fHasSparkSpend = false;
+    // CheckBlock passes no Spark tx info, so verified Spark spend proofs complete
+    // synchronously here; deferred import blocks are deliberately not cached.
+    bool fSparkSpendProofsComplete = true;
     for (CTransactionRef tx : block.vtx) {
         if (tx->IsSparkSpend())
-            fHasSparkSpend = true;
+            fSparkSpendProofsComplete = fSparkSpendProofsComplete && fVerifySparkSpendProof;
 
         // We don't check transactions against sigma/lelantus state here, we'll check it again later in ConnectBlock
         if (!CheckTransaction(*tx, state, false, tx->GetHash(), isVerifyDB, nHeight, false, false, NULL, fVerifySparkSpendProof))
@@ -4225,7 +4239,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
     if (!spark::CheckSparkBlock(state, block, nHeight))
         return false;
 
-    if (fCheckPOW && fCheckMerkleRoot && (!fHasSparkSpend || fVerifySparkSpendProof))
+    if (fCheckPOW && fCheckMerkleRoot && fSparkSpendProofsComplete)
         block.fChecked = true;
 
     return true;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -573,7 +573,7 @@ int GetUTXOConfirmations(const COutPoint& outpoint)
     return (nPrevoutHeight > -1 && chainActive.Tip()) ? chainActive.Height() - nPrevoutHeight + 1 : -1;
 }
 
-bool CheckTransaction(const CTransaction &tx, CValidationState &state, bool fCheckDuplicateInputs, uint256 hashTx,  bool isVerifyDB, int nHeight, bool isCheckWallet, bool fStatefulZerocoinCheck, spark::CSparkTxInfo* sparkTxInfo)
+bool CheckTransaction(const CTransaction &tx, CValidationState &state, bool fCheckDuplicateInputs, uint256 hashTx,  bool isVerifyDB, int nHeight, bool isCheckWallet, bool fStatefulZerocoinCheck, spark::CSparkTxInfo* sparkTxInfo, bool fVerifySparkSpendProof)
 {
     LogPrint("validation", "CheckTransaction nHeight=%d, isVerifyDB=%d, isCheckWallet=%d, txHash=%s\n", nHeight, (int)isVerifyDB, (int)isCheckWallet, tx.GetHash().ToString());
 
@@ -699,7 +699,7 @@ bool CheckTransaction(const CTransaction &tx, CValidationState &state, bool fChe
         if (tx.IsSparkTransaction()) {
             if (hasExchangeUTXOs)
                 return state.DoS(100, false, REJECT_INVALID, "bad-exchange-address");
-            if (!CheckSparkTransaction(tx, state, hashTx, isVerifyDB, nHeight, isCheckWallet, fStatefulZerocoinCheck, sparkTxInfo))
+            if (!CheckSparkTransaction(tx, state, hashTx, isVerifyDB, nHeight, isCheckWallet, fStatefulZerocoinCheck, sparkTxInfo, fVerifySparkSpendProof))
                 return false;
         }
 
@@ -2512,7 +2512,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     //btzc: update nHeight, isVerifyDB
     // Check it again in case a previous version let a bad block in
     LogPrint("validation", "ConnectBlock nHeight=%d, hash=%s\n", pindex->nHeight, block.GetHash().ToString());
-    if (!CheckBlock(block, state, chainparams.GetConsensus(), !fJustCheck, !fJustCheck, pindex->nHeight, false)) {
+    if (!CheckBlock(block, state, chainparams.GetConsensus(), !fJustCheck, !fJustCheck, pindex->nHeight, false, true)) {
         LogPrintf("--> failed\n");
         return error("%s: Consensus::CheckBlock: %s", __func__, FormatStateMessage(state));
     }
@@ -4142,7 +4142,7 @@ bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, const 
     return true;
 }
 
-bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW, bool fCheckMerkleRoot, int nHeight, bool isVerifyDB) {
+bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW, bool fCheckMerkleRoot, int nHeight, bool isVerifyDB, bool fDeferSparkSpendProofVerification) {
     // CheckBlock not only checks the block, but also fills up sparkTxInfo.
     if (!block.sparkTxInfo)
         block.sparkTxInfo = std::make_shared<spark::CSparkTxInfo>();
@@ -4200,9 +4200,16 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
         nHeight = GetNHeight(block.GetBlockHeader());
     LogPrint("validation", "CheckBlock() nHeight=%d, blockHash=%s, isVerifyDB=%d\n", nHeight, block.GetHash().ToString(), isVerifyDB);
 
+    // Only callers that immediately run stateful Spark checks may defer this expensive proof.
+    // VerifyDB keeps its explicit proof-verification request.
+    const bool fVerifySparkSpendProof = isVerifyDB || !fDeferSparkSpendProofVerification;
+    bool fHasSparkSpend = false;
     for (CTransactionRef tx : block.vtx) {
+        if (tx->IsSparkSpend())
+            fHasSparkSpend = true;
+
         // We don't check transactions against sigma/lelantus state here, we'll check it again later in ConnectBlock
-        if (!CheckTransaction(*tx, state, false, tx->GetHash(), isVerifyDB, nHeight, false, false, NULL))
+        if (!CheckTransaction(*tx, state, false, tx->GetHash(), isVerifyDB, nHeight, false, false, NULL, fVerifySparkSpendProof))
             return state.Invalid(false, state.GetRejectCode(), state.GetRejectReason(),
                                 strprintf("Transaction check failed (tx hash %s) %s", tx->GetHash().ToString(), state.GetDebugMessage()));
 
@@ -4218,7 +4225,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
     if (!spark::CheckSparkBlock(state, block, nHeight))
         return false;
 
-    if (fCheckPOW && fCheckMerkleRoot)
+    if (fCheckPOW && fCheckMerkleRoot && fVerifySparkSpendProof && !fHasSparkSpend)
         block.fChecked = true;
 
     return true;
@@ -4629,7 +4636,7 @@ static bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidation
     }
     if (fNewBlock) *fNewBlock = true;
 
-    if (!CheckBlock(block, state, chainparams.GetConsensus(), true, true, pindex->nHeight, false) ||
+    if (!CheckBlock(block, state, chainparams.GetConsensus(), true, true, pindex->nHeight, false, false) ||
         !ContextualCheckBlock(block, state, chainparams.GetConsensus(), pindex->pprev)) {
         if (state.IsInvalid() && !state.CorruptionPossible()) {
             pindex->nStatus |= BLOCK_FAILED_VALID;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2759,7 +2759,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                 return state.DoS(100, false, REJECT_INVALID, "bad-txns-fee-outofrange");
 
             // Check transaction against signa/lelantus state
-            if (!CheckTransaction(tx, state, false, txHash, false, pindex->nHeight, false, true, block.sparkTxInfo.get()))
+            if (!CheckTransaction(tx, state, false, txHash, false, pindex->nHeight, false, true, block.sparkTxInfo.get(), true))
                 return state.DoS(100, error("stateful zerocoin check failed"),
                                  REJECT_INVALID, "bad-txns-zerocoin");
         }
@@ -4636,7 +4636,10 @@ static bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidation
     }
     if (fNewBlock) *fNewBlock = true;
 
-    if (!CheckBlock(block, state, chainparams.GetConsensus(), true, true, pindex->nHeight, false, false) ||
+    // During import/reindex, defer Spark spend proof verification to the
+    // stateful ConnectBlock check that runs before chain state is updated.
+    const bool fDeferSparkSpendProofVerification = dbp != NULL;
+    if (!CheckBlock(block, state, chainparams.GetConsensus(), true, true, pindex->nHeight, false, fDeferSparkSpendProofVerification) ||
         !ContextualCheckBlock(block, state, chainparams.GetConsensus(), pindex->pprev)) {
         if (state.IsInvalid() && !state.CorruptionPossible()) {
             pindex->nStatus |= BLOCK_FAILED_VALID;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -30,6 +30,7 @@
 #include "script/script.h"
 #include "script/sigcache.h"
 #include "script/standard.h"
+#include "spark/state.h"
 #include "timedata.h"
 #include "tinyformat.h"
 #include "txdb.h"
@@ -573,8 +574,11 @@ int GetUTXOConfirmations(const COutPoint& outpoint)
     return (nPrevoutHeight > -1 && chainActive.Tip()) ? chainActive.Height() - nPrevoutHeight + 1 : -1;
 }
 
-bool CheckTransaction(const CTransaction &tx, CValidationState &state, bool fCheckDuplicateInputs, uint256 hashTx,  bool isVerifyDB, int nHeight, bool isCheckWallet, bool fStatefulZerocoinCheck, spark::CSparkTxInfo* sparkTxInfo, bool fVerifySparkSpendProof)
+bool CheckTransaction(const CTransaction &tx, CValidationState &state, bool fCheckDuplicateInputs, uint256 hashTx,  bool isVerifyDB, int nHeight, bool isCheckWallet, bool fStatefulZerocoinCheck, spark::CSparkTxInfo* sparkTxInfo, bool fVerifySparkSpendProof, spark::SparkSpendProofVerificationResult* sparkSpendProofResult)
 {
+    if (sparkSpendProofResult)
+        *sparkSpendProofResult = spark::SparkSpendProofVerificationResult::NotApplicable;
+
     LogPrint("validation", "CheckTransaction nHeight=%d, isVerifyDB=%d, isCheckWallet=%d, txHash=%s\n", nHeight, (int)isVerifyDB, (int)isCheckWallet, tx.GetHash().ToString());
 
     bool allowEmptyTxInOut = false;
@@ -699,7 +703,7 @@ bool CheckTransaction(const CTransaction &tx, CValidationState &state, bool fChe
         if (tx.IsSparkTransaction()) {
             if (hasExchangeUTXOs)
                 return state.DoS(100, false, REJECT_INVALID, "bad-exchange-address");
-            if (!CheckSparkTransaction(tx, state, hashTx, isVerifyDB, nHeight, isCheckWallet, fStatefulZerocoinCheck, sparkTxInfo, fVerifySparkSpendProof))
+            if (!CheckSparkTransaction(tx, state, hashTx, isVerifyDB, nHeight, isCheckWallet, fStatefulZerocoinCheck, sparkTxInfo, fVerifySparkSpendProof, sparkSpendProofResult))
                 return false;
         }
 
@@ -4213,19 +4217,21 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
     LogPrint("validation", "CheckBlock() nHeight=%d, blockHash=%s, isVerifyDB=%d\n", nHeight, block.GetHash().ToString(), isVerifyDB);
 
     // Only callers that immediately run stateful Spark checks may defer this expensive proof.
-    // VerifyDB keeps its explicit proof-verification request.
     const bool fVerifySparkSpendProof = isVerifyDB || !fDeferSparkSpendProofVerification;
-    // CheckBlock passes no Spark tx info, so verified Spark spend proofs complete
+    // CheckBlock passes no Spark tx info, so non-deferred proof checks complete
     // synchronously here; deferred import blocks are deliberately not cached.
     bool fSparkSpendProofsComplete = true;
     for (CTransactionRef tx : block.vtx) {
-        if (tx->IsSparkSpend())
-            fSparkSpendProofsComplete = fSparkSpendProofsComplete && fVerifySparkSpendProof;
+        spark::SparkSpendProofVerificationResult sparkSpendProofResult = spark::SparkSpendProofVerificationResult::NotApplicable;
 
         // We don't check transactions against sigma/lelantus state here, we'll check it again later in ConnectBlock
-        if (!CheckTransaction(*tx, state, false, tx->GetHash(), isVerifyDB, nHeight, false, false, NULL, fVerifySparkSpendProof))
+        if (!CheckTransaction(*tx, state, false, tx->GetHash(), isVerifyDB, nHeight, false, false, NULL, fVerifySparkSpendProof, &sparkSpendProofResult))
             return state.Invalid(false, state.GetRejectCode(), state.GetRejectReason(),
                                 strprintf("Transaction check failed (tx hash %s) %s", tx->GetHash().ToString(), state.GetDebugMessage()));
+
+        if (tx->IsSparkSpend())
+            fSparkSpendProofsComplete = fSparkSpendProofsComplete &&
+                    sparkSpendProofResult == spark::SparkSpendProofVerificationResult::Verified;
 
     }
     unsigned int nSigOps = 0;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -31,6 +31,7 @@
 #include "script/sigcache.h"
 #include "script/standard.h"
 #include "spark/state.h"
+#include <secp256k1/include/MultiExponent.h>
 #include "timedata.h"
 #include "tinyformat.h"
 #include "txdb.h"
@@ -2849,6 +2850,10 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
             batchProofContainer->verify();
             sparkBatchCleanup.dismiss();
         }
+        catch (const secp_primitives::MultiExponentRuntimeError& e) {
+            batchProofContainer->clear();
+            return state.Error(strprintf("ConnectBlock(): Spark batch verification runtime failure: %s", e.what()));
+        }
         catch (const std::exception& e) {
             batchProofContainer->clear();
             return state.DoS(100,
@@ -4295,9 +4300,15 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
     return true;
 }
 
+bool CanDeferSparkSpendProofVerificationBeforeConnect(const CBlockIndex* pindexPrev, bool fAllowSparkSpendProofDeferral, bool fShutdownRequested)
+{
+    return fAllowSparkSpendProofDeferral && !fShutdownRequested && pindexPrev != nullptr;
+}
+
 bool CanDeferSparkSpendProofVerificationOnImport(const CDiskBlockPos* dbp, const CBlockIndex* pindexPrev, const CBlockIndex* activeTip, bool fAllowSparkSpendProofDeferral, bool fShutdownRequested)
 {
-    return fAllowSparkSpendProofDeferral && !fShutdownRequested && dbp != nullptr && pindexPrev != nullptr;
+    return dbp != nullptr && CanDeferSparkSpendProofVerificationBeforeConnect(
+            pindexPrev, fAllowSparkSpendProofDeferral, fShutdownRequested);
 }
 
 static bool CheckIndexAgainstCheckpoint(const CBlockIndex* pindexPrev, CValidationState& state, const CChainParams& chainparams, const uint256& hash)
@@ -4705,15 +4716,14 @@ static bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidation
     }
     if (fNewBlock) *fNewBlock = true;
 
-    // During raw block-file import/reindex, defer Spark spend proof verification
-    // to the stateful ConnectBlock check that runs immediately before chain
-    // state is updated. Imported side-chain or out-of-order blocks can reference
-    // Spark cover-set state that is not active yet; CheckBlock never caches
-    // Spark-spend blocks as fully checked, so they are verified if later
-    // connected. Do not defer during shutdown: ActivateBestChain can exit
-    // without connecting the just-accepted block.
-    const bool fDeferSparkSpendProofVerification = CanDeferSparkSpendProofVerificationOnImport(
-            dbp, pindex->pprev, chainActive.Tip(), fAllowSparkSpendProofDeferral, ShutdownRequested());
+    // Defer Spark spend proof verification to the stateful ConnectBlock check
+    // that runs immediately before chain state is updated. Side-chain and
+    // out-of-order blocks can reference cover-set state that is not active yet.
+    // CheckBlock never caches Spark-spend blocks as fully checked, so they are
+    // verified if later connected. Do not defer during shutdown: ActivateBestChain
+    // can exit without connecting the just-accepted block.
+    const bool fDeferSparkSpendProofVerification = CanDeferSparkSpendProofVerificationBeforeConnect(
+            pindex->pprev, fAllowSparkSpendProofDeferral, ShutdownRequested());
     if (!CheckBlock(block, state, chainparams.GetConsensus(), true, true, pindex->nHeight, false, fDeferSparkSpendProofVerification) ||
         !ContextualCheckBlock(block, state, chainparams.GetConsensus(), pindex->pprev)) {
         if (state.IsInvalid() && !state.CorruptionPossible()) {
@@ -4764,8 +4774,9 @@ bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<cons
         LOCK(cs_main);
 
         // Ensure that CheckBlock() passes before calling AcceptBlock, as
-        // belt-and-suspenders.
-        bool ret = CheckBlock(*pblock, state, chainparams.GetConsensus());
+        // belt-and-suspenders. Spark spend proofs are checked in AcceptBlock's
+        // stateful connect path, where side-chain cover-set state is available.
+        bool ret = CheckBlock(*pblock, state, chainparams.GetConsensus(), true, true, INT_MAX, false, !ShutdownRequested());
 
         if (ret) {
             // Store to disk

--- a/src/validation.h
+++ b/src/validation.h
@@ -52,6 +52,10 @@ struct ChainTxData;
 
 struct PrecomputedTransactionData;
 struct LockPoints;
+namespace spark {
+class CSparkTxInfo;
+enum class SparkSpendProofVerificationResult;
+} // namespace spark
 
 /** btzc: update Firo config */
 /** Default for DEFAULT_WHITELISTRELAY. */
@@ -418,7 +422,7 @@ void UpdateCoins(const CTransaction& tx, CCoinsViewCache& inputs, int nHeight);
 /** Transaction validation functions */
 
 /** Context-independent validity checks */
-bool CheckTransaction(const CTransaction& tx, CValidationState& state, bool fCheckDuplicateInputs, uint256 hashTx, bool isVerifyDB, int nHeight = INT_MAX, bool isCheckWallet = false, bool fStatefulZerocoinCheck = true, spark::CSparkTxInfo* sparkTxInfo = NULL, bool fVerifySparkSpendProof = true);
+bool CheckTransaction(const CTransaction& tx, CValidationState& state, bool fCheckDuplicateInputs, uint256 hashTx, bool isVerifyDB, int nHeight = INT_MAX, bool isCheckWallet = false, bool fStatefulZerocoinCheck = true, spark::CSparkTxInfo* sparkTxInfo = NULL, bool fVerifySparkSpendProof = true, spark::SparkSpendProofVerificationResult* sparkSpendProofResult = NULL);
 
 namespace Consensus {
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -307,6 +307,8 @@ bool IsInitialBlockDownload();
 bool GetTransaction(const uint256 &hash, CTransactionRef &tx, const Consensus::Params& params, uint256 &hashBlock, bool fAllowSlow = false);
 /** Find the best known block, and make it the tip of the block chain */
 bool ActivateBestChain(CValidationState& state, const CChainParams& chainparams, std::shared_ptr<const CBlock> pblock = std::shared_ptr<const CBlock>());
+/** Verify any deferred Spark proof batch before persisting validation state. */
+bool VerifyPendingSparkBatch(CValidationState& state, const std::string& reason);
 CAmount GetBlockSubsidyWithMTPFlag(int nHeight, const Consensus::Params& consensusParams, bool fMTP, bool fShorterBlockDistance);
 CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams, int nTime = 1475020800);
 CAmount GetMasternodePayment(int nHeight, int nTime, CAmount blockValue);
@@ -422,7 +424,7 @@ void UpdateCoins(const CTransaction& tx, CCoinsViewCache& inputs, int nHeight);
 /** Transaction validation functions */
 
 /** Context-independent validity checks */
-bool CheckTransaction(const CTransaction& tx, CValidationState& state, bool fCheckDuplicateInputs, uint256 hashTx, bool isVerifyDB, int nHeight = INT_MAX, bool isCheckWallet = false, bool fStatefulZerocoinCheck = true, spark::CSparkTxInfo* sparkTxInfo = NULL, bool fVerifySparkSpendProof = true, spark::SparkSpendProofVerificationResult* sparkSpendProofResult = NULL);
+bool CheckTransaction(const CTransaction& tx, CValidationState& state, bool fCheckDuplicateInputs, uint256 hashTx, bool isVerifyDB, int nHeight = INT_MAX, bool isCheckWallet = false, bool fStatefulZerocoinCheck = true, spark::CSparkTxInfo* sparkTxInfo = NULL, bool fVerifySparkSpendProof = true, spark::SparkSpendProofVerificationResult* sparkSpendProofResult = NULL, spark::CSparkValidationContext* sparkValidationContext = NULL);
 
 namespace Consensus {
 
@@ -553,7 +555,7 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, const Co
  *  Validity checks that depend on the UTXO set are also done; ConnectBlock()
  *  can fail if those validity checks fail (among other reasons). */
 bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pindex, CCoinsViewCache& coins,
-                  const CChainParams& chainparams, bool fJustCheck = false);
+                  const CChainParams& chainparams, bool fJustCheck = false, bool fVerifyDB = false, spark::CSparkValidationContext* sparkValidationContext = NULL);
 
 /** Reprocess a number of blocks to try and get on the correct chain again **/
 bool DisconnectBlocks(int blocks);

--- a/src/validation.h
+++ b/src/validation.h
@@ -540,6 +540,7 @@ bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus
 /** Context-independent validity checks */
 bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true);
 bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true, bool fCheckMerkleRoot = true, int nHeight = INT_MAX, bool isVerifyDB = false, bool fDeferSparkSpendProofVerification = false);
+bool CanDeferSparkSpendProofVerificationOnImport(const CDiskBlockPos* dbp, const CBlockIndex* pindexPrev, const CBlockIndex* activeTip, bool fAllowSparkSpendProofDeferral, bool fShutdownRequested);
 
 bool IsTransactionInChain(const uint256& txId, int& nHeightTx, CTransactionRef & tx);
 bool IsTransactionInChain(const uint256& txId, int& nHeightTx);

--- a/src/validation.h
+++ b/src/validation.h
@@ -540,6 +540,7 @@ bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus
 /** Context-independent validity checks */
 bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true);
 bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true, bool fCheckMerkleRoot = true, int nHeight = INT_MAX, bool isVerifyDB = false, bool fDeferSparkSpendProofVerification = false);
+bool CanDeferSparkSpendProofVerificationBeforeConnect(const CBlockIndex* pindexPrev, bool fAllowSparkSpendProofDeferral, bool fShutdownRequested);
 bool CanDeferSparkSpendProofVerificationOnImport(const CDiskBlockPos* dbp, const CBlockIndex* pindexPrev, const CBlockIndex* activeTip, bool fAllowSparkSpendProofDeferral, bool fShutdownRequested);
 
 bool IsTransactionInChain(const uint256& txId, int& nHeightTx, CTransactionRef & tx);

--- a/src/validation.h
+++ b/src/validation.h
@@ -418,7 +418,7 @@ void UpdateCoins(const CTransaction& tx, CCoinsViewCache& inputs, int nHeight);
 /** Transaction validation functions */
 
 /** Context-independent validity checks */
-bool CheckTransaction(const CTransaction& tx, CValidationState& state, bool fCheckDuplicateInputs, uint256 hashTx, bool isVerifyDB, int nHeight = INT_MAX, bool isCheckWallet = false, bool fStatefulZerocoinCheck = true, spark::CSparkTxInfo* sparkTxInfo = NULL);
+bool CheckTransaction(const CTransaction& tx, CValidationState& state, bool fCheckDuplicateInputs, uint256 hashTx, bool isVerifyDB, int nHeight = INT_MAX, bool isCheckWallet = false, bool fStatefulZerocoinCheck = true, spark::CSparkTxInfo* sparkTxInfo = NULL, bool fVerifySparkSpendProof = true);
 
 namespace Consensus {
 
@@ -533,7 +533,7 @@ bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus
 
 /** Context-independent validity checks */
 bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true);
-bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true, bool fCheckMerkleRoot = true, int nHeight = INT_MAX, bool isVerifyDB = false);
+bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true, bool fCheckMerkleRoot = true, int nHeight = INT_MAX, bool isVerifyDB = false, bool fDeferSparkSpendProofVerification = false);
 
 bool IsTransactionInChain(const uint256& txId, int& nHeightTx, CTransactionRef & tx);
 bool IsTransactionInChain(const uint256& txId, int& nHeightTx);

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -433,7 +433,7 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             CWalletTx wtx;
             ssValue >> wtx;
             CValidationState state;
-            if (!(CheckTransaction(wtx, state, true, wtx.GetHash(), true, INT_MAX, false, false) && (wtx.GetHash() == hash) && state.IsValid()))
+            if (!(CheckTransaction(wtx, state, true, wtx.GetHash(), true, INT_MAX, false, false, NULL, false) && (wtx.GetHash() == hash) && state.IsValid()))
                 return false;
 
             // Undo serialize changes in 31600

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -433,7 +433,7 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             CWalletTx wtx;
             ssValue >> wtx;
             CValidationState state;
-            if (!(CheckTransaction(wtx, state, true, wtx.GetHash(), true, INT_MAX, false, false, NULL, false) && (wtx.GetHash() == hash) && state.IsValid()))
+            if (!(CheckTransaction(wtx, state, true, wtx.GetHash(), true, INT_MAX, true, false, NULL, false) && (wtx.GetHash() == hash) && state.IsValid()))
                 return false;
 
             // Undo serialize changes in 31600


### PR DESCRIPTION
Overall this PR should result in `-reindex` process 2x-3x faster. 

1. This PR speeds up early -reindex around the DIP3 deterministic masternode activation window by avoiding redundant cbTx masternode-list merkle-root work. During block connection, Firo already builds the deterministic masternode list and diff for the block; the patch reuses that freshly computed list for cbTx MN merkle validation, and skips rebuilding the simplified MN-list merkle root when a diff only changes fields that are not serialized into CSimplifiedMNListEntry. Consensus-relevant MN changes still force recomputation. 

2. For Spark-heavy reindex, this PR defers Spark spend proof verification during raw block import and batch-verifies proofs before validation state is persisted, while preserving fail-closed behavior. It also avoids rebuilding unnecessary full cover sets for Grootle batch checks, keeps proof-cache entries tied to exact proof inputs, verifies deferred batches before flush/shutdown/reindex completion, and gates high-volume Spark validation trace logs behind -debug=validation to reduce log I/O during reindex.


First part of this PR already evaluated/approved by @levonpetrosyan93  at https://github.com/firoorg/firo/pull/1864