### PR TITLE
qt: sign and verify messages with Spark addresses

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -327,6 +327,7 @@ add_library(firo_node STATIC EXCLUDE_FROM_ALL
   ${CMAKE_CURRENT_SOURCE_DIR}/script/ismine.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/script/sigcache.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/spark/primitives.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/spark/sparkmessage.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/sparkname.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/spark/state.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/threadinterrupt.cpp

--- a/src/qt/forms/signverifymessagedialog.ui
+++ b/src/qt/forms/signverifymessagedialog.ui
@@ -48,7 +48,7 @@
          <item>
           <widget class="QValidatedLineEdit" name="addressIn_SM">
            <property name="toolTip">
-            <string>The Firo address to sign the message with</string>
+            <string>The Firo or Spark address to sign the message with</string>
            </property>
           </widget>
          </item>
@@ -152,7 +152,7 @@
          <item>
           <widget class="QPushButton" name="signMessageButton_SM">
            <property name="toolTip">
-            <string>Sign the message to prove you own this Firo address</string>
+            <string>Sign the message to prove you own this Firo or Spark address</string>
            </property>
            <property name="text">
             <string>Sign &amp;Message</string>
@@ -250,7 +250,7 @@
          <item>
           <widget class="QValidatedLineEdit" name="addressIn_VM">
            <property name="toolTip">
-            <string>The Firo address the message was signed with</string>
+            <string>The Firo or Spark address the message was signed with</string>
            </property>
           </widget>
          </item>
@@ -287,7 +287,7 @@
          <item>
           <widget class="QPushButton" name="verifyMessageButton_VM">
            <property name="toolTip">
-            <string>Verify the message to ensure it was signed with the specified Firo address</string>
+            <string>Verify the message to ensure it was signed with the specified Firo or Spark address</string>
            </property>
            <property name="text">
             <string>Verify &amp;Message</string>

--- a/src/qt/forms/signverifymessagedialog.ui
+++ b/src/qt/forms/signverifymessagedialog.ui
@@ -117,11 +117,14 @@
           <number>0</number>
          </property>
          <item>
-          <widget class="QLineEdit" name="signatureOut_SM">
+          <widget class="QPlainTextEdit" name="signatureOut_SM">
            <property name="font">
             <font>
              <italic>true</italic>
             </font>
+           </property>
+           <property name="tabChangesFocus">
+            <bool>true</bool>
            </property>
            <property name="readOnly">
             <bool>true</bool>

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -155,7 +155,9 @@ void SignVerifyMessageDialog::on_signMessageButton_SM_clicked()
         if (signature.isEmpty())
         {
             ui->statusLabel_SM->setStyleSheet("QLabel { color: red; }");
-            ui->statusLabel_SM->setText(QString("<nobr>") + error + QString("</nobr>"));
+            /* Plain text: the label is Qt::AutoText, and this string comes from a lower
+               layer rather than being a literal wrapped in markup like the ones below. */
+            ui->statusLabel_SM->setText(error);
             return;
         }
 

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -12,6 +12,7 @@
 
 #include "base58.h"
 #include "init.h"
+#include "spark/sparkmessage.h"
 #include "validation.h" // For strMessageMagic
 #include "wallet/wallet.h"
 
@@ -105,6 +106,21 @@ void SignVerifyMessageDialog::on_pasteButton_SM_clicked()
     setAddress_SM(QApplication::clipboard()->text());
 }
 
