### PR TITLE
Utils and libraries: Update Tor to 0.4.9.11

### DIFF
--- a/depends/packages/tor.mk
+++ b/depends/packages/tor.mk
@@ -1,53 +1,10 @@
 PACKAGE=tor
-$(package)_version=0.4.8.9
+$(package)_version=0.4.9.11
 $(package)_download_path=https://archive.torproject.org/tor-package-archive
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=59bb7d8890f6131b4ce5344f3dcea5deb2182b7f4f10ff0cb4e4d81f11b2cf65
+$(package)_sha256_hash=2e6c1720118c812acf0079fd47cf91b6bfaba5d766c321c4d3d2a28d6a11a8ed
 $(package)_dependencies=zlib openssl libevent
 $(package)_patches = configure.patch
-$(package)_lib_files = \
-    src/core/libtor-app.a \
-    src/lib/libtor-meminfo.a \
-    src/lib/libtor-term.a \
-    src/lib/libtor-osinfo.a \
-    src/lib/libtor-geoip.a \
-    src/lib/libtor-math.a \
-    src/lib/libtor-tls.a \
-    src/lib/libtor-process.a \
-    src/lib/libtor-evloop.a \
-    src/lib/libtor-thread.a \
-    src/lib/libtor-compress.a \
-    src/lib/libtor-net.a \
-    src/lib/libtor-buf.a \
-    src/lib/libtor-time.a \
-    src/lib/libtor-err.a \
-    src/lib/libtor-log.a \
-    src/lib/libtor-pubsub.a \
-    src/lib/libtor-dispatch.a \
-    src/lib/libtor-confmgt.a \
-    src/lib/libtor-container.a \
-    src/lib/libtor-crypt-ops.a \
-    src/lib/libtor-fs.a \
-    src/lib/libtor-fdio.a \
-    src/lib/libtor-sandbox.a \
-    src/lib/libtor-memarea.a \
-    src/lib/libtor-encoding.a \
-    src/lib/libtor-smartlist-core.a \
-    src/lib/libtor-lock.a \
-    src/lib/libtor-wallclock.a \
-    src/lib/libtor-string.a \
-    src/lib/libtor-malloc.a \
-    src/lib/libtor-version.a \
-    src/lib/libtor-intmath.a \
-    src/lib/libtor-ctime.a \
-    src/lib/libtor-llharden.a \
-    src/lib/libtor-metrics.a \
-    src/lib/libtor-trace.a \
-    src/trunnel/libor-trunnel.a \
-    src/lib/libcurve25519_donna.a \
-    src/ext/ed25519/donna/libed25519_donna.a \
-    src/ext/ed25519/ref10/libed25519_ref10.a \
-    src/ext/keccak-tiny/libkeccak-tiny.a
 
 define $(package)_set_vars
   $(package)_config_opts+=--disable-system-torrc --disable-systemd --disable-lzma --disable-asciidoc --disable-libscrypt --disable-gcc-hardening --enable-pic --disable-unittests --disable-tool-name-check --disable-seccomp ac_cv_header_sys_capability_h=no ac_cv_lib_cap_cap_init=no ac_cv_func_cap_set_proc=no
@@ -56,8 +13,7 @@ endef
 
 define $(package)_preprocess_cmds
   cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub . && \
-  patch -p1 < $($(package)_patch_dir)/configure.patch && \
-  sed -i.old 's/^PROGRAMS =.*/PROGRAMS =/' Makefile.in
+  patch -p1 < $($(package)_patch_dir)/configure.patch
 endef
 
 define $(package)_config_cmds
@@ -65,15 +21,10 @@ define $(package)_config_cmds
 endef
 
 define $(package)_build_cmds
