### PR TITLE
Qt: fix GUI freezes on new blocks and when sending

### DIFF
--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -606,6 +606,7 @@ QModelIndex AddressTableModel::index(int row, int column, const QModelIndex &par
 void AddressTableModel::updateEntry(const QString &address,
         const QString &label, bool isMine, const QString &purpose, int status)
 {
+    labelCache.remove(address);
     // Update address book model from Bitcoin core
     priv->updateEntry(address, label, isMine, purpose, status);
 }
@@ -613,6 +614,7 @@ void AddressTableModel::updateEntry(const QString &address,
 //[firo] AddressTableModel.updateEntry()
 void AddressTableModel::updateEntry(const QString &pubCoin, const QString &isUsed, int status)
 {
+    labelCache.remove(pubCoin);
     // Update stealth address book model from Bitcoin core
     priv->updateEntry(pubCoin, isUsed, status);
 }
@@ -744,30 +746,40 @@ bool AddressTableModel::removeRows(int row, int count, const QModelIndex &parent
  */
 QString AddressTableModel::labelForAddress(const QString &address) const
 {
+    QString label;
     {
-        LOCK(wallet->cs_wallet);
+        // This is called from the transaction list paint path for every
+        // visible row, so it must not block: cs_wallet can be held for a long
+        // time while a block or transaction is being processed. Fall back to
+        // the cached label if the lock is not available; the view repaints
+        // shortly after via updateConfirmations() and picks up fresh data.
+        TRY_LOCK(wallet->cs_wallet, lockWallet);
+        if (!lockWallet)
+            return labelCache.value(address);
+
         CBitcoinAddress address_parsed(address.toStdString());
         if(address_parsed.IsValid()) {
             std::map<CTxDestination, CAddressBookData>::iterator mi = wallet->mapAddressBook.find(address_parsed.Get());
             if (mi != wallet->mapAddressBook.end())
             {
-                return QString::fromStdString(mi->second.name);
+                label = QString::fromStdString(mi->second.name);
             }
         } else if(walletModel->validateSparkAddress(address)) {
             std::map<std::string, CAddressBookData>::iterator mi = wallet->mapSparkAddressBook.find(address.toStdString());
             if(mi != wallet->mapSparkAddressBook.end())
             {
-                return QString::fromStdString(mi->second.name);
+                label = QString::fromStdString(mi->second.name);
             }
         } else if(bip47::CPaymentCode::validate(address.toStdString())) {
             std::map<std::string, CAddressBookData>::iterator mi = wallet->mapRAPAddressBook.find(address.toStdString());
             if(mi != wallet->mapRAPAddressBook.end())
             {
-                return QString::fromStdString(mi->second.name);
+                label = QString::fromStdString(mi->second.name);
             }
         }
     }
-    return QString();
+    labelCache.insert(address, label);
+    return label;
 }
 
 int AddressTableModel::lookupAddress(const QString &address) const

--- a/src/qt/addresstablemodel.h
+++ b/src/qt/addresstablemodel.h
@@ -6,6 +6,7 @@
 #define BITCOIN_QT_ADDRESSTABLEMODEL_H
 
 #include <QAbstractTableModel>
+#include <QHash>
 #include <QStringList>
 
 class AddressTablePriv;
@@ -103,6 +104,11 @@ protected:
 
 private:
     AddressTablePriv *priv;
+
+    /** Cache of address -> label lookups, used to answer labelForAddress()
+     * without blocking when cs_wallet is held by another thread. Only
+     * accessed from the GUI thread. */
+    mutable QHash<QString, QString> labelCache;
 
     /** Notify listeners that data changed. */
     void emitDataChanged(int index);

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -253,8 +253,19 @@ WalletModel::SendCoinsReturn runWalletOperation(std::function<WalletModel::SendC
         QMetaObject::invokeMethod(&waitLoop, &QEventLoop::quit, Qt::QueuedConnection);
     });
     QApplication::setOverrideCursor(Qt::WaitCursor);
+    // Restore the cursor and join the worker even if an exception escapes the
+    // nested event loop: destroying a joinable std::thread would call
+    // std::terminate().
+    struct Cleanup {
+        std::thread& worker;
+        ~Cleanup()
+        {
+            if (worker.joinable())
+                worker.join();
+            QApplication::restoreOverrideCursor();
+        }
+    } cleanup{worker};
     waitLoop.exec(QEventLoop::ExcludeUserInputEvents);
-    QApplication::restoreOverrideCursor();
     worker.join();
     if (exception)
         std::rethrow_exception(exception);
@@ -417,6 +428,7 @@ void SendCoinsDialog::on_sendButton_clicked()
             });
         else {
             processSendCoinsReturn(WalletModel::InvalidAddress);
+            fNewRecipientAllowed = true;
             return;
         }
     } else if ((fAnonymousMode == false) && (sparkAddressCount == 0)) {

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -24,12 +24,18 @@
 #include "wallet/wallet.h"
 #include "overviewpage.h"
 
+#include <QApplication>
+#include <QEventLoop>
 #include <QFontMetrics>
 #include <QMessageBox>
 #include <QScrollBar>
 #include <QSettings>
 #include <QTextDocument>
 #include <QTimer>
+
+#include <exception>
+#include <functional>
+#include <thread>
 
 #define SEND_CONFIRM_DELAY   3
 
@@ -223,6 +229,39 @@ SendCoinsDialog::~SendCoinsDialog()
     delete ui;
 }
 
