### PR TITLE
fix: use glibc assert hook with clang on linux

### DIFF
--- a/src/stacktraces.cpp
+++ b/src/stacktraces.cpp
@@ -579,7 +579,7 @@ extern "C" void __real___cxa_free_exception(void * thrown_exception)
     static auto f = (void(*)(void*))dlsym(RTLD_NEXT, "__cxa_free_exception");
     return f(thrown_exception);
 }
-#if __clang__
+#if defined(__APPLE__)
 extern "C" void __attribute__((noreturn)) __real___assert_rtn(const char *function, const char *file, int line, const char *assertion)
 {
     static auto f = (void(__attribute__((noreturn)) *) (const char*, const char*, int, const char*))dlsym(RTLD_NEXT, "__assert_rtn");
@@ -644,7 +644,7 @@ static __attribute__((noinline)) crash_info GetCrashInfoFromAssertion(const char
     return ci;
 }
 
-#if __clang__
+#if defined(__APPLE__)
 extern "C" void __attribute__((noinline)) WRAPPED_NAME(__assert_rtn)(const char *function, const char *file, int line, const char *assertion)
 {
     auto ci = GetCrashInfoFromAssertion(assertion, file, line, function);


### PR DESCRIPTION
## PR intention
This fixes crash-hook builds with Clang on Linux by selecting the assertion hook based on platform libc behavior rather than compiler. `__assert_rtn` is the Apple assertion entry point, while Linux/glibc uses `__assert_fail`, so Clang-on-Linux should not be routed through the Apple path. I verified crash-hook builds with both GCC and Clang, and confirmed `firod -testcrash` still prints decoded stack traces for both builds.