-  $(MAKE) && \
-  mkdir objfiles && cd objfiles && \
-  for lib in $($(package)_lib_files); do \
-    (l=$$$${lib##*/} && mkdir $$$$l && cd $$$$l && $($(package)_ar) x ../../$$$${lib}); \
-  done && \
-  $($(package)_ar) cr libtor.a `find . -name *.o | LC_ALL=C sort`
+  $(MAKE) libtor.a
 endef
 
 define $(package)_stage_cmds
   mkdir -p $($(package)_staging_prefix_dir)/lib && \
-  install -m 644 objfiles/libtor.a $($(package)_staging_prefix_dir)/lib
+  install -m 644 libtor.a $($(package)_staging_prefix_dir)/lib
 endef

--- a/depends/patches/tor/configure.patch
+++ b/depends/patches/tor/configure.patch
@@ -1,8 +1,8 @@
 diff --git a/configure b/configure
-index 9ffb69e795..7a61e6cb3d 100755
+index 33117729a4..d737001008 100755
 --- a/configure
 +++ b/configure
-@@ -9769,7 +9769,6 @@ for ac_func in _NSGetEnviron \
+@@ -9859,7 +9859,6 @@ for ac_func in _NSGetEnviron \
  	backtrace \
  	backtrace_symbols_fd \
  	eventfd \
@@ -10,7 +10,7 @@ index 9ffb69e795..7a61e6cb3d 100755
  	timingsafe_memcmp \
  	flock \
  	fsync \
-@@ -10457,7 +10456,7 @@ save_LIBS="$LIBS"
+@@ -10554,7 +10553,7 @@ save_LIBS="$LIBS"
  save_LDFLAGS="$LDFLAGS"
  save_CPPFLAGS="$CPPFLAGS"
  
@@ -19,7 +19,7 @@ index 9ffb69e795..7a61e6cb3d 100755
  LDFLAGS="$TOR_LDFLAGS_libevent $LDFLAGS"
  CPPFLAGS="$TOR_CPPFLAGS_libevent $CPPFLAGS"
  
-@@ -10858,7 +10857,7 @@ else
+@@ -10984,7 +10983,7 @@ else
  
    for tor_trydir in "$tryopenssldir" "(system)" "$prefix" /usr/local /usr/pkg /usr/local/opt/openssl /usr/local/openssl /usr/lib/openssl /usr/local/ssl /usr/lib/ssl /usr/local /opt/openssl; do
      LDFLAGS="$tor_saved_LDFLAGS"
@@ -28,7 +28,7 @@ index 9ffb69e795..7a61e6cb3d 100755
      CPPFLAGS="$tor_saved_CPPFLAGS"
  
      if test -z "$tor_trydir" ; then
-@@ -11020,7 +11019,7 @@ fi
+@@ -11148,7 +11147,7 @@ fi
  fi
  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $tor_cv_library_openssl_dir" >&5
  $as_echo "$tor_cv_library_openssl_dir" >&6; }
@@ -37,7 +37,7 @@ index 9ffb69e795..7a61e6cb3d 100755
  if test "$tor_cv_library_openssl_dir" != "(system)"; then
  
    if test -d "$tor_cv_library_openssl_dir/lib"; then
-@@ -11151,10 +11150,10 @@ if test "$enable_static_openssl" = "yes"; then
+@@ -11284,10 +11283,10 @@ if test "$enable_static_openssl" = "yes"; then
     if test "$tor_cv_library_openssl_dir" = "(system)"; then
       as_fn_error $? "\"You must specify an explicit --with-openssl-dir=x option when using --enable-static-openssl\"" "$LINENO" 5
     else


### PR DESCRIPTION
## PR intention

Update Firo's bundled C Tor from 0.4.8.9 to 0.4.9.11.

Tor 0.4.8 reached end of life on 1 June 2026, and the Tor Project plans to stop supporting 0.4.8 and earlier on the network from 1 September 2026. Those clients do not understand the descriptor formats that omit legacy TAP onion keys and carry the new family identifiers. Tor 0.4.9 implements those formats, so updating the bundled library keeps `-torsetup` compatible without adding a Firo-side protocol workaround.

References:

- [Tor 0.4.8 sunset and 1 September cutoff](https://blog.torproject.org/sunsetting-tor-048/)
- [Tor 0.4.9.11 security release](https://forum.torproject.org/t/security-release-0-4-9-11/21786)
- [Official 0.4.9.11 checksum](https://dist.torproject.org/tor-0.4.9.11.tar.gz.sha256sum)

## Code changes brief

- Pin Tor 0.4.9.11 and its official SHA-256.
- Build and stage Tor's upstream `libtor.a` target.
- Remove Firo's hard-coded list of 42 internal Tor archives and the manual extraction/repack step.
- Rebase the existing `configure.patch` hunk locations onto 0.4.9.11; its intended platform fixes are unchanged.

The archive change is required because Tor 0.4.9 adds `src/ext/polyval/libpolyval.a`. The old manual list does not include it. Using Tor's aggregate target keeps the archive complete for configured and future internal libraries, uses the configured `AR`/`RANLIB`, and preserves Tor's Darwin archive handling.

No Firo SOCKS or control-port code changes are needed: the September incompatibility is handled inside Tor's directory parser. Firo's existing `PROTOCOLINFO 1`, SAFECOOKIE, SOCKS5, and v3 `ADD_ONION` usage remains supported.

### Review guide

The behavioral change is confined to `depends/packages/tor.mk`. `depends/patches/tor/configure.patch` only updates source blob IDs and hunk positions for the new release. The branch is one commit and two files: 11 additions, 60 deletions.

### Validation performed

- Verified the downloaded tarball against the official SHA-256.
- Applied `configure.patch` to the official 0.4.9.11 source with `patch --dry-run --fuzz=0 -p1`.
- Built the patched upstream `libtor.a` target on Windows/MSYS and linked `src/app/tor.exe`.
- Confirmed the archive contains `libpolyval_a-polyval.o` and exports `tor_main` and `tor_run_main`.
- Confirmed the linked executable reports Tor 0.4.9.11.
- Ran `git diff --check`.

### Suggested reviewer checks

```sh
make -C depends -j"$(nproc)" tor
make -C depends HOST=x86_64-w64-mingw32 -j"$(nproc)" tor
```

The normal CI Linux, Windows, macOS, and Guix Darwin builds provide the remaining platform coverage.