+bool SignVerifyMessageDialog::resolveSparkAddress(QString &address) const
+{
+    /* The address entry validator accepts "@name" Spark name notation, so resolve it here
+       rather than letting the handlers reject input the field was happy to take. */
+    if (!address.startsWith('@') || !model)
+        return true;
+
+    QString resolved = model->getSparkNameAddress(address.mid(1));
+    if (resolved.isEmpty())
+        return false;
+
+    address = resolved;
+    return true;
+}
+
 void SignVerifyMessageDialog::on_signMessageButton_SM_clicked()
 {
     if (!model)
@@ -113,7 +129,44 @@ void SignVerifyMessageDialog::on_signMessageButton_SM_clicked()
     /* Clear old signature to ensure users don't get confused on error with an old signature displayed */
     ui->signatureOut_SM->clear();
 
-    CBitcoinAddress addr(ui->addressIn_SM->text().toStdString());
+    QString addressIn = ui->addressIn_SM->text();
+    if (!resolveSparkAddress(addressIn))
+    {
+        ui->addressIn_SM->setValid(false);
+        ui->statusLabel_SM->setStyleSheet("QLabel { color: red; }");
+        ui->statusLabel_SM->setText(tr("The entered Spark name is not registered.") + QString(" ") + tr("Please check the address and try again."));
+        return;
+    }
+
+    /* Spark addresses are signed with an ownership proof rather than a compact ECDSA
+       signature, so branch here and leave the transparent path below untouched. */
+    if (model->validateSparkAddress(addressIn))
+    {
+        WalletModel::UnlockContext ctx(model->requestUnlock());
+        if (!ctx.isValid())
+        {
+            ui->statusLabel_SM->setStyleSheet("QLabel { color: red; }");
+            ui->statusLabel_SM->setText(tr("Wallet unlock was cancelled."));
+            return;
+        }
+
+        QString error;
+        QString signature = model->signSparkMessage(addressIn, ui->messageIn_SM->document()->toPlainText(), error);
+        if (signature.isEmpty())
+        {
+            ui->statusLabel_SM->setStyleSheet("QLabel { color: red; }");
+            ui->statusLabel_SM->setText(QString("<nobr>") + error + QString("</nobr>"));
+            return;
+        }
+
+        ui->statusLabel_SM->setStyleSheet("QLabel { color: green; }");
+        ui->statusLabel_SM->setText(QString("<nobr>") + tr("Message signed.") + QString("</nobr>"));
+
+        ui->signatureOut_SM->setText(signature);
+        return;
+    }
+
+    CBitcoinAddress addr(addressIn.toStdString());
     if (!addr.IsValid())
     {
         ui->statusLabel_SM->setStyleSheet("QLabel { color: red; }");
@@ -193,7 +246,51 @@ void SignVerifyMessageDialog::on_addressBookButton_VM_clicked()
 
 void SignVerifyMessageDialog::on_verifyMessageButton_VM_clicked()
 {
-    CBitcoinAddress addr(ui->addressIn_VM->text().toStdString());
+    QString addressIn = ui->addressIn_VM->text();
+    if (!resolveSparkAddress(addressIn))
+    {
+        ui->addressIn_VM->setValid(false);
+        ui->statusLabel_VM->setStyleSheet("QLabel { color: red; }");
+        ui->statusLabel_VM->setText(tr("The entered Spark name is not registered.") + QString(" ") + tr("Please check the address and try again."));
+        return;
+    }
+
+    /* Spark signatures are hex encoded ownership proofs rather than base64 compact
+       signatures, so they need a different check. InvalidAddress means the input did not
+       decode as a Spark address at all, which is the signal to fall through to the
+       transparent path below; that path is left untouched. */
+    spark::VerifyResult sparkResult = spark::VerifyMessage(
+        addressIn.toStdString(),
+        ui->signatureIn_VM->text().toStdString(),
+        ui->messageIn_VM->document()->toPlainText().toStdString());
+
+    if (sparkResult != spark::VerifyResult::InvalidAddress)
+    {
+        switch (sparkResult)
+        {
+        case spark::VerifyResult::Ok:
+            ui->statusLabel_VM->setStyleSheet("QLabel { color: green; }");
+            ui->statusLabel_VM->setText(QString("<nobr>") + tr("Message verified.") + QString("</nobr>"));
+            return;
+        case spark::VerifyResult::WrongNetwork:
+            ui->addressIn_VM->setValid(false);
+            ui->statusLabel_VM->setStyleSheet("QLabel { color: red; }");
+            ui->statusLabel_VM->setText(tr("The entered address is for a different network.") + QString(" ") + tr("Please check the address and try again."));
+            return;
+        case spark::VerifyResult::NotHex:
+        case spark::VerifyResult::MalformedProof:
+            ui->signatureIn_VM->setValid(false);
+            ui->statusLabel_VM->setStyleSheet("QLabel { color: red; }");
+            ui->statusLabel_VM->setText(tr("The signature could not be decoded.") + QString(" ") + tr("Please check the signature and try again."));
+            return;
+        default:
+            ui->statusLabel_VM->setStyleSheet("QLabel { color: red; }");
+            ui->statusLabel_VM->setText(QString("<nobr>") + tr("Message verification failed.") + QString("</nobr>"));
+            return;
+        }
+    }
+
+    CBitcoinAddress addr(addressIn.toStdString());
     if (!addr.IsValid())
     {
         ui->statusLabel_VM->setStyleSheet("QLabel { color: red; }");

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -19,7 +19,9 @@
 #include <string>
 #include <vector>
 
+#include <QAbstractTextDocumentLayout>
 #include <QClipboard>
+#include <QtMath>
 
 SignVerifyMessageDialog::SignVerifyMessageDialog(const PlatformStyle *_platformStyle, QWidget *parent) :
     QDialog(parent),
@@ -44,12 +46,31 @@ SignVerifyMessageDialog::SignVerifyMessageDialog(const PlatformStyle *_platformS
     ui->addressIn_SM->installEventFilter(this);
     ui->messageIn_SM->installEventFilter(this);
     ui->signatureOut_SM->installEventFilter(this);
+    ui->signatureOut_SM->viewport()->installEventFilter(this);
     ui->addressIn_VM->installEventFilter(this);
     ui->messageIn_VM->installEventFilter(this);
     ui->signatureIn_VM->installEventFilter(this);
 
     ui->signatureOut_SM->setFont(GUIUtil::fixedPitchFont());
     ui->signatureIn_VM->setFont(GUIUtil::fixedPitchFont());
+
+    /* A transparent signature is ~88 characters but a Spark ownership proof is several
+       hundred, so let the field grow with its content. Empty it is one line tall, keeping
+       the dialog's familiar layout. documentSizeChanged also fires on reflow, so the
+       height tracks dialog resizes too. */
+    connect(ui->signatureOut_SM->document()->documentLayout(), &QAbstractTextDocumentLayout::documentSizeChanged,
+            this, &SignVerifyMessageDialog::adjustSignatureOutHeight);
+    adjustSignatureOutHeight();
+}
+
+void SignVerifyMessageDialog::adjustSignatureOutHeight()
+{
+    QPlainTextEdit* sigOut = ui->signatureOut_SM;
+    const int lines = qBound(1, qCeil(sigOut->document()->size().height()), 4);
+    const int chrome = 2 * sigOut->frameWidth() + qRound(2 * sigOut->document()->documentMargin());
+    const int height = lines * sigOut->fontMetrics().lineSpacing() + chrome;
+    if (sigOut->height() != height)
+        sigOut->setFixedHeight(height);
 }
 
 SignVerifyMessageDialog::~SignVerifyMessageDialog()
@@ -164,7 +185,7 @@ void SignVerifyMessageDialog::on_signMessageButton_SM_clicked()
         ui->statusLabel_SM->setStyleSheet("QLabel { color: green; }");
         ui->statusLabel_SM->setText(QString("<nobr>") + tr("Message signed.") + QString("</nobr>"));
 
-        ui->signatureOut_SM->setText(signature);
+        ui->signatureOut_SM->setPlainText(signature);
         return;
     }
 
@@ -215,12 +236,12 @@ void SignVerifyMessageDialog::on_signMessageButton_SM_clicked()
     ui->statusLabel_SM->setStyleSheet("QLabel { color: green; }");
     ui->statusLabel_SM->setText(QString("<nobr>") + tr("Message signed.") + QString("</nobr>"));
 
-    ui->signatureOut_SM->setText(QString::fromStdString(EncodeBase64(&vchSig[0], vchSig.size())));
+    ui->signatureOut_SM->setPlainText(QString::fromStdString(EncodeBase64(&vchSig[0], vchSig.size())));
 }
 
 void SignVerifyMessageDialog::on_copySignatureButton_SM_clicked()
 {
-    GUIUtil::setClipboard(ui->signatureOut_SM->text());
+    GUIUtil::setClipboard(ui->signatureOut_SM->toPlainText());
 }
 
 void SignVerifyMessageDialog::on_clearButton_SM_clicked()
@@ -363,7 +384,7 @@ bool SignVerifyMessageDialog::eventFilter(QObject *object, QEvent *event)
             ui->statusLabel_SM->clear();
 
             /* Select generated signature */
-            if (object == ui->signatureOut_SM)
+            if (object == ui->signatureOut_SM || object == ui->signatureOut_SM->viewport())
             {
                 ui->signatureOut_SM->selectAll();
                 return true;

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -113,7 +113,10 @@ void SignVerifyMessageDialog::on_addressBookButton_SM_clicked()
 {
     if (model && model->getAddressTableModel())
     {
-        AddressBookPage dlg(platformStyle, AddressBookPage::ForSelection, AddressBookPage::ReceivingTab, this);
+        /* isReused=false shows the address type selector, so a Spark address can be picked
+           here as well; pin it to Transparent so the default stays what it was. */
+        AddressBookPage dlg(platformStyle, AddressBookPage::ForSelection, AddressBookPage::ReceivingTab, this, false);
+        dlg.setInitialAddressType(AddressBookPage::Transparent);
         dlg.setModel(model->getAddressTableModel());
         if (dlg.exec())
         {

--- a/src/qt/signverifymessagedialog.h
+++ b/src/qt/signverifymessagedialog.h
@@ -41,6 +41,10 @@ private:
        using that notation is left alone. Returns false if the name is not registered. */
     bool resolveSparkAddress(QString &address) const;
 
+    /* Size signatureOut_SM to its content: one line while empty, up to four for a long
+       Spark ownership proof. */
+    void adjustSignatureOutHeight();
+
 private Q_SLOTS:
     /* sign message */
     void on_addressBookButton_SM_clicked();

--- a/src/qt/signverifymessagedialog.h
+++ b/src/qt/signverifymessagedialog.h
@@ -37,6 +37,10 @@ private:
     WalletModel *model;
     const PlatformStyle *platformStyle;
 
+    /* Resolve "@name" Spark name notation in place to the address it points at. Input not
+       using that notation is left alone. Returns false if the name is not registered. */
+    bool resolveSparkAddress(QString &address) const;
+
 private Q_SLOTS:
     /* sign message */
     void on_addressBookButton_SM_clicked();

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -1092,10 +1092,18 @@ QString WalletModel::signSparkMessage(const QString& sparkAddress, const QString
 
     const spark::Params* params = spark::Params::get_default();
     spark::Address address(params);
+    unsigned char coinNetwork;
     try {
-        address.decode(sparkAddress.toStdString());
+        coinNetwork = address.decode(sparkAddress.toStdString());
     } catch (const std::exception&) {
         error = tr("The entered address is invalid.");
+        return QString();
+    }
+
+    // Match the RPC signing path and spark::VerifyMessage, which both reject
+    // addresses encoded for a different network.
+    if (coinNetwork != spark::GetNetworkType()) {
+        error = tr("The entered address is for a different network.");
         return QString();
     }
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -1082,7 +1082,9 @@ bool WalletModel::isSparkAddressMine(const QString& address)
 
 QString WalletModel::signSparkMessage(const QString& sparkAddress, const QString& message, QString& error)
 {
-    LOCK2(cs_main, wallet->cs_wallet);
+    // Signing touches no chain state, so cs_wallet alone is enough; taking cs_main here
+    // would block the GUI thread whenever a block is being connected.
+    LOCK(wallet->cs_wallet);
 
     if (!wallet->sparkWallet) {
         error = tr("Spark wallet is not available.");

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -1080,6 +1080,39 @@ bool WalletModel::isSparkAddressMine(const QString& address)
     return wallet->IsSparkAddressMine(address.toStdString());
 }
 
+QString WalletModel::signSparkMessage(const QString& sparkAddress, const QString& message, QString& error)
+{
+    LOCK2(cs_main, wallet->cs_wallet);
+
+    if (!wallet->sparkWallet) {
+        error = tr("Spark wallet is not available.");
+        return QString();
+    }
+
+    const spark::Params* params = spark::Params::get_default();
+    spark::Address address(params);
+    try {
+        address.decode(sparkAddress.toStdString());
+    } catch (const std::exception&) {
+        error = tr("The entered address is invalid.");
+        return QString();
+    }
+
+    if (!wallet->sparkWallet->isAddressMine(address)) {
+        error = tr("The entered address does not belong to this wallet.");
+        return QString();
+    }
+
+    try {
+        return QString::fromStdString(wallet->sparkWallet->SignMessage(address, message.toStdString()));
+    } catch (const std::exception& e) {
+        // Remaining failures are internal (spend key generation), so surface them verbatim
+        // rather than guessing at a friendlier wording.
+        error = QString::fromStdString(e.what());
+        return QString();
+    }
+}
+
 QString WalletModel::generateSparkAddress()
 {
     const spark::Params* params = spark::Params::get_default();

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -157,6 +157,10 @@ public:
     bool isSparkAddressMine(const QString &address);
     std::pair<CAmount, CAmount> getSparkBalance();
 
+    // Sign a message with a Spark address held by this wallet. Returns the ownership proof
+    // as hex, or a null QString with `error` set to a message fit to show the user.
+    QString signSparkMessage(const QString &sparkAddress, const QString &message, QString &error);
+
     // Generate spark address
     QString generateSparkAddress();
 

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -20,6 +20,7 @@
 #include "wallet/walletdb.h"
 #endif
 #include "txdb.h"
+#include "spark/sparkmessage.h"
 
 #include "masternode-sync.h"
 #include "evo/deterministicmns.h"
@@ -509,45 +510,22 @@ UniValue verifymessagewithsparkaddress(const JSONRPCRequest& request)
     std::string strSign     = request.params[1].get_str();
     std::string strMessage  = request.params[2].get_str();
 
-    const spark::Params* params = spark::Params::get_default();
-    unsigned char network = spark::GetNetworkType();
-    spark::Address address(params);
-    unsigned char coinNetwork;
-    try {
-        coinNetwork = address.decode(strAddress);
-    } catch (const std::exception&) {
+    switch (spark::VerifyMessage(strAddress, strSign, strMessage)) {
+    case spark::VerifyResult::Ok:
+        return true;
+    case spark::VerifyResult::Mismatch:
+        return false;
+    case spark::VerifyResult::InvalidAddress:
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Spark address");
-    }
-    if (coinNetwork != network)
+    case spark::VerifyResult::WrongNetwork:
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Spark address is for a different network");
-
-    // Decode the hex signature into an OwnershipProof
-    if (!IsHex(strSign))
+    case spark::VerifyResult::NotHex:
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Signature must be a hex string");
-
-    std::vector<unsigned char> proofData = ParseHex(strSign);
-    CDataStream proofStream(proofData, SER_NETWORK, PROTOCOL_VERSION);
-    spark::OwnershipProof proof;
-    try {
-        proofStream >> proof;
-    } catch (const std::exception&) {
+    case spark::VerifyResult::MalformedProof:
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Malformed ownership proof");
     }
 
-    // Hash the message the same way as signmessage / signmessagewithsparkaddress
-    CHashWriter ss(SER_GETHASH, 0);
-    ss << strMessageMagic;
-    ss << strMessage;
-    uint256 msgHash = ss.GetHash();
-
-    spark::Scalar m;
-    m.SetHex(msgHash.GetHex());
-
-    try {
-        return address.verify_own(m, proof);
-    } catch (const std::exception&) {
-        return false;
-    }
+    return false; // every enumerator is handled above
 }
 
 UniValue signmessagewithprivkey(const JSONRPCRequest& request)

--- a/src/spark/sparkmessage.cpp
+++ b/src/spark/sparkmessage.cpp
@@ -51,6 +51,12 @@ VerifyResult VerifyMessage(const std::string& encodedAddress,
         return VerifyResult::MalformedProof;
     }
 
+    // Require the encoding to be canonical. Deserializing stops as soon as the proof is
+    // complete, so without this a valid signature with arbitrary bytes appended would
+    // still verify.
+    if (!proofStream.empty())
+        return VerifyResult::MalformedProof;
+
     try {
         return address.verify_own(MessageScalar(message), proof) ? VerifyResult::Ok
                                                                  : VerifyResult::Mismatch;

--- a/src/spark/sparkmessage.cpp
+++ b/src/spark/sparkmessage.cpp
@@ -51,10 +51,10 @@ VerifyResult VerifyMessage(const std::string& encodedAddress,
         return VerifyResult::MalformedProof;
     }
 
-    // Require the encoding to be canonical. Deserializing stops as soon as the proof is
-    // complete, so without this a valid signature with arbitrary bytes appended would
-    // still verify.
-    if (!proofStream.empty())
+    // Require the exact canonical encoding emitted by the serializers.
+    CDataStream canonicalProof(SER_NETWORK, PROTOCOL_VERSION);
+    canonicalProof << proof;
+    if (proofData != std::vector<unsigned char>(canonicalProof.begin(), canonicalProof.end()))
         return VerifyResult::MalformedProof;
 
     try {

--- a/src/spark/sparkmessage.cpp
+++ b/src/spark/sparkmessage.cpp
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 The Firo Core Developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "sparkmessage.h"
+
+#include "state.h"
+#include "../hash.h"
+#include "../streams.h"
+#include "../utilstrencodings.h"
+#include "../validation.h" // For strMessageMagic
+#include "../version.h"
+
+namespace spark {
+
+Scalar MessageScalar(const std::string& message)
+{
+    CHashWriter ss(SER_GETHASH, 0);
+    ss << strMessageMagic;
+    ss << message;
+
+    Scalar m;
+    m.SetHex(ss.GetHash().GetHex());
+    return m;
+}
+
+VerifyResult VerifyMessage(const std::string& encodedAddress,
+                           const std::string& hexProof,
+                           const std::string& message)
+{
+    const spark::Params* params = spark::Params::get_default();
+    spark::Address address(params);
+    unsigned char coinNetwork;
+    try {
+        coinNetwork = address.decode(encodedAddress);
+    } catch (const std::exception&) {
+        return VerifyResult::InvalidAddress;
+    }
+    if (coinNetwork != GetNetworkType())
+        return VerifyResult::WrongNetwork;
+
+    if (!IsHex(hexProof))
+        return VerifyResult::NotHex;
+
+    std::vector<unsigned char> proofData = ParseHex(hexProof);
+    CDataStream proofStream(proofData, SER_NETWORK, PROTOCOL_VERSION);
+    spark::OwnershipProof proof;
+    try {
+        proofStream >> proof;
+    } catch (const std::exception&) {
+        return VerifyResult::MalformedProof;
+    }
+
+    try {
+        return address.verify_own(MessageScalar(message), proof) ? VerifyResult::Ok
+                                                                 : VerifyResult::Mismatch;
+    } catch (const std::exception&) {
+        // A proof that deserializes but holds junk group elements throws out of libspark
+        // rather than returning false. Either way the message is not proven.
+        return VerifyResult::Mismatch;
+    }
+}
+
+} // namespace spark

--- a/src/spark/sparkmessage.h
+++ b/src/spark/sparkmessage.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 The Firo Core Developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef FIRO_SPARK_SPARKMESSAGE_H
+#define FIRO_SPARK_SPARKMESSAGE_H
+
+#include <string>
+
+#include "../libspark/keys.h"
+
+namespace spark {
+
+/*
+ * Message signing and verification for Spark addresses.
+ *
+ * A signature is a libspark OwnershipProof over the message digest, serialized and hex
+ * encoded. The RPC layer and the GUI both go through here, so the digest convention lives
+ * in one place. The signing half needs a wallet and lives in CSparkWallet::SignMessage.
+ */
+
+// Message digest as a Scalar, the value an ownership proof commits to. Hashed the same way
+// as signmessage: strMessageMagic followed by the message.
+Scalar MessageScalar(const std::string& message);
+
+enum class VerifyResult
+{
+    Ok,             // proof is valid for this address and message
+    Mismatch,       // well formed proof, but not valid for this address and message
+    InvalidAddress, // address could not be decoded
+    WrongNetwork,   // address decoded but belongs to a different network
+    NotHex,         // signature is not a hex string
+    MalformedProof  // signature is hex but does not deserialize to an OwnershipProof
+};
+
+// Verify a hex encoded OwnershipProof against an encoded Spark address. Never throws.
+VerifyResult VerifyMessage(const std::string& encodedAddress,
+                           const std::string& hexProof,
+                           const std::string& message);
+
+} // namespace spark
+
+#endif // FIRO_SPARK_SPARKMESSAGE_H

--- a/src/spark/sparkwallet.cpp
+++ b/src/spark/sparkwallet.cpp
@@ -1,5 +1,6 @@
 #include "sparkwallet.h"
 #include "threadpool.h"
+#include "sparkmessage.h"
 #include "state.h"
 #include "../wallet/wallet.h"
 #include "../wallet/coincontrol.h"
@@ -8,6 +9,7 @@
 #include "../validation.h"
 #include "../policy/policy.h"
 #include "../script/sign.h"
+#include "../utilstrencodings.h"
 #include "state.h"
 #include "sparkname.h"
 #include "../chain.h"
@@ -330,6 +332,31 @@ bool CSparkWallet::isAddressMine(const spark::Address& address) {
 
 bool CSparkWallet::isChangeAddress(const uint64_t& i) const {
     return i == SPARK_CHANGE_D;
+}
+
+std::string CSparkWallet::SignMessage(const spark::Address& address, const std::string& message) {
+    if (!isAddressMine(address))
+        throw std::runtime_error("Spark address does not belong to this wallet");
+
+    const spark::Params* params = spark::Params::get_default();
+
+    spark::SpendKey spendKey(params);
+    try {
+        spendKey = std::move(generateSpendKey(params));
+    } catch (const WalletLocked&) {
+        throw;
+    } catch (const std::exception&) {
+        throw std::runtime_error("Unable to generate spend key");
+    }
+
+    spark::OwnershipProof proof;
+    spark::FullViewKey fullViewKey(spendKey);
+    address.prove_own(spark::MessageScalar(message), spendKey, fullViewKey, proof);
+
+    CDataStream proofStream(SER_NETWORK, PROTOCOL_VERSION);
+    proofStream << proof;
+
+    return HexStr(proofStream.begin(), proofStream.end());
 }
 
 std::vector<CSparkMintMeta> CSparkWallet::ListSparkMints(bool fUnusedOnly, bool fMatureOnly) const {

--- a/src/spark/sparkwallet.h
+++ b/src/spark/sparkwallet.h
@@ -48,6 +48,12 @@ public:
     bool isAddressMine(const spark::Address& address);
     bool isChangeAddress(const uint64_t& i) const;
 
+    // Sign a message with one of our addresses, returning the ownership proof as hex.
+    // Throws WalletLocked if the spend key cannot be generated because the wallet is
+    // locked, or std::runtime_error if the address is not ours or the key generation
+    // fails for any other reason.
+    std::string SignMessage(const spark::Address& address, const std::string& message);
+
     // list spark mint, mint metadata in memory and in db should be the same at this moment, so get from memory
     std::vector<CSparkMintMeta> ListSparkMints(bool fUnusedOnly = false, bool fMatureOnly = false) const;
     std::list<CSparkSpendEntry> ListSparkSpends() const;

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -94,6 +94,7 @@ add_executable(test_firo
   ${CMAKE_CURRENT_SOURCE_DIR}/evo_simplifiedmns_tests.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/progpow_tests.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/bls_tests.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/sparkmessage_tests.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/sparkname_tests.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/../libspark/test/ownership_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/../libspark/test/transcript_test.cpp

--- a/src/test/sparkmessage_tests.cpp
+++ b/src/test/sparkmessage_tests.cpp
@@ -1,0 +1,103 @@
+#include "../chainparams.h"
+#include "../spark/sparkmessage.h"
+#include "../spark/state.h"
+#include "../utilstrencodings.h"
+#include "../validation.h"
+#include "../wallet/wallet.h"
+#include "../wallet/walletexcept.h"
+
+#include "test_bitcoin.h"
+#include "fixtures.h"
+
+#include <boost/test/unit_test.hpp>
+
+namespace spark {
+
+class SparkMessageTests : public SparkTestingSetup
+{
+public:
+    // An address belonging to the test wallet, in its encoded form.
+    std::string MyAddress()
+    {
+        LOCK(pwalletMain->cs_wallet);
+        return pwalletMain->sparkWallet->generateNewAddress().encode(GetNetworkType());
+    }
+
+    std::string Sign(const std::string &encodedAddress, const std::string &message)
+    {
+        Address address(params);
+        address.decode(encodedAddress);
+        LOCK(pwalletMain->cs_wallet);
+        return pwalletMain->sparkWallet->SignMessage(address, message);
+    }
+};
+
+BOOST_FIXTURE_TEST_SUITE(sparkmessage, spark::SparkMessageTests)
+
+BOOST_AUTO_TEST_CASE(sign_then_verify_round_trip)
+{
+    std::string addr = MyAddress();
+    std::string message = "firo-forum-spark-name/v1|example|round trip";
+
+    std::string signature = Sign(addr, message);
+    BOOST_CHECK(!signature.empty());
+    BOOST_CHECK(IsHex(signature));
+
+    BOOST_CHECK(VerifyMessage(addr, signature, message) == VerifyResult::Ok);
+}
+
+BOOST_AUTO_TEST_CASE(verify_rejects_tampered_message)
+{
+    std::string addr = MyAddress();
+    std::string signature = Sign(addr, "the original message");
+
+    BOOST_CHECK(VerifyMessage(addr, signature, "the original message ") == VerifyResult::Mismatch);
+    BOOST_CHECK(VerifyMessage(addr, signature, "a different message") == VerifyResult::Mismatch);
+    BOOST_CHECK(VerifyMessage(addr, signature, "") == VerifyResult::Mismatch);
+}
+
+BOOST_AUTO_TEST_CASE(verify_rejects_a_proof_made_for_another_address)
+{
+    std::string message = "same message, two addresses";
+    std::string addrA = MyAddress();
+    std::string addrB = MyAddress();
+    BOOST_REQUIRE(addrA != addrB);
+
+    BOOST_CHECK(VerifyMessage(addrB, Sign(addrA, message), message) == VerifyResult::Mismatch);
+}
+
+BOOST_AUTO_TEST_CASE(verify_reports_malformed_input)
+{
+    std::string addr = MyAddress();
+    std::string signature = Sign(addr, "a message");
+
+    // Not hex at all.
+    BOOST_CHECK(VerifyMessage(addr, "not a hex string", "a message") == VerifyResult::NotHex);
+    // Hex, but far too short to deserialize into an ownership proof.
+    BOOST_CHECK(VerifyMessage(addr, "abcd", "a message") == VerifyResult::MalformedProof);
+    // A truncated proof still fails to deserialize rather than being treated as a mismatch.
+    BOOST_CHECK(VerifyMessage(addr, signature.substr(0, signature.size() / 2), "a message")
+                == VerifyResult::MalformedProof);
+
+    BOOST_CHECK(VerifyMessage("not an address", signature, "a message") == VerifyResult::InvalidAddress);
+    BOOST_CHECK(VerifyMessage("", signature, "a message") == VerifyResult::InvalidAddress);
+}
+
+BOOST_AUTO_TEST_CASE(sign_rejects_an_address_we_do_not_own)
+{
+    // A well formed address derived from a spend key that is not the wallet's.
+    SpendKey foreignSpendKey(params);
+    IncomingViewKey foreignViewKey(FullViewKey{foreignSpendKey});
+    Address foreign(foreignViewKey, 0);
+
+    BOOST_CHECK_THROW(
+        {
+            LOCK(pwalletMain->cs_wallet);
+            pwalletMain->sparkWallet->SignMessage(foreign, "a message");
+        },
+        std::runtime_error);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+} // namespace spark

--- a/src/test/sparkmessage_tests.cpp
+++ b/src/test/sparkmessage_tests.cpp
@@ -76,7 +76,10 @@ BOOST_AUTO_TEST_CASE(verify_reports_malformed_input)
     // Hex, but far too short to deserialize into an ownership proof.
     BOOST_CHECK(VerifyMessage(addr, "abcd", "a message") == VerifyResult::MalformedProof);
     // A truncated proof still fails to deserialize rather than being treated as a mismatch.
-    BOOST_CHECK(VerifyMessage(addr, signature.substr(0, signature.size() / 2), "a message")
+    // Drop one whole byte so the input stays valid hex and the failure is the truncation
+    // rather than an odd digit count.
+    BOOST_REQUIRE(signature.size() > 2);
+    BOOST_CHECK(VerifyMessage(addr, signature.substr(0, signature.size() - 2), "a message")
                 == VerifyResult::MalformedProof);
 
     BOOST_CHECK(VerifyMessage("not an address", signature, "a message") == VerifyResult::InvalidAddress);

--- a/src/test/sparkmessage_tests.cpp
+++ b/src/test/sparkmessage_tests.cpp
@@ -83,6 +83,39 @@ BOOST_AUTO_TEST_CASE(verify_reports_malformed_input)
     BOOST_CHECK(VerifyMessage("", signature, "a message") == VerifyResult::InvalidAddress);
 }
 
+BOOST_AUTO_TEST_CASE(verify_requires_a_canonical_proof)
+{
+    std::string addr = MyAddress();
+    std::string message = "a message";
+    std::string signature = Sign(addr, message);
+
+    BOOST_REQUIRE(VerifyMessage(addr, signature, message) == VerifyResult::Ok);
+
+    // Deserialization stops as soon as the proof is complete, so trailing bytes have to be
+    // rejected explicitly or a valid signature stays valid with junk appended.
+    BOOST_CHECK(VerifyMessage(addr, signature + "00", message) == VerifyResult::MalformedProof);
+    BOOST_CHECK(VerifyMessage(addr, signature + "deadbeef", message) == VerifyResult::MalformedProof);
+}
+
+BOOST_AUTO_TEST_CASE(verify_rejects_an_address_from_another_network)
+{
+    Address address(params);
+    {
+        LOCK(pwalletMain->cs_wallet);
+        address = pwalletMain->sparkWallet->generateNewAddress();
+    }
+
+    // Encode the very same address for a different network: it decodes cleanly, so it has
+    // to be turned away on the network byte rather than as an invalid address.
+    unsigned char foreignNetwork = GetNetworkType() == ADDRESS_NETWORK_MAINNET
+                                       ? ADDRESS_NETWORK_TESTNET
+                                       : ADDRESS_NETWORK_MAINNET;
+    std::string signature = Sign(address.encode(GetNetworkType()), "a message");
+
+    BOOST_CHECK(VerifyMessage(address.encode(foreignNetwork), signature, "a message")
+                == VerifyResult::WrongNetwork);
+}
+
 BOOST_AUTO_TEST_CASE(sign_rejects_an_address_we_do_not_own)
 {
     // A well formed address derived from a spend key that is not the wallet's.

--- a/src/test/sparkmessage_tests.cpp
+++ b/src/test/sparkmessage_tests.cpp
@@ -98,6 +98,13 @@ BOOST_AUTO_TEST_CASE(verify_requires_a_canonical_proof)
     // rejected explicitly or a valid signature stays valid with junk appended.
     BOOST_CHECK(VerifyMessage(addr, signature + "00", message) == VerifyResult::MalformedProof);
     BOOST_CHECK(VerifyMessage(addr, signature + "deadbeef", message) == VerifyResult::MalformedProof);
+
+    // OwnershipProof begins with a GroupElement whose byte 32 is a y-oddness flag.
+    // Its serializer emits only 0 or 1, but its deserializer accepts other values.
+    std::string nonCanonical = signature;
+    BOOST_REQUIRE(nonCanonical.size() >= 66);
+    nonCanonical.replace(64, 2, "02");
+    BOOST_CHECK(VerifyMessage(addr, nonCanonical, message) == VerifyResult::MalformedProof);
 }
 
 BOOST_AUTO_TEST_CASE(verify_rejects_an_address_from_another_network)

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1414,35 +1414,13 @@ UniValue signmessagewithsparkaddress(const JSONRPCRequest& request)
     if (coinNetwork != spark::GetNetworkType())
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Spark address is for a different network");
 
-    if (!pwallet->sparkWallet->isAddressMine(address))
-        throw JSONRPCError(RPC_WALLET_ERROR, "Spark address does not belong to this wallet");
-
-    // Hash the message the same way as signmessage
-    CHashWriter ss(SER_GETHASH, 0);
-    ss << strMessageMagic;
-    ss << strMessage;
-    uint256 msgHash = ss.GetHash();
-
-    spark::Scalar m;
-    m.SetHex(msgHash.ToString());
-
-    spark::SpendKey spendKey(params);
     try {
-        spendKey = std::move(pwallet->sparkWallet->generateSpendKey(params));
+        return pwallet->sparkWallet->SignMessage(address, strMessage);
     } catch (const WalletLocked&) {
         throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED, "Unable to generate spend key, wallet may be locked");
-    } catch (const std::exception&) {
-        throw JSONRPCError(RPC_WALLET_ERROR, "Unable to generate spend key");
+    } catch (const std::exception& e) {
+        throw JSONRPCError(RPC_WALLET_ERROR, e.what());
     }
-
-    spark::OwnershipProof proof;
-    spark::FullViewKey fullViewKey(spendKey);
-    address.prove_own(m, spendKey, fullViewKey, proof);
-
-    CDataStream proofStream(SER_NETWORK, PROTOCOL_VERSION);
-    proofStream << proof;
-
-    return HexStr(proofStream.begin(), proofStream.end());
 }
 
 UniValue getreceivedbyaddress(const JSONRPCRequest& request)


### PR DESCRIPTION
## Why

`signmessagewithsparkaddress` and `verifymessagewithsparkaddress` are reachable only over RPC. Proving control of a Spark address from the GUI therefore means opening the debug console or using `firo-cli`, which is a hard ceiling on any feature that asks ordinary users to sign a challenge with their Spark address.

This wires both into the Sign/Verify dialog that already exists for transparent addresses.

## Approach: detect the address type, don't add tabs

The dialog branches on what was entered rather than growing "Sign Spark Message" / "Verify Spark Message" tabs. Four near-identical tabs would be worse UX, and it would force the user to know which signature scheme backs their address — something they have no reason to care about.

This turned out to need **no structural change to the form**:

- `BitcoinAddressEntryValidator` / `BitcoinAddressCheckValidator` already accept Spark addresses and `@name` Spark name notation.
- `GUIUtil::setupAddressWidget` already advertises a Spark address in the placeholder text.

So `signverifymessagedialog.ui` changes only four tooltip strings ("Firo address" → "Firo or Spark address"). No new widgets, no geometry change.

`@name` input is now resolved via the existing `WalletModel::getSparkNameAddress()`. That also fixes a small pre-existing wart: the validator accepted `@name`, and then the handler rejected it with "The entered address is invalid."

## The refactor

The signing and verification crypto sat **inline inside the two RPC bodies**, so none of it was callable from the GUI. Copying it into Qt would have put the `strMessageMagic` digest convention in a third place. Instead:

- **`src/spark/sparkmessage.{h,cpp}`** (new, builds into `firo_node`) — `spark::MessageScalar()` and `spark::VerifyMessage()`. Verification needs no wallet, matching `verifymessagewithsparkaddress` being a `util` RPC.
- **`CSparkWallet::SignMessage()`** — the signing half, which does need a wallet.
- Both RPCs rewired to call them.

`VerifyMessage` returns a `VerifyResult` enum rather than a bool on purpose. `verifymessagewithsparkaddress` currently *throws* for a bad address, wrong network, non-hex signature or unparseable proof, and only *returns false* for a well-formed proof that does not match. A bool would collapse that; the enum preserves every existing error code and message byte-for-byte, and gives the GUI enough to write a useful status label.

## Tests

`src/test/sparkmessage_tests.cpp` on the existing `SparkTestingSetup` fixture: sign/verify round trip, tampered message, a proof made for a different address of the same wallet, malformed and truncated signatures, invalid addresses, and signing with an address the wallet does not own.

## Two limitations in the original submission — both since fixed

- **`signatureOut_SM` was a single-line `QLineEdit`**, which a several-hundred-character Spark ownership proof scrolled unusably. It is now a read-only `QPlainTextEdit` that grows with its content (7ad2362): one line tall while empty, so the dialog layout is unchanged until a signature appears, then up to four wrapped lines. Click-to-select-all and the Copy button behave as before.
- **The Sign tab's address-book button** opened `AddressBookPage::ReceivingTab` with the default `isReused=true`, the one condition that hides the address-type selector, so it offered transparent addresses only. It now passes `isReused=false` with the initial type pinned to Transparent (60bf3e8), so a Spark address can be picked from the address book while the default selection stays what it was. The Verify tab already offered Spark addresses via `SendingTab`.

## Verification status

I could not build this locally (no MinGW/depends toolchain on hand), so **CI is the compile check** — please treat the build result as authoritative rather than my say-so. The behaviour-preservation claim about the two RPCs is worth a careful look in review: the intent is that `signmessagewithsparkaddress` and `verifymessagewithsparkaddress` are indistinguishable before and after for every input, including error paths — with **one deliberate exception adopted during review**: a proof with trailing bytes or a non-canonical encoding is now rejected as `Malformed ownership proof`, where the old verifier accepted it (50df625, 00fec36). No signer Firo ships produces such an encoding, and there are regression tests for both cases.