### PR TITLE
Wallet: Lock Spark address state

### DIFF
--- a/src/spark/sparkwallet.cpp
+++ b/src/spark/sparkwallet.cpp
@@ -103,10 +103,12 @@ void CSparkWallet::FinishTasks() {
 }
 
 void CSparkWallet::resetDiversifierFromDB(CWalletDB& walletdb) {
+    LOCK(cs_spark_wallet);
     walletdb.readDiversifier(lastDiversifier);
 }
 
 void CSparkWallet::updatetDiversifierInDB(CWalletDB& walletdb) {
+    LOCK(cs_spark_wallet);
     walletdb.writeDiversifier(lastDiversifier);
 }
 
@@ -219,11 +221,13 @@ CAmount CSparkWallet::getAddressUnconfirmedBalance(const spark::Address& address
 }
 
 spark::Address CSparkWallet::generateNextAddress() {
+    LOCK(cs_spark_wallet);
     lastDiversifier++;
     return spark::Address(viewKey, lastDiversifier);
 }
 
 spark::Address CSparkWallet::generateNewAddress() {
+    LOCK(cs_spark_wallet);
     lastDiversifier++;
     spark::Address address(viewKey, lastDiversifier);
 
@@ -234,6 +238,7 @@ spark::Address CSparkWallet::generateNewAddress() {
 }
 
 spark::Address CSparkWallet::getDefaultAddress() {
+    LOCK(cs_spark_wallet);
     if (addresses.count(0))
         return addresses[0];
     lastDiversifier = 0;
@@ -283,10 +288,12 @@ spark::IncomingViewKey CSparkWallet::generateIncomingViewKey(const spark::FullVi
 }
 
 std::unordered_map<int32_t, spark::Address> CSparkWallet::getAllAddresses() {
+    LOCK(cs_spark_wallet);
     return addresses;
 }
 
 spark::Address CSparkWallet::getAddress(const int32_t& i) {
+    LOCK(cs_spark_wallet);
     if (lastDiversifier < i || addresses.count(i) == 0)
         return spark::Address(viewKey, i);
 
@@ -306,6 +313,7 @@ bool CSparkWallet::isAddressMine(const std::string& encodedAddr) {
 }
 
 bool CSparkWallet::isAddressMine(const spark::Address& address) {
+    LOCK(cs_spark_wallet);
     for (const auto& itr : addresses) {
         if (itr.second.get_Q1() == address.get_Q1() && itr.second.get_Q2() == address.get_Q2())
             return true;

--- a/src/spark/sparkwallet.cpp
+++ b/src/spark/sparkwallet.cpp
@@ -495,6 +495,7 @@ bool CSparkWallet::getMintAmount(spark::Coin coin, CAmount& amount) {
 }
 
 void CSparkWallet::UpdateSpendState(const GroupElement& lTag, const uint256& lTagHash, const uint256& txHash, bool fUpdateMint) {
+    LOCK(cs_spark_wallet);
     if (coinMeta.count(lTagHash)) {
         auto mintMeta = coinMeta[lTagHash];
 

--- a/src/spark/sparkwallet.h
+++ b/src/spark/sparkwallet.h
@@ -157,13 +157,13 @@ public:
     void FinishTasks();
 
 public:
-    // to protect coinMeta
+    // Protects lastDiversifier, addresses, and coinMeta.
     mutable CCriticalSection cs_spark_wallet;
 
 private:
     std::string strWalletFile;
     // this is latest used diversifier
-    int32_t lastDiversifier;
+    int32_t lastDiversifier GUARDED_BY(cs_spark_wallet);
 
     // this is full view key, which is saved into db
     spark::FullViewKey fullViewKey;
@@ -171,7 +171,7 @@ private:
     spark::IncomingViewKey viewKey;
 
     // map diversifier to address.
-    std::unordered_map<int32_t, spark::Address> addresses;
+    std::unordered_map<int32_t, spark::Address> addresses GUARDED_BY(cs_spark_wallet);
 
     // map lTagHash to coin meta
     std::unordered_map<uint256, CSparkMintMeta> coinMeta;

--- a/src/spark/sparkwallet.h
+++ b/src/spark/sparkwallet.h
@@ -174,7 +174,7 @@ private:
     std::unordered_map<int32_t, spark::Address> addresses GUARDED_BY(cs_spark_wallet);
 
     // map lTagHash to coin meta
-    std::unordered_map<uint256, CSparkMintMeta> coinMeta;
+    std::unordered_map<uint256, CSparkMintMeta> coinMeta GUARDED_BY(cs_spark_wallet);
 
     void* threadPool;
 };


### PR DESCRIPTION
## PR intention

Fixes #1878.

`CSparkWallet` accessed its Spark address map and `lastDiversifier` from concurrent RPC and GUI paths without `cs_spark_wallet`. An address insertion can rehash the `std::unordered_map` while another thread copies or iterates it, causing undefined behavior and potentially crashing the wallet process.

Review also found one existing unlocked `coinMeta` access in `UpdateSpendState()`, reachable from wallet transaction handling while Spark worker threads use the same map.

## Code changes brief

- Take `cs_spark_wallet` in every address-state accessor, the two diversifier database helpers, and the shared `UpdateSpendState()` implementation.
- Mark `lastDiversifier`, `addresses`, and `coinMeta` with `GUARDED_BY(cs_spark_wallet)` so Clang thread-safety analysis can detect future unlocked access.

## Testing

- `git diff --check`
- Audited every affected caller and confirmed the existing lock order remains `cs_main`, then `cs_wallet`, then `cs_spark_wallet`.
- Verified the branch merges cleanly with current `master` and the merged result retains every lock and annotation.
- A native build was not run because this Windows environment has no C++ toolchain or existing build artifacts.