### PR TITLE
Wallet: Cache Spark coin lookups and show wallet load progress

### DIFF
--- a/src/spark/sparkwallet.cpp
+++ b/src/spark/sparkwallet.cpp
@@ -406,7 +406,7 @@ void CSparkWallet::eraseMint(const uint256& hash, CWalletDB& walletdb) {
     walletdb.EraseSparkMint(hash);
     auto it = coinMeta.find(hash);
     if (it != coinMeta.end()) {
-        removeFromLookups(it->second);
+        removeFromLookups(hash, it->second);
         coinMeta.erase(it);
     }
 }
@@ -420,7 +420,7 @@ void CSparkWallet::addOrUpdateMint(const CSparkMintMeta& mint, const uint256& lT
     }
     auto it = coinMeta.find(lTagHash);
     if (it != coinMeta.end())
-        removeFromLookups(it->second);
+        removeFromLookups(lTagHash, it->second);
     coinMeta[lTagHash] = mint;
     addToLookups(lTagHash, mint);
     walletdb.WriteSparkMint(lTagHash, mint);
@@ -451,7 +451,7 @@ void CSparkWallet::updateMintInMemory(const CSparkMintMeta& mint) {
     LOCK(cs_spark_wallet);
     for (auto& itr : coinMeta) {
         if (itr.second == mint) {
-            removeFromLookups(itr.second);
+            removeFromLookups(itr.first, itr.second);
             coinMeta[itr.first] = mint;
             addToLookups(itr.first, mint);
             break;
@@ -465,10 +465,17 @@ void CSparkWallet::addToLookups(const uint256& lTagHash, const CSparkMintMeta& m
     nonceLookup[mint.GetNonceHash()] = lTagHash;
 }
 
-void CSparkWallet::removeFromLookups(const CSparkMintMeta& mint) {
-    if (mint.coin != spark::Coin())
-        coinLookup.erase(primitives::GetSparkCoinHash(mint.coin));
-    nonceLookup.erase(mint.GetNonceHash());
+void CSparkWallet::removeFromLookups(const uint256& lTagHash, const CSparkMintMeta& mint) {
+    // Only drop entries still owned by this mint, so a colliding entry that
+    // points at a surviving mint is left intact.
+    if (mint.coin != spark::Coin()) {
+        auto coinIt = coinLookup.find(primitives::GetSparkCoinHash(mint.coin));
+        if (coinIt != coinLookup.end() && coinIt->second == lTagHash)
+            coinLookup.erase(coinIt);
+    }
+    auto nonceIt = nonceLookup.find(mint.GetNonceHash());
+    if (nonceIt != nonceLookup.end() && nonceIt->second == lTagHash)
+        nonceLookup.erase(nonceIt);
 }
 
 const CSparkMintMeta* CSparkWallet::findMintMeta(const spark::Coin& coin) const {

--- a/src/spark/sparkwallet.cpp
+++ b/src/spark/sparkwallet.cpp
@@ -18,6 +18,8 @@ const uint32_t DEFAULT_SPARK_NCOUNT = 1;
 
 CSparkWallet::CSparkWallet(const std::string& strWalletFile) {
 
+    uiInterface.InitMessage(_("Loading Spark wallet..."));
+
     CWalletDB walletdb(strWalletFile);
     this->strWalletFile = strWalletFile;
 
@@ -78,7 +80,7 @@ CSparkWallet::CSparkWallet(const std::string& strWalletFile) {
             for (auto& coin : coinMeta) {
                 coin.second.coin.setParams(params);
                 coin.second.coin.setSerialContext(coin.second.serial_context);
-
+                addToLookups(coin.first, coin.second);
             }
         }
 
@@ -393,6 +395,8 @@ void CSparkWallet::clearAllMints(CWalletDB& walletdb) {
     }
 
     coinMeta.clear();
+    coinLookup.clear();
+    nonceLookup.clear();
     lastDiversifier = 0;
     walletdb.writeDiversifier(lastDiversifier);
 }
@@ -400,7 +404,11 @@ void CSparkWallet::clearAllMints(CWalletDB& walletdb) {
 void CSparkWallet::eraseMint(const uint256& hash, CWalletDB& walletdb) {
     LOCK(cs_spark_wallet);
     walletdb.EraseSparkMint(hash);
-    coinMeta.erase(hash);
+    auto it = coinMeta.find(hash);
+    if (it != coinMeta.end()) {
+        removeFromLookups(it->second);
+        coinMeta.erase(it);
+    }
 }
 
 void CSparkWallet::addOrUpdateMint(const CSparkMintMeta& mint, const uint256& lTagHash, CWalletDB& walletdb) {
@@ -410,7 +418,11 @@ void CSparkWallet::addOrUpdateMint(const CSparkMintMeta& mint, const uint256& lT
         lastDiversifier = mint.i;
         walletdb.writeDiversifier(lastDiversifier);
     }
+    auto it = coinMeta.find(lTagHash);
+    if (it != coinMeta.end())
+        removeFromLookups(it->second);
     coinMeta[lTagHash] = mint;
+    addToLookups(lTagHash, mint);
     walletdb.WriteSparkMint(lTagHash, mint);
 }
 
@@ -439,10 +451,42 @@ void CSparkWallet::updateMintInMemory(const CSparkMintMeta& mint) {
     LOCK(cs_spark_wallet);
     for (auto& itr : coinMeta) {
         if (itr.second == mint) {
+            removeFromLookups(itr.second);
             coinMeta[itr.first] = mint;
+            addToLookups(itr.first, mint);
             break;
         }
     }
+}
+
+void CSparkWallet::addToLookups(const uint256& lTagHash, const CSparkMintMeta& mint) {
+    if (mint.coin != spark::Coin())
+        coinLookup[primitives::GetSparkCoinHash(mint.coin)] = lTagHash;
+    nonceLookup[mint.GetNonceHash()] = lTagHash;
+}
+
+void CSparkWallet::removeFromLookups(const CSparkMintMeta& mint) {
+    if (mint.coin != spark::Coin())
+        coinLookup.erase(primitives::GetSparkCoinHash(mint.coin));
+    nonceLookup.erase(mint.GetNonceHash());
+}
+
+const CSparkMintMeta* CSparkWallet::findMintMeta(const spark::Coin& coin) const {
+    auto it = coinLookup.find(primitives::GetSparkCoinHash(coin));
+    if (it == coinLookup.end())
+        return nullptr;
+
+    auto metaIt = coinMeta.find(it->second);
+    if (metaIt == coinMeta.end())
+        return nullptr;
+
+    const CSparkMintMeta& meta = metaIt->second;
+    // Coin equality does not cover the serial context, but identification
+    // depends on it; require both so a hit answers exactly as identify would.
+    if (meta.coin != coin || meta.serial_context != coin.serial_context)
+        return nullptr;
+
+    return &meta;
 }
 
 CSparkMintMeta CSparkWallet::getMintMeta(const uint256& hash) {
@@ -454,15 +498,25 @@ CSparkMintMeta CSparkWallet::getMintMeta(const uint256& hash) {
 
 CSparkMintMeta CSparkWallet::getMintMeta(const secp_primitives::Scalar& nonce) {
     LOCK(cs_spark_wallet);
-    for (const auto& meta : coinMeta) {
-        if (meta.second.k == nonce)
-            return meta.second;
+    auto it = nonceLookup.find(primitives::GetNonceHash(nonce));
+    if (it != nonceLookup.end()) {
+        auto metaIt = coinMeta.find(it->second);
+        if (metaIt != coinMeta.end() && metaIt->second.k == nonce)
+            return metaIt->second;
     }
 
     return CSparkMintMeta();
 }
 
 bool CSparkWallet::getMintMeta(spark::Coin coin, CSparkMintMeta& mintMeta) {
+    {
+        LOCK(cs_spark_wallet);
+        const CSparkMintMeta* meta = findMintMeta(coin);
+        if (meta) {
+            mintMeta = *meta;
+            return true;
+        }
+    }
     spark::IdentifiedCoinData identifiedCoinData;
     try {
         identifiedCoinData = coin.identify(this->viewKey);
@@ -476,6 +530,14 @@ bool CSparkWallet::getMintMeta(spark::Coin coin, CSparkMintMeta& mintMeta) {
 }
 
 bool CSparkWallet::getMintAmount(spark::Coin coin, CAmount& amount) {
+    {
+        LOCK(cs_spark_wallet);
+        const CSparkMintMeta* meta = findMintMeta(coin);
+        if (meta) {
+            amount = meta->v;
+            return true;
+        }
+    }
     spark::IdentifiedCoinData identifiedCoinData;
     try {
         identifiedCoinData = coin.identify(this->viewKey);
@@ -551,6 +613,11 @@ void CSparkWallet::UpdateSpendStateFromBlock(const CBlock& block) {
 }
 
 bool CSparkWallet::isMine(spark::Coin coin) const {
+    {
+        LOCK(cs_spark_wallet);
+        if (findMintMeta(coin))
+            return true;
+    }
     try {
         spark::IdentifiedCoinData identifiedCoinData = coin.identify(this->viewKey);
     } catch (const std::exception &) {
@@ -573,6 +640,12 @@ bool CSparkWallet::isMine(const std::vector<GroupElement>& lTags) const {
 }
 
 CAmount CSparkWallet::getMyCoinV(spark::Coin coin) const {
+    {
+        LOCK(cs_spark_wallet);
+        const CSparkMintMeta* meta = findMintMeta(coin);
+        if (meta)
+            return meta->v;
+    }
     CAmount v(0);
     try {
         spark::IdentifiedCoinData identifiedCoinData = coin.identify(this->viewKey);
@@ -584,6 +657,12 @@ CAmount CSparkWallet::getMyCoinV(spark::Coin coin) const {
 }
 
 bool CSparkWallet::getMyCoinIsChange(spark::Coin coin) const {
+    {
+        LOCK(cs_spark_wallet);
+        const CSparkMintMeta* meta = findMintMeta(coin);
+        if (meta)
+            return isChangeAddress(meta->i);
+    }
     try {
         spark::IdentifiedCoinData identifiedCoinData = coin.identify(this->viewKey);
         return isChangeAddress(identifiedCoinData.i);
@@ -593,6 +672,12 @@ bool CSparkWallet::getMyCoinIsChange(spark::Coin coin) const {
 }
 
 spark::Address CSparkWallet::getMyCoinAddress(spark::Coin coin) {
+    {
+        LOCK(cs_spark_wallet);
+        const CSparkMintMeta* meta = findMintMeta(coin);
+        if (meta)
+            return getAddress(int32_t(meta->i));
+    }
     spark::Address address;
     try {
         spark::IdentifiedCoinData identifiedCoinData = coin.identify(this->viewKey);

--- a/src/spark/sparkwallet.cpp
+++ b/src/spark/sparkwallet.cpp
@@ -10,7 +10,9 @@
 #include "state.h"
 #include "sparkname.h"
 #include "../chain.h"
+#include "../init.h"
 #include <boost/format.hpp>
+#include <algorithm>
 #include <string>
 #include <thread>
 
@@ -88,6 +90,19 @@ CSparkWallet::CSparkWallet(const std::string& strWalletFile) {
 
     unsigned nThreads = std::thread::hardware_concurrency();
     threadPool = new ParallelOpThreadPool<void>(static_cast<std::size_t>(nThreads));
+
+    fCacheAudit = GetBoolArg("-sparkcacheverify", false);
+
+    // The lookup indexes answer ownership and value queries from the recorded
+    // metadata without re-running identification, so verify the records in
+    // the background and evict the fast-path entries of any that fail.
+    bool fHaveCachedCoins;
+    {
+        LOCK(cs_spark_wallet);
+        fHaveCachedCoins = !coinMeta.empty();
+    }
+    if (fHaveCachedCoins)
+        ((ParallelOpThreadPool<void>*)threadPool)->PostTask([this]() { verifyCachedCoins(); });
 
     if (fWalletJustUnlocked)
         pwalletMain->Lock();
@@ -493,7 +508,102 @@ const CSparkMintMeta* CSparkWallet::findMintMeta(const spark::Coin& coin) const 
     if (meta.coin != coin || meta.serial_context != coin.serial_context)
         return nullptr;
 
+    if (fCacheAudit) {
+        // Audit mode: reject the hit unless identification confirms the record
+        try {
+            spark::Coin coinCopy = coin;
+            spark::IdentifiedCoinData data = coinCopy.identify(viewKey);
+            if (data.k != meta.k || data.v != meta.v || data.i != meta.i || data.d != meta.d) {
+                LogPrintf("CSparkWallet::%s: audit: cached mint %s diverges from identification\n", __func__, it->second.GetHex());
+                return nullptr;
+            }
+        } catch (const std::exception&) {
+            LogPrintf("CSparkWallet::%s: audit: cached mint %s failed identification\n", __func__, it->second.GetHex());
+            return nullptr;
+        }
+    }
+
     return &meta;
+}
+
+size_t CSparkWallet::verifyCachedCoins() {
+    std::vector<std::pair<uint256, CSparkMintMeta>> snapshot;
+    {
+        LOCK(cs_spark_wallet);
+        snapshot.reserve(coinMeta.size());
+        for (const auto& it : coinMeta) {
+            if (it.second.coin == spark::Coin())
+                continue;
+            // only records that still hold a fast-path entry need verifying
+            auto coinIt = coinLookup.find(primitives::GetSparkCoinHash(it.second.coin));
+            bool fIndexed = coinIt != coinLookup.end() && coinIt->second == it.first;
+            if (!fIndexed) {
+                auto nonceIt = nonceLookup.find(it.second.GetNonceHash());
+                fIndexed = nonceIt != nonceLookup.end() && nonceIt->second == it.first;
+            }
+            if (fIndexed)
+                snapshot.push_back(it);
+        }
+    }
+    // records that unspent balances display are the ones to confirm first
+    std::stable_partition(snapshot.begin(), snapshot.end(),
+                          [](const std::pair<uint256, CSparkMintMeta>& entry) { return !entry.second.isUsed; });
+
+    size_t evicted = 0;
+    for (const auto& entry : snapshot) {
+        if (ShutdownRequested() || (threadPool && ((ParallelOpThreadPool<void>*)threadPool)->IsPoolShutdown()))
+            break;
+
+        const CSparkMintMeta& meta = entry.second;
+        bool fValid = false;
+        try {
+            spark::Coin coin = meta.coin;
+            spark::IdentifiedCoinData data = coin.identify(viewKey);
+            fValid = data.k == meta.k && data.v == meta.v && data.i == meta.i && data.d == meta.d;
+        } catch (const std::exception&) {
+            fValid = false;
+        }
+
+        if (!fValid) {
+            LOCK(cs_spark_wallet);
+            auto it = coinMeta.find(entry.first);
+            // evict only if the record has not changed since the snapshot
+            if (it != coinMeta.end() && it->second == meta && it->second.coin == meta.coin) {
+                removeFromLookups(entry.first, it->second);
+                ++evicted;
+                LogPrintf("CSparkWallet::%s: cached mint %s failed identification, lookup entries evicted\n", __func__, entry.first.GetHex());
+            }
+        }
+    }
+
+    if (evicted > 0)
+        LogPrintf("CSparkWallet::%s: verified %d cached mints, evicted %d from lookup indexes\n", __func__, snapshot.size(), evicted);
+    return evicted;
+}
+
+bool CSparkWallet::validateLookupIndexes() const {
+    LOCK(cs_spark_wallet);
+    for (const auto& entry : coinLookup) {
+        auto it = coinMeta.find(entry.second);
+        if (it == coinMeta.end())
+            return false;
+        if (primitives::GetSparkCoinHash(it->second.coin) != entry.first)
+            return false;
+    }
+    for (const auto& entry : nonceLookup) {
+        auto it = coinMeta.find(entry.second);
+        if (it == coinMeta.end())
+            return false;
+        if (it->second.GetNonceHash() != entry.first)
+            return false;
+    }
+    for (const auto& entry : coinMeta) {
+        if (entry.second.coin != spark::Coin() && !coinLookup.count(primitives::GetSparkCoinHash(entry.second.coin)))
+            return false;
+        if (!nonceLookup.count(entry.second.GetNonceHash()))
+            return false;
+    }
+    return true;
 }
 
 CSparkMintMeta CSparkWallet::getMintMeta(const uint256& hash) {

--- a/src/spark/sparkwallet.h
+++ b/src/spark/sparkwallet.h
@@ -109,6 +109,18 @@ public:
     // get the vector of mint metadata for a single address
     std::vector<CSparkMintMeta> listAddressCoins(const int32_t& i, bool fUnusedOnly = false);
 
+    /**
+     * Re-run identification on every cached mint and evict the lookup index
+     * entries of records the cryptography does not confirm, so queries on
+     * them fall back to full identification instead of trusting the record.
+     * Unspent records are verified first. Runs on the thread pool after the
+     * constructor loads a non-empty wallet; stops early on shutdown.
+     * @return number of records evicted from the lookup indexes
+     */
+    size_t verifyCachedCoins();
+    // check that the lookup indexes and coinMeta describe each other exactly
+    bool validateLookupIndexes() const;
+
 
     // generate recipient data for mint transaction,
     static std::vector<CRecipient> CreateSparkMintRecipients(
@@ -182,6 +194,10 @@ private:
     // wherever coinMeta is mutated.
     std::unordered_map<uint256, uint256> coinLookup;  // GetSparkCoinHash(meta.coin) -> lTagHash
     std::unordered_map<uint256, uint256> nonceLookup; // GetNonceHash(meta.k) -> lTagHash
+
+    // when true (-sparkcacheverify), every lookup index hit is cross-checked
+    // against identification and rejected on divergence
+    bool fCacheAudit{false};
 
     void addToLookups(const uint256& lTagHash, const CSparkMintMeta& mint);
     void removeFromLookups(const uint256& lTagHash, const CSparkMintMeta& mint);

--- a/src/spark/sparkwallet.h
+++ b/src/spark/sparkwallet.h
@@ -176,6 +176,23 @@ private:
     // map lTagHash to coin meta
     std::unordered_map<uint256, CSparkMintMeta> coinMeta;
 
+    // Lookup indexes into coinMeta (values are its lTagHash keys), so that
+    // wallet-known coins are resolved by hash lookup instead of trial
+    // decryption or a linear scan. Guarded by cs_spark_wallet and maintained
+    // wherever coinMeta is mutated.
+    std::unordered_map<uint256, uint256> coinLookup;  // GetSparkCoinHash(meta.coin) -> lTagHash
+    std::unordered_map<uint256, uint256> nonceLookup; // GetNonceHash(meta.k) -> lTagHash
+
+    void addToLookups(const uint256& lTagHash, const CSparkMintMeta& mint);
+    void removeFromLookups(const CSparkMintMeta& mint);
+    /**
+     * Return the recorded meta for a wallet-known coin, or nullptr.
+     * A non-null result requires full coin equality plus an equal serial
+     * context, so the answer matches what identification would produce.
+     * @pre cs_spark_wallet is held; the pointer is valid only under it
+     */
+    const CSparkMintMeta* findMintMeta(const spark::Coin& coin) const;
+
     void* threadPool;
 };
 

--- a/src/spark/sparkwallet.h
+++ b/src/spark/sparkwallet.h
@@ -184,7 +184,7 @@ private:
     std::unordered_map<uint256, uint256> nonceLookup; // GetNonceHash(meta.k) -> lTagHash
 
     void addToLookups(const uint256& lTagHash, const CSparkMintMeta& mint);
-    void removeFromLookups(const CSparkMintMeta& mint);
+    void removeFromLookups(const uint256& lTagHash, const CSparkMintMeta& mint);
     /**
      * Return the recorded meta for a wallet-known coin, or nullptr.
      * A non-null result requires full coin equality plus an equal serial

--- a/src/test/spark_tests.cpp
+++ b/src/test/spark_tests.cpp
@@ -688,6 +688,87 @@ BOOST_AUTO_TEST_CASE(coingroup)
     sparkState->Reset();
 }
 
+BOOST_AUTO_TEST_CASE(wallet_lookup_indexes)
+{
+    auto params = Params::get_default();
+    CSparkWallet* wallet = pwalletMain->sparkWallet.get();
+    CWalletDB walletdb(pwalletMain->strWalletFile);
+
+    // Build a meta for a coin generated from foreign keys: trial decryption
+    // with the wallet's view key can never identify it, so any positive
+    // answer below must come from the lookup indexes, not the EC fallback.
+    const SpendKey spendKey(params);
+    const FullViewKey fullViewKey(spendKey);
+    const IncomingViewKey incomingViewKey(fullViewKey);
+    const Address address(incomingViewKey, 1);
+
+    CSparkMintMeta meta;
+    meta.nHeight = 1;
+    meta.nId = 1;
+    meta.isUsed = false;
+    meta.txid = uint256();
+    meta.i = 1;
+    meta.d = address.get_d();
+    meta.v = 7 * COIN;
+    meta.k.randomize();
+    meta.memo = "lookup test";
+    meta.serial_context = random_char_vector();
+    meta.type = COIN_TYPE_MINT;
+    meta.coin = Coin(params, meta.type, meta.k, address, meta.v, meta.memo, meta.serial_context);
+
+    const uint256 lTagHash = uint256S("0x1");
+
+    // Unknown coin: both the coin index and identification miss
+    BOOST_CHECK(!wallet->isMine(meta.coin));
+    BOOST_CHECK(wallet->getMintMeta(meta.k) == CSparkMintMeta());
+
+    wallet->addOrUpdateMint(meta, lTagHash, walletdb);
+
+    // Coin index hits
+    BOOST_CHECK(wallet->isMine(meta.coin));
+    BOOST_CHECK_EQUAL(wallet->getMyCoinV(meta.coin), CAmount(meta.v));
+    CAmount amount(0);
+    BOOST_CHECK(wallet->getMintAmount(meta.coin, amount));
+    BOOST_CHECK_EQUAL(amount, CAmount(meta.v));
+    CSparkMintMeta byCoin;
+    BOOST_CHECK(wallet->getMintMeta(meta.coin, byCoin));
+    BOOST_CHECK(byCoin == meta);
+
+    // Nonce index hits
+    BOOST_CHECK(wallet->getMintMeta(meta.k) == meta);
+    BOOST_CHECK_EQUAL(wallet->getMintMeta(meta.k).v, meta.v);
+    BOOST_CHECK(wallet->getMintMeta(meta.k).serial_context == meta.serial_context);
+    Scalar otherNonce;
+    otherNonce.randomize();
+    BOOST_CHECK(wallet->getMintMeta(otherNonce) == CSparkMintMeta());
+
+    // Same coin under a different serial context must not hit: coin equality
+    // does not cover the serial context, but identification depends on it
+    Coin altered = meta.coin;
+    altered.setSerialContext(random_char_vector());
+    BOOST_CHECK(!wallet->isMine(altered));
+
+    // Indexes follow an in-memory update
+    CSparkMintMeta updated = meta;
+    updated.isUsed = true;
+    wallet->updateMintInMemory(updated);
+    BOOST_CHECK(wallet->getMintMeta(meta.k).isUsed);
+    BOOST_CHECK(wallet->isMine(meta.coin));
+
+    // Indexes drop the entry on erase
+    wallet->eraseMint(lTagHash, walletdb);
+    BOOST_CHECK(!wallet->isMine(meta.coin));
+    BOOST_CHECK(wallet->getMintMeta(meta.k) == CSparkMintMeta());
+    BOOST_CHECK(!wallet->getMintAmount(meta.coin, amount));
+
+    // Re-add, then clearAllMints empties the indexes
+    wallet->addOrUpdateMint(meta, lTagHash, walletdb);
+    BOOST_CHECK(wallet->isMine(meta.coin));
+    wallet->clearAllMints(walletdb);
+    BOOST_CHECK(!wallet->isMine(meta.coin));
+    BOOST_CHECK(wallet->getMintMeta(meta.k) == CSparkMintMeta());
+}
+
 } // end of namespace spark
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/spark_tests.cpp
+++ b/src/test/spark_tests.cpp
@@ -721,8 +721,10 @@ BOOST_AUTO_TEST_CASE(wallet_lookup_indexes)
     // Unknown coin: both the coin index and identification miss
     BOOST_CHECK(!wallet->isMine(meta.coin));
     BOOST_CHECK(wallet->getMintMeta(meta.k) == CSparkMintMeta());
+    BOOST_CHECK(wallet->validateLookupIndexes());
 
     wallet->addOrUpdateMint(meta, lTagHash, walletdb);
+    BOOST_CHECK(wallet->validateLookupIndexes());
 
     // Coin index hits
     BOOST_CHECK(wallet->isMine(meta.coin));
@@ -754,12 +756,14 @@ BOOST_AUTO_TEST_CASE(wallet_lookup_indexes)
     wallet->updateMintInMemory(updated);
     BOOST_CHECK(wallet->getMintMeta(meta.k).isUsed);
     BOOST_CHECK(wallet->isMine(meta.coin));
+    BOOST_CHECK(wallet->validateLookupIndexes());
 
     // Indexes drop the entry on erase
     wallet->eraseMint(lTagHash, walletdb);
     BOOST_CHECK(!wallet->isMine(meta.coin));
     BOOST_CHECK(wallet->getMintMeta(meta.k) == CSparkMintMeta());
     BOOST_CHECK(!wallet->getMintAmount(meta.coin, amount));
+    BOOST_CHECK(wallet->validateLookupIndexes());
 
     // Re-add, then clearAllMints empties the indexes
     wallet->addOrUpdateMint(meta, lTagHash, walletdb);
@@ -767,6 +771,76 @@ BOOST_AUTO_TEST_CASE(wallet_lookup_indexes)
     wallet->clearAllMints(walletdb);
     BOOST_CHECK(!wallet->isMine(meta.coin));
     BOOST_CHECK(wallet->getMintMeta(meta.k) == CSparkMintMeta());
+    BOOST_CHECK(wallet->validateLookupIndexes());
+}
+
+BOOST_AUTO_TEST_CASE(wallet_cache_verification)
+{
+    auto params = Params::get_default();
+    CSparkWallet* wallet = pwalletMain->sparkWallet.get();
+    CWalletDB walletdb(pwalletMain->strWalletFile);
+
+    // A record whose coin was built from the wallet's own keys, so
+    // identification confirms it
+    const uint64_t goodI = 5;
+    const Address goodAddress = wallet->getAddress(int32_t(goodI));
+    CSparkMintMeta good;
+    good.nHeight = 1;
+    good.nId = 1;
+    good.isUsed = false;
+    good.txid = uint256();
+    good.i = goodI;
+    good.d = goodAddress.get_d();
+    good.v = 3 * COIN;
+    good.k.randomize();
+    good.memo = "good";
+    good.serial_context = random_char_vector();
+    good.type = COIN_TYPE_MINT;
+    good.coin = Coin(params, good.type, good.k, goodAddress, good.v, good.memo, good.serial_context);
+    const uint256 goodTag = uint256S("0x10");
+
+    // A record whose coin was built from foreign keys, standing in for a
+    // corrupt or tampered wallet record that identification rejects
+    const SpendKey foreignSpend(params);
+    const FullViewKey foreignFull(foreignSpend);
+    const IncomingViewKey foreignView(foreignFull);
+    const Address foreignAddress(foreignView, 1);
+    CSparkMintMeta bad;
+    bad.nHeight = 1;
+    bad.nId = 1;
+    bad.isUsed = false;
+    bad.txid = uint256();
+    bad.i = 1;
+    bad.d = foreignAddress.get_d();
+    bad.v = 9 * COIN;
+    bad.k.randomize();
+    bad.memo = "bad";
+    bad.serial_context = random_char_vector();
+    bad.type = COIN_TYPE_MINT;
+    bad.coin = Coin(params, bad.type, bad.k, foreignAddress, bad.v, bad.memo, bad.serial_context);
+    const uint256 badTag = uint256S("0x20");
+
+    wallet->addOrUpdateMint(good, goodTag, walletdb);
+    wallet->addOrUpdateMint(bad, badTag, walletdb);
+    BOOST_CHECK(wallet->isMine(good.coin));
+    BOOST_CHECK(wallet->isMine(bad.coin));
+    BOOST_CHECK(wallet->validateLookupIndexes());
+
+    // The sweep confirms the good record and evicts only the bad one
+    BOOST_CHECK_EQUAL(wallet->verifyCachedCoins(), 1u);
+    BOOST_CHECK(wallet->isMine(good.coin));
+    BOOST_CHECK(wallet->getMintMeta(good.k) == good);
+    BOOST_CHECK(!wallet->isMine(bad.coin));
+    BOOST_CHECK(wallet->getMintMeta(bad.k) == CSparkMintMeta());
+
+    // Only the fast path was evicted; the record itself remains
+    BOOST_CHECK(wallet->getMintMeta(badTag) == bad);
+
+    // A second sweep has nothing left to evict
+    BOOST_CHECK_EQUAL(wallet->verifyCachedCoins(), 0u);
+
+    wallet->clearAllMints(walletdb);
+    BOOST_CHECK(wallet->validateLookupIndexes());
 }
 
 } // end of namespace spark

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -693,6 +693,7 @@ DBErrors CWalletDB::LoadWallet(CWallet* pwallet)
     CWalletScanState wss;
     bool fNoncriticalErrors = false;
     DBErrors result = DB_LOAD_OK;
+    unsigned int nLoadedTxs = 0;
 
     LOCK2(cs_main, pwallet->cs_wallet);
     try {
@@ -745,6 +746,10 @@ DBErrors CWalletDB::LoadWallet(CWallet* pwallet)
             }
             if (!strErr.empty())
                 LogPrintf("%s\n", strErr);
+
+            // Keep the splash screen alive while large wallets load
+            if (strType == "tx" && ++nLoadedTxs % 1000 == 0)
+                uiInterface.InitMessage(strprintf(_("Loading wallet... (%d transactions)"), nLoadedTxs));
         }
         pcursor->close();
     }

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -729,7 +729,8 @@ DBErrors CWalletDB::LoadWallet(CWallet* pwallet)
 
             // Try to be tolerant of single corrupt records:
             std::string strType, strErr;
-            if (!ReadKeyValue(pwallet, ssKey, ssValue, wss, strType, strErr))
+            bool fReadOK = ReadKeyValue(pwallet, ssKey, ssValue, wss, strType, strErr);
+            if (!fReadOK)
             {
                 // losing keys is considered a catastrophic error, anything else
                 // we assume the user can live with:
@@ -748,7 +749,7 @@ DBErrors CWalletDB::LoadWallet(CWallet* pwallet)
                 LogPrintf("%s\n", strErr);
 
             // Keep the splash screen alive while large wallets load
-            if (strType == "tx" && ++nLoadedTxs % 1000 == 0)
+            if (fReadOK && strType == "tx" && ++nLoadedTxs % 1000 == 0)
                 uiInterface.InitMessage(strprintf(_("Loading wallet... (%d transactions)"), nLoadedTxs));
         }
         pcursor->close();


### PR DESCRIPTION
## PR intention

Follow-up to #1885, targeting the next startup bottleneck: the long, opaque stall at "Loading wallet...".

Two costs dominate that phase for wallets with many Spark coins:

1. `CSparkWallet::isMine`, `getMyCoinV`, `getMintAmount`, `getMyCoinIsChange`, `getMyCoinAddress`, and `getMintMeta(coin)` run a full EC trial decryption (`coin.identify`) on **every call**, even though every wallet-known coin is already recorded in the in-memory `coinMeta` map (loaded from the wallet DB at startup). These are called per output during wallet load, balance computation, and coin listing.
2. `getMintMeta(nonce)` **linearly scans** `coinMeta` comparing scalars. Since `IsSpent` goes through it per Spark output, wallet-wide loops were still O(outputs × coins).

On top of that, the splash message never updates during the whole phase, so users see a frozen "Loading wallet..." with no sign of life.

## Code changes brief

**Two lookup indexes into `coinMeta`** (values are its `lTagHash` keys), guarded by the existing `cs_spark_wallet` and maintained at every `coinMeta` mutation site — constructor bulk load, `addOrUpdateMint`, `eraseMint`, `clearAllMints`, `updateMintInMemory`; all other mutation paths funnel through these:

- **`coinLookup`: coin hash → lTagHash.** Consulted before trial decryption. A hit requires **full coin equality plus an equal serial context** (coin equality alone does not cover the serial context, which identification depends on). Since coins only enter `coinMeta` after a successful `identify()` at recording time, and `identify()` is deterministic in (coin, serial context, view key), a hit can only return exactly what the cryptography would — the EC path remains as fallback for unknown coins, so a cache miss degrades to current behavior, never to a wrong answer.
- **`nonceLookup`: nonce hash → lTagHash**, replacing the linear scan in `getMintMeta(nonce)`, with a nonce equality check on the hit to guard against hash collisions.

This is the same pattern the wallet already uses for spend-side ownership: `isMine(lTags)` has always been a pure `coinMeta` lookup, and all balances (`getAvailableBalance`, coin selection, `listunspentsparkmints`) already trust `coinMeta` as the source of truth.

**Progress reporting** while the wallet loads, using the splash screen's existing `InitMessage` support: a transaction count is emitted every 1000 tx records read from the wallet database ("Loading wallet... (N transactions)"), and a message marks the Spark wallet loading stage.

**Cache verification hardening** (added during review): answering these queries from recorded metadata shifts trust from the cryptography to wallet.dat integrity, so verification is restored without restoring its cost:

- A **background sweep** posted from the constructor re-runs `identify()` on every indexed record (unspent records first, early-out on shutdown) and evicts the fast-path entries of any record the cryptography does not confirm, with a log line per eviction. Queries on evicted records fall back to full identification; the record itself is untouched.
- **`-sparkcacheverify`** (default off) additionally cross-checks every index hit against identification at query time and rejects divergent hits.
- **`validateLookupIndexes()`** checks the structural invariant between `coinMeta` and the indexes.

**Unit tests** (`spark_tests.cpp`): `wallet_lookup_indexes` registers a mint meta built from foreign keys — trial decryption can never identify it, so every positive answer must come from the indexes, making maintenance bugs visible instead of masked by the EC fallback — and covers add/hit (by coin and nonce), the serial-context mismatch guard, in-memory update, erase, and clear, asserting the structural invariant after every mutation. `wallet_cache_verification` covers the sweep: the foreign-key record is evicted while a wallet-own record survives, and only the fast path is dropped.

No database format changes — the indexes are in-memory and rebuilt from `coinMeta` at construction. No consensus, RPC, or spend-building changes.

Combined with #1885 this removes all remaining per-coin EC work and quadratic scans from the startup path; "Loading wallet..." should collapse to roughly DB I/O time and visibly count up while it runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PRhMvsTAUDw51jHJV5pTyZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRhMvsTAUDw51jHJV5pTyZ)_