+namespace {
+/** Run a slow wallet operation on a worker thread while keeping the GUI event
+ * loop spinning, and return its result. Creating a transaction can take
+ * several seconds: Spark spends generate zero-knowledge proofs, and both
+ * creation and commit wait on cs_main/cs_wallet, which are contended while
+ * incoming blocks and transactions are processed. Doing that work directly in
+ * a slot freezes the whole GUI for its duration.
+ *
+ * User input is excluded from event processing while the operation runs, so
+ * the calling code path behaves as if it were synchronous. */
+WalletModel::SendCoinsReturn runWalletOperation(std::function<WalletModel::SendCoinsReturn()> operation)
+{
+    WalletModel::SendCoinsReturn result;
+    std::exception_ptr exception;
+    QEventLoop waitLoop;
+    std::thread worker([&] {
+        try {
+            result = operation();
+        } catch (...) {
+            exception = std::current_exception();
+        }
+        QMetaObject::invokeMethod(&waitLoop, &QEventLoop::quit, Qt::QueuedConnection);
+    });
+    QApplication::setOverrideCursor(Qt::WaitCursor);
+    waitLoop.exec(QEventLoop::ExcludeUserInputEvents);
+    QApplication::restoreOverrideCursor();
+    worker.join();
+    if (exception)
+        std::rethrow_exception(exception);
+    return result;
+}
+}
+
 void SendCoinsDialog::on_sendButton_clicked()
 {
     updateGlobalFeeVariables();
@@ -368,16 +407,22 @@ void SendCoinsDialog::on_sendButton_clicked()
     CAmount totalAmount = 0;
 
     if ((fAnonymousMode == true) && spark::IsSparkAllowed()) {
-        prepareStatus = model->prepareSpendSparkTransaction(currentTransaction, &ctrl);
+        prepareStatus = runWalletOperation([&] {
+            return model->prepareSpendSparkTransaction(currentTransaction, &ctrl);
+        });
     } else if ((fAnonymousMode == false) && (recipients.size() == sparkAddressCount)) {
         if (spark::IsSparkAllowed())
-            prepareStatus = model->prepareMintSparkTransaction(transactions, recipients, wtxAndFees, reservekeys, &ctrl);
+            prepareStatus = runWalletOperation([&] {
+                return model->prepareMintSparkTransaction(transactions, recipients, wtxAndFees, reservekeys, &ctrl);
+            });
         else {
             processSendCoinsReturn(WalletModel::InvalidAddress);
             return;
         }
     } else if ((fAnonymousMode == false) && (sparkAddressCount == 0)) {
-        prepareStatus = model->prepareTransaction(currentTransaction, &ctrl);
+        prepareStatus = runWalletOperation([&] {
+            return model->prepareTransaction(currentTransaction, &ctrl);
+        });
     } else {
         fNewRecipientAllowed = true;
         return;
@@ -602,11 +647,17 @@ void SendCoinsDialog::on_sendButton_clicked()
     WalletModel::SendCoinsReturn sendStatus;
 
     if ((fAnonymousMode == true) && spark::IsSparkAllowed()) {
-        sendStatus = model->spendSparkCoins(currentTransaction);
+        sendStatus = runWalletOperation([&] {
+            return model->spendSparkCoins(currentTransaction);
+        });
     } else if ((fAnonymousMode == false) && (sparkAddressCount == recipients.size()) && spark::IsSparkAllowed()) {
-        sendStatus = model->mintSparkCoins(transactions, wtxAndFees, reservekeys);
+        sendStatus = runWalletOperation([&] {
+            return model->mintSparkCoins(transactions, wtxAndFees, reservekeys);
+        });
     } else if ((fAnonymousMode == false) && (sparkAddressCount == 0)) {
-        sendStatus = model->sendCoins(currentTransaction);
+        sendStatus = runWalletOperation([&] {
+            return model->sendCoins(currentTransaction);
+        });
     } else {
         return;
     }
@@ -655,7 +706,9 @@ void SendCoinsDialog::on_sendButton_clicked()
 
         WalletModelTransaction  secondTransaction(exchangeRecipients);
 
-        prepareStatus = model->prepareTransaction(secondTransaction, &ctrl);
+        prepareStatus = runWalletOperation([&] {
+            return model->prepareTransaction(secondTransaction, &ctrl);
+        });
 
         // process prepareStatus and on error generate message shown to user
         processSendCoinsReturn(prepareStatus,
@@ -666,7 +719,9 @@ void SendCoinsDialog::on_sendButton_clicked()
             return;
         }
 
-        sendStatus = model->sendCoins(secondTransaction);
+        sendStatus = runWalletOperation([&] {
+            return model->sendCoins(secondTransaction);
+        });
         // process sendStatus and on error generate message shown to user
         processSendCoinsReturn(sendStatus);
     }

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -195,9 +195,19 @@ void WalletModel::checkBalanceChanged()
         return;
     }
 
