### PR TITLE
Fix Spark spend key derivation buffer reuse

### DIFF
--- a/src/libspark/keys.cpp
+++ b/src/libspark/keys.cpp
@@ -3,6 +3,8 @@
 #include "../support/cleanse.h"
 #include "transcript.h"
 
+#include <array>
+
 namespace spark {
 
 using namespace secp_primitives;
@@ -17,28 +19,22 @@ SpendKey::SpendKey(const Params* params) {
 SpendKey::SpendKey(const Params* params, const Scalar& r_) {
     this->params = params;
     this->r = r_;
-    std::vector<unsigned char> data;
-    data.resize(32);
+    std::array<unsigned char, Scalar::memoryRequired()> data;
     r.serialize(data.data());
-    std::vector<unsigned char> result(CSHA256().OUTPUT_SIZE);
+    std::array<unsigned char, CHash256::OUTPUT_SIZE> result;
 
     CHash256 hash256;
     std::string prefix1 = "s1_generation";
     hash256.Write(reinterpret_cast<const unsigned char*>(prefix1.c_str()), prefix1.size());
     hash256.Write(data.data(), data.size());
-    hash256.Finalize(&result[0]);
-    this->s1.memberFromSeed(&result[0]);
-
-    data.clear();
-    result.clear();
-    hash256.Reset();
-    s1.serialize(data.data());
+    hash256.Finalize(result.data());
+    this->s1.memberFromSeed(result.data());
 
     std::string prefix2 = "s2_generation";
+    hash256.Reset();
     hash256.Write(reinterpret_cast<const unsigned char*>(prefix2.c_str()), prefix2.size());
-    hash256.Write(data.data(), data.size());
-    hash256.Finalize(&result[0]);
-    this->s2.memberFromSeed(&result[0]);
+    hash256.Finalize(result.data());
+    this->s2.memberFromSeed(result.data());
 }
 
 const Params* SpendKey::get_params() const {

--- a/src/libspark/test/address_test.cpp
+++ b/src/libspark/test/address_test.cpp
@@ -1,13 +1,50 @@
 #include "../keys.h"
 
+#include "../../hash.h"
 #include "../../test/test_bitcoin.h"
 #include <boost/test/unit_test.hpp>
+
+#include <array>
 
 namespace spark {
 
 using namespace secp_primitives;
 
 BOOST_FIXTURE_TEST_SUITE(spark_address_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(spend_key_from_r)
+{
+    const Params* params = Params::get_test();
+
+    Scalar r(42);
+    SpendKey spend_key(params, r);
+    SpendKey same_spend_key(params, r);
+    std::array<unsigned char, Scalar::memoryRequired()> data;
+    std::array<unsigned char, CHash256::OUTPUT_SIZE> result;
+
+    CHash256 hash256;
+    std::string prefix1 = "s1_generation";
+    r.serialize(data.data());
+    hash256.Write(reinterpret_cast<const unsigned char*>(prefix1.c_str()), prefix1.size());
+    hash256.Write(data.data(), data.size());
+    hash256.Finalize(result.data());
+    Scalar expected_s1;
+    expected_s1.memberFromSeed(result.data());
+
+    std::string prefix2 = "s2_generation";
+    hash256.Reset();
+    hash256.Write(reinterpret_cast<const unsigned char*>(prefix2.c_str()), prefix2.size());
+    hash256.Finalize(result.data());
+    Scalar expected_s2;
+    expected_s2.memberFromSeed(result.data());
+
+    BOOST_CHECK(spend_key == same_spend_key);
+    BOOST_CHECK(spend_key.get_r() == r);
+    BOOST_CHECK(spend_key.get_s1() == expected_s1);
+    BOOST_CHECK(spend_key.get_s2() == expected_s2);
+    BOOST_CHECK(spend_key.get_s1().isMember());
+    BOOST_CHECK(spend_key.get_s2().isMember());
+}
 
 // Check that correct encoding and decoding succeed
 BOOST_AUTO_TEST_CASE(correctness)


### PR DESCRIPTION
## PR intention

Fixes a Spark wallet startup crash caused by clearing temporary buffers and then reusing them during spend-key derivation. The fix keeps fixed-size buffers valid for both derivation steps and adds a unit test covering deterministic SpendKey construction from r.