### PR TITLE
Improve the performance of `firo-qt` on Mac when the UI is out of focus

### DIFF
--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -167,6 +167,8 @@ add_library(firoqt STATIC EXCLUDE_FROM_ALL
   $<$<PLATFORM_ID:Darwin>:${CMAKE_CURRENT_SOURCE_DIR}/macdockiconhandler.mm>
   $<$<PLATFORM_ID:Darwin>:${CMAKE_CURRENT_SOURCE_DIR}/macnotificationhandler.h>
   $<$<PLATFORM_ID:Darwin>:${CMAKE_CURRENT_SOURCE_DIR}/macnotificationhandler.mm>
+  $<$<PLATFORM_ID:Darwin>:${CMAKE_CURRENT_SOURCE_DIR}/macnapinhibitor.h>
+  $<$<PLATFORM_ID:Darwin>:${CMAKE_CURRENT_SOURCE_DIR}/macnapinhibitor.mm>
   $<$<BOOL:${WIN32}>:${CMAKE_CURRENT_SOURCE_DIR}/winshutdownmonitor.cpp>
   $<$<BOOL:${WIN32}>:${CMAKE_CURRENT_SOURCE_DIR}/winshutdownmonitor.h>
 )

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -22,6 +22,9 @@
 #include "utilitydialog.h"
 #include "winshutdownmonitor.h"
 #include "askpassphrasedialog.h"
+#ifdef Q_OS_MAC
+#include "macnapinhibitor.h"
+#endif
 #ifdef ENABLE_WALLET
 #include "paymentserver.h"
 #include "walletmodel.h"
@@ -755,6 +758,9 @@ int main(int argc, char *argv[])
 #endif
 #ifdef Q_OS_MAC
     QApplication::setAttribute(Qt::AA_DontShowIconsInMenus);
+    // Prevent macOS App Nap from throttling background threads (e.g. block
+    // reindex/resync) once the wallet window loses focus or is hidden.
+    MacNapInhibitor::disableAppNap();
 #endif
 
     BitcoinApplication app(argc, argv);
@@ -924,6 +930,9 @@ int main(int argc, char *argv[])
         PrintExceptionContinue(std::current_exception(), "Runaway exception");
         app.handleRunawayException(QString::fromStdString(GetWarnings("gui")));
     }
+#ifdef Q_OS_MAC
+    MacNapInhibitor::enableAppNap();
+#endif
     return app.getReturnValue();
 }
 #endif // BITCOIN_QT_TEST

--- a/src/qt/macnapinhibitor.h
+++ b/src/qt/macnapinhibitor.h
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 The Firo Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_MACNAPINHIBITOR_H
+#define BITCOIN_QT_MACNAPINHIBITOR_H
+
+/** Prevents macOS "App Nap" from throttling timers, threads and I/O of the
+ * process. Without this, App Nap can de-prioritize the app once its window
+ * loses focus or is not visible, which severely slows down blockchain
+ * reindexing/resyncing since those run mostly on background threads.
+ */
+class MacNapInhibitor
+{
+public:
+    /** Start suppressing App Nap. Safe to call multiple times. */
+    static void disableAppNap();
+    /** Stop suppressing App Nap. Safe to call even if never disabled. */
+    static void enableAppNap();
+};
+
+#endif // BITCOIN_QT_MACNAPINHIBITOR_H

--- a/src/qt/macnapinhibitor.mm
+++ b/src/qt/macnapinhibitor.mm
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 The Firo Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "macnapinhibitor.h"
+
+#undef slots
+#include <Cocoa/Cocoa.h>
+
+namespace {
+// Holds the activity token returned by NSProcessInfo while App Nap is
+// suppressed. nil when App Nap is not currently being inhibited.
+id<NSObject> g_napActivityToken = nil;
+} // namespace
+
+void MacNapInhibitor::disableAppNap()
+{
+    if (g_napActivityToken != nil) return;
+
+    // NSActivityUserInitiatedAllowingIdleSystemSleep tells the OS this
+    // process is doing user-relevant work and should not be throttled by
+    // App Nap, while still allowing the system to idle-sleep on its own
+    // (unlike plain NSActivityUserInitiated, which also asserts
+    // PreventUserIdleSystemSleep).
+    g_napActivityToken = [[NSProcessInfo processInfo]
+        beginActivityWithOptions:NSActivityUserInitiatedAllowingIdleSystemSleep
+                           reason:@"Synchronizing with the Firo network"];
+    [g_napActivityToken retain];
+}
+
+void MacNapInhibitor::enableAppNap()
+{
+    if (g_napActivityToken == nil) return;
+
+    [[NSProcessInfo processInfo] endActivity:g_napActivityToken];
+    [g_napActivityToken release];
+    g_napActivityToken = nil;
+}


### PR DESCRIPTION
## PR intention
When main window is out of focus on Mac the OS prioritises the performance of the application. This PR prevents that.

## Code changes brief
Additional code in `src/qt/macnapinhibitor.h/ .mm` prevents nap from happening