### PR TITLE
Build: eliminate macOS warning noise

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,14 @@
 #  - CMake 3.26.5, https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/
 cmake_minimum_required(VERSION 3.22)
 
+# De-duplicate libraries when the linker can safely rescan static archives.
+if(POLICY CMP0156)
+  cmake_policy(SET CMP0156 NEW)
+endif()
+if(POLICY CMP0179)
+  cmake_policy(SET CMP0179 NEW)
+endif()
+
 if (${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
   message(FATAL_ERROR "In-source builds are not allowed.")
 endif()

--- a/src/secp256k1/src/CMakeLists.txt
+++ b/src/secp256k1/src/CMakeLists.txt
@@ -15,7 +15,7 @@ target_link_libraries(secp256k1
 )
 
 target_include_directories(secp256k1
-  PUBLIC
+  SYSTEM PUBLIC
     ${GMP_INCLUDES}
 )
 
@@ -135,20 +135,20 @@ if(SECP256K1_BUILD_BENCHMARK)
   target_link_libraries(bench_verify PUBLIC secp256k1)
   add_executable(bench_internal bench_internal.c)
   target_link_libraries(bench_internal PUBLIC secp256k1_asm ${GMP_LIBRARIES})
-  target_include_directories(bench_internal PUBLIC ${GMP_INCLUDES})
+  target_include_directories(bench_internal SYSTEM PUBLIC ${GMP_INCLUDES})
 endif()
 
 if(SECP256K1_BUILD_TESTS)
   add_executable(noverify_tests tests.c)
   target_compile_definitions(noverify_tests PRIVATE VERIFY)
   target_link_libraries(noverify_tests secp256k1_asm ${GMP_LIBRARIES})
-  target_include_directories(noverify_tests PUBLIC ${GMP_INCLUDES})
+  target_include_directories(noverify_tests SYSTEM PUBLIC ${GMP_INCLUDES})
   add_test(NAME secp256k1_noverify_tests COMMAND noverify_tests)
   if(NOT CMAKE_BUILD_TYPE STREQUAL "Coverage")
     add_executable(tests tests.c)
     target_compile_definitions(tests PRIVATE VERIFY)
     target_link_libraries(tests secp256k1_asm ${GMP_LIBRARIES})
-    target_include_directories(tests PUBLIC ${GMP_INCLUDES})
+    target_include_directories(tests SYSTEM PUBLIC ${GMP_INCLUDES})
     add_test(NAME secp256k1_tests COMMAND tests)
   endif()
 endif()
@@ -157,7 +157,7 @@ if(SECP256K1_BUILD_EXHAUSTIVE_TESTS)
   # Note: do not include secp256k1_precomputed in exhaustive_tests (it uses runtime-generated tables).
   add_executable(exhaustive_tests tests_exhaustive.c)
   target_link_libraries(exhaustive_tests PRIVATE secp256k1_asm ${GMP_LIBRARIES})
-  target_include_directories(exhaustive_tests PUBLIC ${GMP_INCLUDES})
+  target_include_directories(exhaustive_tests SYSTEM PUBLIC ${GMP_INCLUDES})
   target_compile_definitions(exhaustive_tests PRIVATE $<$<NOT:$<CONFIG:Coverage>>:VERIFY>)
   add_test(NAME secp256k1_exhaustive_tests COMMAND exhaustive_tests)
 endif()

--- a/src/test/sparkname_tests.cpp
+++ b/src/test/sparkname_tests.cpp
@@ -795,7 +795,7 @@ BOOST_AUTO_TEST_CASE(validity_overflow_protection)
     // --- Fresh registration with sparkNameValidityBlocks = INT_MAX + 1 ---
     std::string addr2 = GenerateSparkAddress();
     CMutableTransaction txNewOverflow = CreateSparkNameTx("newname1", addr2, nBlockPerYear, "", false);
-    ModifySparkNameTx(txNewOverflow, [overflowBlocks](CSparkNameTxData &data) {
+    ModifySparkNameTx(txNewOverflow, [](CSparkNameTxData &data) {
         data.sparkNameValidityBlocks = overflowBlocks;
     });
     int oldHeight = chainActive.Height();
@@ -804,7 +804,7 @@ BOOST_AUTO_TEST_CASE(validity_overflow_protection)
 
     // --- Renewal of existing name with sparkNameValidityBlocks = INT_MAX + 1 ---
     CMutableTransaction txUpdateOverflow = CreateSparkNameTx("overtest", addr1, nBlockPerYear, "", false);
-    ModifySparkNameTx(txUpdateOverflow, [overflowBlocks](CSparkNameTxData &data) {
+    ModifySparkNameTx(txUpdateOverflow, [](CSparkNameTxData &data) {
         data.sparkNameValidityBlocks = overflowBlocks;
     });
     oldHeight = chainActive.Height();


### PR DESCRIPTION
## PR intention
This marks GMP headers as system includes, removes two unused test lambda captures, and enables linker-aware archive deduplication on supported CMake versions. 