-    CAmount newPrivateBalance, newUnconfirmedPrivateBalance;
-    std::tie(newPrivateBalance, newUnconfirmedPrivateBalance) =
-            getSparkBalance();
+    // getSparkBalance() takes cs_spark_wallet, which can also be held by
+    // Spark wallet background tasks that do not hold cs_main, so it has to be
+    // try-locked as well.
+    CAmount newPrivateBalance = 0, newUnconfirmedPrivateBalance = 0;
+    if (wallet->sparkWallet) {
+        TRY_LOCK(wallet->sparkWallet->cs_spark_wallet, lockSpark);
+        if (!lockSpark) {
+            fForceCheckBalanceChanged = true;
+            return;
+        }
+        std::tie(newPrivateBalance, newUnconfirmedPrivateBalance) =
+                getSparkBalance();
+    }
 
     if (haveWatchOnly())
     {

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -165,6 +165,23 @@ void WalletModel::setClientModel(ClientModel* client_model)
 
 void WalletModel::checkBalanceChanged()
 {
+    // Get the required locks upfront with try-semantics. Balance computation
+    // (including the Spark balance) needs cs_main/cs_wallet/cs_spark_wallet,
+    // which are held for long stretches while a block or transaction is being
+    // processed (Spark proof verification, trial decryption of incoming
+    // coins). Blocking here would freeze the GUI for that whole time, so give
+    // up and retry on the next poll instead.
+    TRY_LOCK(cs_main, lockMain);
+    if (!lockMain) {
+        fForceCheckBalanceChanged = true; // retry on next pollBalanceChanged
+        return;
+    }
+    TRY_LOCK(wallet->cs_wallet, lockWallet);
+    if (!lockWallet) {
+        fForceCheckBalanceChanged = true;
+        return;
+    }
+
     CAmount newBalance = cachedBalance;
     CAmount newUnconfirmedBalance = cachedUnconfirmedBalance;
     CAmount newImmatureBalance = cachedImmatureBalance;
@@ -173,9 +190,10 @@ void WalletModel::checkBalanceChanged()
     CAmount newWatchImmatureBalance = 0;
     CAmount newAnonymizableBalance = cachedAnonymizableBalance;
 
-    if (!wallet->TryGetBalances(newBalance, newUnconfirmedBalance, newImmatureBalance, newAnonymizableBalance))
+    if (!wallet->TryGetBalances(newBalance, newUnconfirmedBalance, newImmatureBalance, newAnonymizableBalance)) {
+        fForceCheckBalanceChanged = true;
         return;
-
+    }
 
     CAmount newPrivateBalance, newUnconfirmedPrivateBalance;
     std::tie(newPrivateBalance, newUnconfirmedPrivateBalance) =
@@ -410,7 +428,9 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(WalletModelTransaction &tran
         }
         Q_EMIT coinsSent(wallet, rcp, transaction_array);
     }
-    checkBalanceChanged(); // update balance immediately, otherwise there could be a short noticeable delay until pollBalanceChanged hits
+    // update balance immediately, otherwise there could be a short noticeable delay until pollBalanceChanged hits.
+    // Queued so that it runs on the GUI thread even when sendCoins is called from a worker thread.
+    QMetaObject::invokeMethod(this, "checkBalanceChanged", Qt::QueuedConnection);
 
     return SendCoinsReturn(OK);
 }
