### PR TITLE
Wallet: Avoid O(N²) wallet scans for Spark outputs to fix slow Firo-QT startup

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -510,7 +510,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog, bool a
 
         // Amount
         if(out.tx->tx->vout[out.i].scriptPubKey.IsSparkSMint()) {
-            nAmount += model->GetJMintCredit(out.tx->tx->vout[out.i]);
+            nAmount += model->GetJMintCredit(out.tx->tx->vout[out.i], *out.tx->tx);
         } else {
             nAmount += out.tx->tx->vout[out.i].nValue;
         }
@@ -734,7 +734,7 @@ void CoinControlDialog::updateView()
         BOOST_FOREACH(const COutput& out, coins.second) {
             CAmount amount;
             if(out.tx->tx->vout[out.i].scriptPubKey.IsSparkSMint()) {
-                amount = model->GetJMintCredit(out.tx->tx->vout[out.i]);
+                amount = model->GetJMintCredit(out.tx->tx->vout[out.i], *out.tx->tx);
             } else {
                 amount = out.tx->tx->vout[out.i].nValue;
             }

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -169,7 +169,7 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
         //
         CAmount nUnmatured = 0;
         BOOST_FOREACH(const CTxOut& txout, wtx.tx->vout)
-            nUnmatured += wallet->GetCredit(txout, ISMINE_ALL);
+            nUnmatured += wallet->GetCredit(txout, *wtx.tx, ISMINE_ALL);
         strHTML += "<b>" + tr("Credit") + ":</b> ";
         if (wtx.IsInMainChain())
             strHTML += BitcoinUnits::formatHtmlWithUnit(unit, nUnmatured)+ " (" + tr("matures in %n more block(s)", "", wtx.GetBlocksToMaturity()) + ")";
@@ -196,7 +196,7 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
         isminetype fAllToMe = ISMINE_SPENDABLE;
         BOOST_FOREACH(const CTxOut& txout, wtx.tx->vout)
         {
-            isminetype mine = wallet->IsMine(txout);
+            isminetype mine = wallet->IsMine(txout, *wtx.tx);
             if(fAllToMe > mine) fAllToMe = mine;
         }
 
@@ -211,7 +211,7 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
             BOOST_FOREACH(const CTxOut& txout, wtx.tx->vout)
             {
                 // Ignore change
-                isminetype toSelf = wallet->IsMine(txout);
+                isminetype toSelf = wallet->IsMine(txout, *wtx.tx);
                 if ((toSelf == ISMINE_SPENDABLE) && (fAllFromMe == ISMINE_SPENDABLE))
                     continue;
                 CSparkOutputTx sparkOutput;
@@ -283,8 +283,8 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
                 if (wallet->IsMine(txin, *wtx.tx))
                     strHTML += "<b>" + tr("Debit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, -wallet->GetDebit(txin, *wtx.tx, ISMINE_ALL)) + "<br>";
             BOOST_FOREACH(const CTxOut& txout, wtx.tx->vout)
-                if (wallet->IsMine(txout))
-                    strHTML += "<b>" + tr("Credit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, wallet->GetCredit(txout, ISMINE_ALL)) + "<br>";
+                if (wallet->IsMine(txout, *wtx.tx))
+                    strHTML += "<b>" + tr("Credit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, wallet->GetCredit(txout, *wtx.tx, ISMINE_ALL)) + "<br>";
         }
     }
 
@@ -378,8 +378,8 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
             if(wallet->IsMine(txin, *wtx.tx))
                 strHTML += "<b>" + tr("Debit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, -wallet->GetDebit(txin, *wtx.tx, ISMINE_ALL)) + "<br>";
         BOOST_FOREACH(const CTxOut& txout, wtx.tx->vout)
-            if(wallet->IsMine(txout))
-                strHTML += "<b>" + tr("Credit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, wallet->GetCredit(txout, ISMINE_ALL)) + "<br>";
+            if(wallet->IsMine(txout, *wtx.tx))
+                strHTML += "<b>" + tr("Credit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, wallet->GetCredit(txout, *wtx.tx, ISMINE_ALL)) + "<br>";
 
         strHTML += "<br><b>" + tr("Transaction") + ":</b><br>";
         strHTML += GUIUtil::HtmlEscape(wtx.tx->ToString(), true);

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -61,7 +61,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
         bool firstAddress = true;
 
         for (const CTxOut& txout : wtx.tx->vout) {
-            isminetype mine = wallet->IsMine(txout);
+            isminetype mine = wallet->IsMine(txout, *wtx.tx);
             if (!mine) {
                 isAllToMe = false;
                 break;
@@ -91,7 +91,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
                 if (wtx.IsChange(txout) || txout.scriptPubKey.IsLelantusJMint()) {
                     continue;
                 }
-                isminetype mine = wallet->IsMine(txout);
+                isminetype mine = wallet->IsMine(txout, *wtx.tx);
 
                 TransactionRecord sub(hash, nTime);
                 CTxDestination address;
@@ -146,7 +146,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
         for(unsigned int i = 0; i < wtx.tx->vout.size(); i++)
         {
             const CTxOut& txout = wtx.tx->vout[i];
-            isminetype mine = wallet->IsMine(txout);
+            isminetype mine = wallet->IsMine(txout, *wtx.tx);
             if (mine)
             {
                 TransactionRecord sub(hash, nTime);
@@ -212,7 +212,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
         isminetype fAllToMe = ISMINE_SPENDABLE;
         BOOST_FOREACH(const CTxOut& txout, wtx.tx->vout)
         {
-            isminetype mine = wallet->IsMine(txout);
+            isminetype mine = wallet->IsMine(txout, *wtx.tx);
             if(mine & ISMINE_WATCH_ONLY) involvesWatchAddress = true;
             if(fAllToMe > mine) fAllToMe = mine;
         }
@@ -271,7 +271,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
                 sub.involvesWatchAddress = involvesWatchAddress;
                 CSparkOutputTx output;
 
-                if(wallet->IsMine(txout))
+                if(wallet->IsMine(txout, *wtx.tx))
                 {
                     // Ignore parts sent to self, as this is usually the change
                     // from a transaction sent back to our own address.

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -809,7 +809,7 @@ void WalletModel::listCoins(std::map<QString, std::vector<COutput> >& mapCoins, 
             if (!isMint) continue;
         }
 
-        if (outpoint.n < out.tx->tx->vout.size() && wallet->IsMine(out.tx->tx->vout[outpoint.n]) == ISMINE_SPENDABLE)
+        if (outpoint.n < out.tx->tx->vout.size() && wallet->IsMine(out.tx->tx->vout[outpoint.n], *out.tx->tx) == ISMINE_SPENDABLE)
             vCoins.push_back(out);
     }
 
@@ -988,8 +988,8 @@ bool WalletModel::rebroadcastTransaction(uint256 hash, CValidationState &state)
     return true;
 }
 
-CAmount WalletModel::GetJMintCredit(const CTxOut& txout) const {
-    return wallet->GetCredit(txout, ISMINE_SPENDABLE);
+CAmount WalletModel::GetJMintCredit(const CTxOut& txout, const CTransaction& tx) const {
+    return wallet->GetCredit(txout, tx, ISMINE_SPENDABLE);
 }
 
 bool WalletModel::isWalletEnabled()

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -988,7 +988,8 @@ bool WalletModel::rebroadcastTransaction(uint256 hash, CValidationState &state)
     return true;
 }
 
-CAmount WalletModel::GetJMintCredit(const CTxOut& txout, const CTransaction& tx) const {
+CAmount WalletModel::GetJMintCredit(const CTxOut& txout, const CTransaction& tx) const
+{
     return wallet->GetCredit(txout, tx, ISMINE_SPENDABLE);
 }
 

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -280,7 +280,7 @@ public:
     bool transactionCanBeRebroadcast(uint256 hash) const;
     bool rebroadcastTransaction(uint256 hash, CValidationState &state);
 
-    CAmount GetJMintCredit(const CTxOut& txout) const;
+    CAmount GetJMintCredit(const CTxOut& txout, const CTransaction& tx) const;
 
 private:
     CWallet *wallet;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -765,18 +765,7 @@ bool CWallet::IsSpent(const uint256 &hash, unsigned int n) const
         } else if (pwalletMain && (script.IsLelantusMint() || script.IsLelantusJMint())) {
            return true;
         } else if (pwalletMain && pwalletMain->sparkWallet && (script.IsSparkMint() || script.IsSparkSMint())) {
-            std::vector<unsigned char> serialContext;
-            for (std::map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it) {
-                const CWalletTx *pcoin = &(*it).second;
-                for (unsigned int i = 0; i < pcoin->tx->vout.size(); i++) {
-                    if (tx->tx->vout[n] == pcoin->tx->vout[i]) {
-                        serialContext = spark::getSerialContext(*pcoin->tx);
-                        break;
-                    }
-                }
-                if (!serialContext.empty())
-                    break;
-            }
+            std::vector<unsigned char> serialContext = spark::getSerialContext(*tx->tx);
 
             spark::Coin coin(spark::Params::get_default());
             try {
@@ -1617,7 +1606,7 @@ isminetype CWallet::IsMine(const CTxOut &txout) const
         // without it in hand, locate the output in the wallet first.
         for (std::map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it) {
             const CWalletTx *pcoin = &(*it).second;
-            for (unsigned int i = 0; i < pcoin->tx->vout.size(); i++) {
+            for (unsigned int i = 0; i < pcoin->tx->vout.size(); ++i) {
                 if (txout == pcoin->tx->vout[i])
                     return IsMine(txout, *pcoin->tx);
             }
@@ -1662,11 +1651,12 @@ CAmount CWallet::GetCredit(const CTxOut& txout, const isminefilter& filter) cons
     if (txout.scriptPubKey.IsSparkSMint()) {
         if (!(filter & ISMINE_SPENDABLE))
             return 0;
+        LOCK(cs_wallet);
         // The Spark serial context is derived from the containing transaction;
         // without it in hand, locate the output in the wallet first.
         for (std::map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it) {
             const CWalletTx *pcoin = &(*it).second;
-            for (unsigned int i = 0; i < pcoin->tx->vout.size(); i++) {
+            for (unsigned int i = 0; i < pcoin->tx->vout.size(); ++i) {
                 if (txout == pcoin->tx->vout[i])
                     return GetCredit(txout, *pcoin->tx, filter);
             }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1169,7 +1169,7 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose)
 
         auto mnList = deterministicMNManager->GetListAtChainTip();
         for(unsigned int i = 0; i < wtx.tx->vout.size(); ++i) {
-            if (IsMine(wtx.tx->vout[i]) && !IsSpent(hash, i)) {
+            if (IsMine(wtx.tx->vout[i], *wtx.tx) && !IsSpent(hash, i)) {
                 setWalletUTXO.insert(COutPoint(hash, i));
                 if (deterministicMNManager->IsProTxWithCollateral(wtx.tx, i) || mnList.HasMNByCollateral(COutPoint(hash, i))) {
                     LockCoin(COutPoint(hash, i));
@@ -1613,20 +1613,27 @@ isminetype CWallet::IsMine(const CTxOut &txout) const
     LOCK(cs_wallet);
 
     if (txout.scriptPubKey.IsSparkMint() || txout.scriptPubKey.IsSparkSMint()) {
-        std::vector<unsigned char> serialContext;
+        // The Spark serial context is derived from the containing transaction;
+        // without it in hand, locate the output in the wallet first.
         for (std::map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it) {
             const CWalletTx *pcoin = &(*it).second;
             for (unsigned int i = 0; i < pcoin->tx->vout.size(); i++) {
-                if (txout == pcoin->tx->vout[i]) {
-                    serialContext = spark::getSerialContext(*pcoin->tx);
-                    break;
-                }
+                if (txout == pcoin->tx->vout[i])
+                    return IsMine(txout, *pcoin->tx);
             }
-
-            if (!serialContext.empty())
-                break;
         }
+        return ISMINE_NO;
+    } else {
+        return ::IsMine(*this, txout.scriptPubKey);
+    }
+}
 
+isminetype CWallet::IsMine(const CTxOut &txout, const CTransaction& tx) const
+{
+    LOCK(cs_wallet);
+
+    if (txout.scriptPubKey.IsSparkMint() || txout.scriptPubKey.IsSparkSMint()) {
+        std::vector<unsigned char> serialContext = spark::getSerialContext(tx);
         if (serialContext.empty())
             return ISMINE_NO;
 
@@ -1655,20 +1662,30 @@ CAmount CWallet::GetCredit(const CTxOut& txout, const isminefilter& filter) cons
     if (txout.scriptPubKey.IsSparkSMint()) {
         if (!(filter & ISMINE_SPENDABLE))
             return 0;
-        std::vector<unsigned char> serialContext;
+        // The Spark serial context is derived from the containing transaction;
+        // without it in hand, locate the output in the wallet first.
         for (std::map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it) {
             const CWalletTx *pcoin = &(*it).second;
             for (unsigned int i = 0; i < pcoin->tx->vout.size(); i++) {
-                if (txout == pcoin->tx->vout[i]) {
-                    serialContext = spark::getSerialContext(*pcoin->tx);
-                    break;
-                }
+                if (txout == pcoin->tx->vout[i])
+                    return GetCredit(txout, *pcoin->tx, filter);
             }
-
-            if (!serialContext.empty())
-                break;
         }
+        return 0;
+    }
 
+    return ((IsMine(txout) & filter) ? txout.nValue : 0);
+}
+
+CAmount CWallet::GetCredit(const CTxOut& txout, const CTransaction& tx, const isminefilter& filter) const
+{
+    if (!MoneyRange(txout.nValue))
+        throw std::runtime_error(std::string(__func__) + ": value out of range");
+
+    if (txout.scriptPubKey.IsSparkSMint()) {
+        if (!(filter & ISMINE_SPENDABLE))
+            return 0;
+        std::vector<unsigned char> serialContext = spark::getSerialContext(tx);
         if (serialContext.empty())
             return 0;
 
@@ -1684,7 +1701,7 @@ CAmount CWallet::GetCredit(const CTxOut& txout, const isminefilter& filter) cons
         return sparkWallet->getMyCoinV(coin);
     }
 
-    return ((IsMine(txout) & filter) ? txout.nValue : 0);
+    return ((IsMine(txout, tx) & filter) ? txout.nValue : 0);
 }
 
 bool CWallet::IsChange(const uint256& tx, const CTxOut &txout) const
@@ -1736,14 +1753,14 @@ bool CWallet::IsMine(const CTransaction& tx) const
                 coin.setSerialContext(serialContext);
                 if(sparkWallet->isMine(coin))
                     return true;
-            } else if (IsMine(txout))
+            } else if (IsMine(txout, tx))
                 return true;
         }
         return false;
     }
 
     BOOST_FOREACH(const CTxOut& txout, tx.vout)
-        if (IsMine(txout))
+        if (IsMine(txout, tx))
             return true;
     return false;
 }
@@ -1791,7 +1808,7 @@ CAmount CWallet::GetCredit(const CTransaction& tx, const isminefilter& filter) c
     CAmount nCredit = 0;
     BOOST_FOREACH(const CTxOut& txout, tx.vout)
     {
-        nCredit += GetCredit(txout, filter);
+        nCredit += GetCredit(txout, tx, filter);
         if (!MoneyRange(nCredit))
             throw std::runtime_error(std::string(__func__) + ": value out of range");
     }
@@ -2081,7 +2098,7 @@ void CWalletTx::GetAmounts(std::list<COutputEntry>& listReceived,
     for (unsigned int i = 0; i < tx->vout.size(); ++i)
     {
         const CTxOut& txout = tx->vout[i];
-        isminetype fIsMine = pwallet->IsMine(txout);
+        isminetype fIsMine = pwallet->IsMine(txout, *tx);
         // Only need to handle txouts if AT LEAST one of these is true:
         //   1) they debit from us (sent)
         //   2) the output is to us (received)
@@ -2113,7 +2130,7 @@ void CWalletTx::GetAmounts(std::list<COutputEntry>& listReceived,
         CAmount nValue;
         if(txout.scriptPubKey.IsSparkSMint()) {
             LOCK(pwalletMain->cs_wallet);
-            nValue = pwallet->GetCredit(txout, ISMINE_SPENDABLE);
+            nValue = pwallet->GetCredit(txout, *tx, ISMINE_SPENDABLE);
         } else {
             nValue = txout.nValue;
         }
@@ -2427,7 +2444,7 @@ CAmount CWalletTx::GetAvailableCredit(bool fUseCache, bool fExcludeLocked) const
 
         if (!pwallet->IsSpent(hashTx, i))
         {
-            nCredit += pwallet->GetCredit(txout, ISMINE_SPENDABLE);
+            nCredit += pwallet->GetCredit(txout, *tx, ISMINE_SPENDABLE);
             if (!MoneyRange(nCredit))
                 throw std::runtime_error("CWalletTx::GetAvailableCredit() : value out of range");
         }
@@ -2474,7 +2491,7 @@ CAmount CWalletTx::GetAvailableWatchOnlyCredit(const bool& fUseCache) const
         if (!pwallet->IsSpent(GetHash(), i))
         {
             const CTxOut &txout = tx->vout[i];
-            nCredit += pwallet->GetCredit(txout, ISMINE_WATCH_ONLY);
+            nCredit += pwallet->GetCredit(txout, *tx, ISMINE_WATCH_ONLY);
             if (!MoneyRange(nCredit))
                 throw std::runtime_error("CWalletTx::GetAvailableCredit() : value out of range");
         }
@@ -2715,7 +2732,7 @@ CAmount CWallet::GetLegacyBalance(const isminefilter& filter, int minDepth, cons
         for (const CTxOut& out : wtx.tx->vout) {
             if (outgoing && IsChange(wtx.tx->GetHash(), out)) {
                 debit -= out.nValue;
-            } else if (IsMine(out) & filter && depth >= minDepth && (!account || *account == GetAccountName(out.scriptPubKey))) {
+            } else if (IsMine(out, *wtx.tx) & filter && depth >= minDepth && (!account || *account == GetAccountName(out.scriptPubKey))) {
                 balance += out.nValue;
             }
         }
@@ -2964,12 +2981,12 @@ void CWallet::AvailableCoins(std::vector <COutput> &vCoins, bool fOnlyConfirmed,
                 }
                 if (!found) continue;
 
-                isminetype mine = IsMine(pcoin->tx->vout[i]);
+                isminetype mine = IsMine(pcoin->tx->vout[i], *pcoin->tx);
 
 
                 if (!(IsSpent(wtxid, i)) && mine != ISMINE_NO &&
                     (!IsLockedCoin((*it).first, i) || nCoinType == CoinType::ONLY_1000) &&
-                    (pcoin->tx->vout[i].nValue > 0 || fIncludeZeroValue || ((pcoin->tx->vout[i].scriptPubKey.IsSparkSMint()) && GetCredit(pcoin->tx->vout[i], ISMINE_SPENDABLE) > 0)) &&
+                    (pcoin->tx->vout[i].nValue > 0 || fIncludeZeroValue || ((pcoin->tx->vout[i].scriptPubKey.IsSparkSMint()) && GetCredit(pcoin->tx->vout[i], *pcoin->tx, ISMINE_SPENDABLE) > 0)) &&
                     (!coinControl || !coinControl->HasSelected() || coinControl->fAllowOtherInputs || coinControl->IsSelected(COutPoint((*it).first, i)))) {
                         vCoins.push_back(COutput(pcoin, i, nDepth,
                                                  ((mine & ISMINE_SPENDABLE) != ISMINE_NO) ||
@@ -4024,7 +4041,7 @@ DBErrors CWallet::LoadWallet(bool& fFirstRunRet)
         LOCK2(cs_main, cs_wallet);
         for (auto& pair : mapWallet) {
             for(unsigned int i = 0; i < pair.second.tx->vout.size(); ++i) {
-                if (IsMine(pair.second.tx->vout[i]) && !IsSpent(pair.first, i)) {
+                if (IsMine(pair.second.tx->vout[i], *pair.second.tx) && !IsSpent(pair.first, i)) {
                     setWalletUTXO.insert(COutPoint(pair.first, i));
                 }
             }
@@ -4049,7 +4066,7 @@ void CWallet::AutoLockMasternodeCollaterals()
     LOCK2(cs_main, cs_wallet);
     for (const auto& pair : mapWallet) {
         for (unsigned int i = 0; i < pair.second.tx->vout.size(); ++i) {
-            if (IsMine(pair.second.tx->vout[i]) && !IsSpent(pair.first, i)) {
+            if (IsMine(pair.second.tx->vout[i], *pair.second.tx) && !IsSpent(pair.first, i)) {
                 if (deterministicMNManager->IsProTxWithCollateral(pair.second.tx, i) || mnList.HasMNByCollateral(COutPoint(pair.first, i))) {
                     LockCoin(COutPoint(pair.first, i));
                 }
@@ -4367,7 +4384,7 @@ std::map<CTxDestination, CAmount> CWallet::GetAddressBalances()
             for (unsigned int i = 0; i < pcoin->tx->vout.size(); i++)
             {
                 CTxDestination addr;
-                if (!IsMine(pcoin->tx->vout[i]))
+                if (!IsMine(pcoin->tx->vout[i], *pcoin->tx))
                     continue;
                 if(!ExtractDestination(pcoin->tx->vout[i].scriptPubKey, addr))
                     continue;
@@ -4431,7 +4448,7 @@ std::set< std::set<CTxDestination> > CWallet::GetAddressGroupings()
 
         // group lone addrs by themselves
         for (unsigned int i = 0; i < pcoin->tx->vout.size(); i++)
-            if (IsMine(pcoin->tx->vout[i]))
+            if (IsMine(pcoin->tx->vout[i], *pcoin->tx))
             {
                 CTxDestination address;
                 if(!ExtractDestination(pcoin->tx->vout[i].scriptPubKey, address))

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1068,7 +1068,13 @@ public:
      */
     CAmount GetDebit(const CTxIn& txin, const CTransaction&tx, const isminefilter& filter) const;
     isminetype IsMine(const CTxOut& txout) const;
+    /** Overload taking the transaction containing txout; avoids scanning the
+     * whole wallet to recover the Spark serial context. */
+    isminetype IsMine(const CTxOut& txout, const CTransaction& tx) const;
     CAmount GetCredit(const CTxOut& txout, const isminefilter& filter) const;
+    /** Overload taking the transaction containing txout; avoids scanning the
+     * whole wallet to recover the Spark serial context. */
+    CAmount GetCredit(const CTxOut& txout, const CTransaction& tx, const isminefilter& filter) const;
     bool IsChange(const uint256& tx, const CTxOut& txout) const;
     CAmount GetChange(const uint256& tx, const CTxOut& txout) const;
     bool IsMine(const CTransaction& tx) const;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1068,12 +1068,25 @@ public:
      */
     CAmount GetDebit(const CTxIn& txin, const CTransaction&tx, const isminefilter& filter) const;
     isminetype IsMine(const CTxOut& txout) const;
-    /** Overload taking the transaction containing txout; avoids scanning the
-     * whole wallet to recover the Spark serial context. */
+    /**
+     * Determine ownership of an output using its containing transaction,
+     * avoiding a wallet-wide scan to recover the Spark serial context.
+     * @param[in] txout   Output to inspect
+     * @param[in] tx      Transaction containing txout
+     * @return Ownership flags for txout
+     * @pre txout is an output of tx
+     */
     isminetype IsMine(const CTxOut& txout, const CTransaction& tx) const;
     CAmount GetCredit(const CTxOut& txout, const isminefilter& filter) const;
-    /** Overload taking the transaction containing txout; avoids scanning the
-     * whole wallet to recover the Spark serial context. */
+    /**
+     * Return the credit of an output using its containing transaction,
+     * avoiding a wallet-wide scan to recover the Spark serial context.
+     * @param[in] txout   Output to inspect
+     * @param[in] tx      Transaction containing txout
+     * @param[in] filter  Ownership filter
+     * @return Credit amount if the output matches the filter, otherwise 0
+     * @pre txout is an output of tx
+     */
     CAmount GetCredit(const CTxOut& txout, const CTransaction& tx, const isminefilter& filter) const;
     bool IsChange(const uint256& tx, const CTxOut& txout) const;
     CAmount GetChange(const uint256& tx, const CTxOut& txout) const;


### PR DESCRIPTION
## PR intention

Reduce Firo-QT startup time and fix the long freeze at "Starting network threads..." before the main window appears.

The splash message is misleading: "Starting network threads..." is the last message painted before init finishes and `initializeResult` constructs `ClientModel`/`WalletModel` synchronously on the GUI thread. `TransactionTablePriv::refreshWallet` then decomposes every wallet transaction under `LOCK2(cs_main, cs_wallet)`, and since the splash spinner is a self-rearming 50 ms timer on that same thread, the splash freezes until model construction completes.

The reason model construction is so slow: `CWallet::IsMine(const CTxOut&)` and `CWallet::GetCredit(const CTxOut&, filter)` recover a Spark output's serial context by linearly scanning **every output of every transaction in `mapWallet`** before doing the trial decryption. They are called per output per transaction during model construction, making it O(N²) in wallet size — minutes of GUI-thread work for wallets with thousands of Spark transactions. The same scans run during `AddToWallet` (rescan/sync), `LoadWallet` (`setWalletUTXO` rebuild at startup), balance computation, `AvailableCoins`, and the coin control dialog.

## Code changes brief

The Spark serial context depends only on the transaction containing the output (`spark::getSerialContext(tx)`), which every hot caller already has in hand — the wallet-wide scan exists only because the helpers receive a bare `CTxOut`.

- Add parent-aware overloads `CWallet::IsMine(const CTxOut&, const CTransaction&)` and `CWallet::GetCredit(const CTxOut&, const CTransaction&, const isminefilter&)` that derive the serial context directly from the containing transaction — the exact pattern `IsMine(const CTransaction&)` already used.
- The old bare-`CTxOut` signatures remain as a fallback: they now locate the containing transaction in the wallet and delegate, so results are unchanged for wallet-known transactions (the only case the scan could ever answer).
- Switch all callers that know the containing transaction: GUI transaction decomposition/description, tx-level `GetCredit`, `GetAmounts`, available/watch-only credit, `GetLegacyBalance`, `AvailableCoins`, address balances/groupings, `AddToWallet`, `LoadWallet`, `AutoLockMasternodeCollaterals`, `listCoins`, and the coin control dialog (`GetJMintCredit` now takes the parent transaction).
- Call sites without the parent transaction in hand (prevout lookups, coin-view debug output) intentionally keep the fallback.

Net effect: O(N²) → O(N) for wallet-wide iteration paths, which removes the frozen splash/late-appearing window and also speeds up balance polling, coin listing, and rescans. No consensus or RPC semantics change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PRhMvsTAUDw51jHJV5pTyZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRhMvsTAUDw51jHJV5pTyZ)_