@@ -1454,8 +1474,10 @@ WalletModel::SendCoinsReturn WalletModel::mintSparkCoins(std::vector<WalletModel
         }
     }
 
-    checkBalanceChanged(); // update balance immediately, otherwise there could be a short noticeable delay until pollBalanceChanged hits
-    
+    // update balance immediately, otherwise there could be a short noticeable delay until pollBalanceChanged hits.
+    // Queued so that it runs on the GUI thread even when mintSparkCoins is called from a worker thread.
+    QMetaObject::invokeMethod(this, "checkBalanceChanged", Qt::QueuedConnection);
+
     return SendCoinsReturn(OK);
 }
 
@@ -1508,7 +1530,9 @@ WalletModel::SendCoinsReturn WalletModel::spendSparkCoins(WalletModelTransaction
         }
     }
 
-    checkBalanceChanged(); // update balance immediately, otherwise there could be a short noticeable delay until pollBalanceChanged hits
+    // update balance immediately, otherwise there could be a short noticeable delay until pollBalanceChanged hits.
+    // Queued so that it runs on the GUI thread even when spendSparkCoins is called from a worker thread.
+    QMetaObject::invokeMethod(this, "checkBalanceChanged", Qt::QueuedConnection);
 
     return SendCoinsReturn(OK);
 }


### PR DESCRIPTION
The GUI thread was acquiring cs_main/cs_wallet/cs_spark_wallet with
blocking locks on paths that run on every incoming block or transaction,
while the validation thread holds those locks for long stretches (Spark
batch proof verification in ConnectBlock/AcceptToMemoryPool and
per-output trial decryption in UpdateMintStateFromBlock /
UpdateSpendStateFromBlock). Any repaint or balance poll during that
window stalled the whole GUI. Sending was worse: transaction creation,
including multi-second Spark zero-knowledge proof generation, ran
directly in the send button slot under LOCK2(cs_main, cs_wallet).

Three changes:

- AddressTableModel::labelForAddress() now uses TRY_LOCK with a label
  cache fallback. It is called from TransactionTableModel::data() for
  every visible row on every repaint, so it must never block. The cache
  is invalidated on address book updates and refreshed on every
  successful lookup.

- WalletModel::checkBalanceChanged() try-locks cs_main and cs_wallet up
  front and, on contention, sets fForceCheckBalanceChanged so the next
  poll retries instead of silently dropping the update. Previously it
  called getSparkBalance() and the watch-only getters with blocking
  locks after the try-lock'd TryGetBalances(), which could still stall
  on cs_wallet/cs_spark_wallet mid block-connect.

- SendCoinsDialog now runs prepare*/sendCoins/mintSparkCoins/
  spendSparkCoins on a worker thread while a local event loop keeps the
  GUI repainting (user input excluded, wait cursor shown), so proof
  generation and mempool acceptance no longer freeze the UI. The
  post-commit checkBalanceChanged() calls in WalletModel are queued to
  the GUI thread accordingly.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UERaE4GaDoWGh4dfycVzvP