### PR TITLE
Wallet: Fix deadlock between walletpassphrase and the lockwallet relock timer

### DIFF
--- a/qa/rpc-tests/wallet-encryption.py
+++ b/qa/rpc-tests/wallet-encryption.py
@@ -64,6 +64,11 @@ class WalletEncryptionTest(BitcoinTestFramework):
         assert_raises_jsonrpc(-1, "walletpassphrasechange <oldpassphrase> <newpassphrase>\nChanges the wallet passphrase from <oldpassphrase> to <newpassphrase>.",
             self.nodes[0].walletpassphrasechange, '', 'ff')
 
+        # Check that a negative timeout is rejected without unlocking the wallet
+        assert_raises_jsonrpc(-8, "Timeout cannot be negative.", self.nodes[0].walletpassphrase, passphrase, -10)
+        otp = self.get_otp(address)
+        assert_raises_jsonrpc(-13, "Please enter the wallet passphrase with walletpassphrase first", self.nodes[0].dumpprivkey, address, otp)
+
         # Check that walletpassphrase works
         self.nodes[0].walletpassphrase(passphrase, 2)
         otp = self.get_otp(address)

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -34,7 +34,11 @@ static std::string rpcWarmupStatus("RPC server started");
 static CCriticalSection cs_rpcWarmup;
 /* Timer-creating functions */
 static RPCTimerInterface* timerInterface = NULL;
-/* Map of name to timer. */
+/* Map of name to timer, and the lock protecting it. Callers may run on any of
+ * the RPC worker threads, so every access has to be serialized. The lock is
+ * held while a timer is destroyed, which blocks until a running timer callback
+ * has returned, so no timer callback may acquire it. */
+static CCriticalSection cs_deadlineTimers;
 static std::map<std::string, std::unique_ptr<RPCTimerBase> > deadlineTimers;
 
 static struct CRPCSignals
@@ -408,7 +412,10 @@ void InterruptRPC()
 void StopRPC()
 {
     LogPrint("rpc", "Stopping RPC\n");
-    deadlineTimers.clear();
+    {
+        LOCK(cs_deadlineTimers);
+        deadlineTimers.clear();
+    }
     DeleteAuthCookie();
     g_rpcSignals.Stopped();
 }
@@ -618,6 +625,7 @@ void RPCRunLater(const std::string& name, boost::function<void(void)> func, int6
 {
     if (!timerInterface)
         throw JSONRPCError(RPC_INTERNAL_ERROR, "No timer handler registered for RPC");
+    LOCK(cs_deadlineTimers);
     deadlineTimers.erase(name);
     LogPrint("rpc", "queue run of timer %s in %i seconds (using %s)\n", name, nSeconds, timerInterface->Name());
     deadlineTimers.emplace(name, std::unique_ptr<RPCTimerBase>(timerInterface->NewTimer(func, nSeconds*1000)));

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3035,6 +3035,18 @@ UniValue walletpassphrase(const JSONRPCRequest& request)
         );
     }
 
+    // Prevent concurrent walletpassphrase calls for the same wallet. Without
+    // this, two overlapping calls can update nRelockTime and schedule the
+    // relock timer in opposite orders, so the slower call installs the last
+    // timer while the faster call owns nRelockTime. The stale callback then
+    // does nothing (see LockWallet) and no timer is left, i.e. the wallet stays
+    // unlocked past the requested timeout.
+    //
+    // This has to be a separate lock rather than cs_wallet, because it is held
+    // across RPCRunLater() below, which blocks on the relock callback, which in
+    // turn takes cs_wallet.
+    LOCK(pwallet->cs_unlock);
+
     int64_t nSleepTime;
     int64_t nRelockTime;
     {
@@ -3071,14 +3083,15 @@ UniValue walletpassphrase(const JSONRPCRequest& request)
         nRelockTime = pwallet->nRelockTime;
     }
 
-    // Schedule the relock *after* releasing cs_wallet. RPCRunLater() erases any
-    // previously scheduled lockwallet timer, and destroying a libevent timer
-    // blocks until that timer's callback has finished executing. When the
-    // callback (LockWallet) happens to be running at that moment it is itself
-    // waiting for cs_wallet, so holding the lock across this call deadlocks the
-    // RPC worker against the HTTP event loop thread. Because the RPC worker also
-    // holds cs_main, every other thread that needs cs_main then piles up behind
-    // it and the whole node stops making progress.
+    // Schedule the relock *after* releasing cs_wallet, but still under cs_unlock.
+    // RPCRunLater() erases any previously scheduled lockwallet timer, and
+    // destroying a libevent timer blocks until that timer's callback has finished
+    // executing. When the callback (LockWallet) happens to be running at that
+    // moment it is itself waiting for cs_wallet, so holding the lock across this
+    // call deadlocks the RPC worker against the HTTP event loop thread. Because
+    // the RPC worker also holds cs_main, every other thread that needs cs_main
+    // then piles up behind it and the whole node stops making progress.
+    AssertLockNotHeld(pwallet->cs_wallet);
     RPCRunLater(strprintf("lockwallet(%s)", pwallet->strWalletFile), boost::bind(LockWallet, pwallet, nRelockTime), nSleepTime);
 
     return NullUniValue;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3065,6 +3065,18 @@ UniValue walletpassphrase(const JSONRPCRequest& request)
         // Alternately, find a way to make request.params[0] mlock()'d to begin with.
         strWalletPass = request.params[0].get_str().c_str();
 
+        nSleepTime = request.params[1].get_int64();
+        // Timeout cannot be negative, otherwise it will relock immediately
+        if (nSleepTime < 0) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Timeout cannot be negative.");
+        }
+        // Clamp the timeout so GetTime() + nSleepTime cannot overflow
+        // nRelockTime (same bound as upstream Bitcoin Core's MAX_SLEEP_TIME)
+        constexpr int64_t MAX_SLEEP_TIME = 100000000;
+        if (nSleepTime > MAX_SLEEP_TIME) {
+            nSleepTime = MAX_SLEEP_TIME;
+        }
+
         if (strWalletPass.length() > 0)
         {
             if (!pwallet->Unlock(strWalletPass)) {
@@ -3078,7 +3090,6 @@ UniValue walletpassphrase(const JSONRPCRequest& request)
 
         pwallet->TopUpKeyPool();
 
-        nSleepTime = request.params[1].get_int64();
         pwallet->nRelockTime = GetTime() + nSleepTime;
         nRelockTime = pwallet->nRelockTime;
     }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2995,9 +2995,14 @@ UniValue keypoolrefill(const JSONRPCRequest& request)
 }
 
 
-static void LockWallet(CWallet* pWallet)
+static void LockWallet(CWallet* pWallet, int64_t nRelockTime)
 {
     LOCK(pWallet->cs_wallet);
+    // Skip if this is not the most recent relock callback. walletpassphrase()
+    // may have been called again in the meantime (extending the timeout), or
+    // walletlock() may have already locked the wallet and reset nRelockTime.
+    if (pWallet->nRelockTime != nRelockTime)
+        return;
     pWallet->nRelockTime = 0;
     pWallet->Lock();
 }
@@ -3030,37 +3035,51 @@ UniValue walletpassphrase(const JSONRPCRequest& request)
         );
     }
 
-    LOCK2(cs_main, pwallet->cs_wallet);
-
-    if (request.fHelp)
-        return true;
-    if (!pwallet->IsCrypted()) {
-        throw JSONRPCError(RPC_WALLET_WRONG_ENC_STATE, "Error: running with an unencrypted wallet, but walletpassphrase was called.");
-    }
-
-    // Note that the walletpassphrase is stored in request.params[0] which is not mlock()ed
-    SecureString strWalletPass;
-    strWalletPass.reserve(100);
-    // TODO: get rid of this .c_str() by implementing SecureString::operator=(std::string)
-    // Alternately, find a way to make request.params[0] mlock()'d to begin with.
-    strWalletPass = request.params[0].get_str().c_str();
-
-    if (strWalletPass.length() > 0)
+    int64_t nSleepTime;
+    int64_t nRelockTime;
     {
-        if (!pwallet->Unlock(strWalletPass)) {
-            throw JSONRPCError(RPC_WALLET_PASSPHRASE_INCORRECT, "Error: The wallet passphrase entered was incorrect.");
+        LOCK2(cs_main, pwallet->cs_wallet);
+
+        if (request.fHelp)
+            return true;
+        if (!pwallet->IsCrypted()) {
+            throw JSONRPCError(RPC_WALLET_WRONG_ENC_STATE, "Error: running with an unencrypted wallet, but walletpassphrase was called.");
         }
+
+        // Note that the walletpassphrase is stored in request.params[0] which is not mlock()ed
+        SecureString strWalletPass;
+        strWalletPass.reserve(100);
+        // TODO: get rid of this .c_str() by implementing SecureString::operator=(std::string)
+        // Alternately, find a way to make request.params[0] mlock()'d to begin with.
+        strWalletPass = request.params[0].get_str().c_str();
+
+        if (strWalletPass.length() > 0)
+        {
+            if (!pwallet->Unlock(strWalletPass)) {
+                throw JSONRPCError(RPC_WALLET_PASSPHRASE_INCORRECT, "Error: The wallet passphrase entered was incorrect.");
+            }
+        }
+        else
+            throw std::runtime_error(
+                "walletpassphrase <passphrase> <timeout>\n"
+                "Stores the wallet decryption key in memory for <timeout> seconds.");
+
+        pwallet->TopUpKeyPool();
+
+        nSleepTime = request.params[1].get_int64();
+        pwallet->nRelockTime = GetTime() + nSleepTime;
+        nRelockTime = pwallet->nRelockTime;
     }
-    else
-        throw std::runtime_error(
-            "walletpassphrase <passphrase> <timeout>\n"
-            "Stores the wallet decryption key in memory for <timeout> seconds.");
 
-    pwallet->TopUpKeyPool();
-
-    int64_t nSleepTime = request.params[1].get_int64();
-    pwallet->nRelockTime = GetTime() + nSleepTime;
-    RPCRunLater(strprintf("lockwallet(%s)", pwallet->strWalletFile), boost::bind(LockWallet, pwallet), nSleepTime);
+    // Schedule the relock *after* releasing cs_wallet. RPCRunLater() erases any
+    // previously scheduled lockwallet timer, and destroying a libevent timer
+    // blocks until that timer's callback has finished executing. When the
+    // callback (LockWallet) happens to be running at that moment it is itself
+    // waiting for cs_wallet, so holding the lock across this call deadlocks the
+    // RPC worker against the HTTP event loop thread. Because the RPC worker also
+    // holds cs_main, every other thread that needs cs_main then piles up behind
+    // it and the whole node stops making progress.
+    RPCRunLater(strprintf("lockwallet(%s)", pwallet->strWalletFile), boost::bind(LockWallet, pwallet, nRelockTime), nSleepTime);
 
     return NullUniValue;
 }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -729,6 +729,17 @@ public:
      */
     mutable CCriticalSection cs_wallet;
 
+    /*
+     * Serializes the walletpassphrase RPC for this wallet, so that unlocking
+     * the wallet and scheduling the matching relock timer happen atomically
+     * with respect to other walletpassphrase calls.
+     *
+     * This must never be acquired while cs_wallet is held: it is held across
+     * RPCRunLater(), which blocks until a running relock callback has returned,
+     * and that callback acquires cs_wallet.
+     */
+    CCriticalSection cs_unlock;
+
     const std::string strWalletFile;
 
     void LoadKeyPool(int nIndex, const CKeyPool &keypool)


### PR DESCRIPTION
Fixes #1888.

## PR intention

`walletpassphrase` holds `LOCK2(cs_main, pwallet->cs_wallet)` across its call to `RPCRunLater`. `RPCRunLater` erases the previously scheduled `lockwallet(...)` timer, and destroying a libevent timer blocks until that timer's callback has finished running. When `LockWallet` is the callback currently executing on the HTTP event loop, it is itself blocked acquiring `cs_wallet` — so the RPC worker and the event loop deadlock on each other.

Since the RPC worker also holds `cs_main`, message handling, the scheduler and connection handling all stall behind it and the node stops entirely. Nothing is logged, and `SIGTERM` does not complete because the shutdown path needs the same locks. Full thread-dump evidence is in #1888.

### This is a known hazard in Bitcoin Core

Core hit the same cycle and documented it in the code, directly above the relock scheduling ([permalink, `21b42f3`](https://github.com/bitcoin/bitcoin/blob/21b42f3c5569f9c884c41d828c087ea971697875/src/wallet/rpc/encrypt.cpp#L91-L95)):

```cpp
// rpcRunLater must be called without cs_wallet held otherwise a deadlock
// can occur. The deadlock would happen when RPCRunLater removes the
// previous timer (and waits for the callback to finish if already running)
// and the callback locks cs_wallet.
AssertLockNotHeld(wallet->cs_wallet);
```

Relevant Core changes:

- [bitcoin/bitcoin#18814](https://github.com/bitcoin/bitcoin/pull/18814) (merged 2020-05-13) — "Relock wallet only if most recent callback": adds the `nRelockTime != relock_time` generation check and `m_unlock_mutex`. Fixes [#18811](https://github.com/bitcoin/bitcoin/issues/18811).
- [bitcoin/bitcoin#32862](https://github.com/bitcoin/bitcoin/pull/32862) (merged 2025-07-08) — "use CScheduler for relocking wallet and remove RPCTimer": moves the relock off the libevent timer entirely and deletes `RPCRunLater`/`RPCTimerInterface`. Superseded [#32796](https://github.com/bitcoin/bitcoin/pull/32796), part of [#31194](https://github.com/bitcoin/bitcoin/issues/31194) (remove libevent). Its motivation was libevent removal rather than this deadlock, but it does eliminate the hazard structurally.

## Code changes brief

Three commits, mirroring Core's #18814.

**1. Break the deadlock** — `Fix deadlock between walletpassphrase and the wallet relock timer`

- `LOCK2(cs_main, pwallet->cs_wallet)` moves into a block that ends before `RPCRunLater` is called, so the relock is scheduled with no wallet lock held. This alone breaks the cycle — the pending callback can acquire `cs_wallet`, finish, and let `event_del` return.
- Releasing the lock earlier opens a small window in which the old timer's callback could lock a wallet that was just unlocked again. `LockWallet` now takes the `nRelockTime` it was scheduled with and returns without doing anything if `pwallet->nRelockTime` no longer matches. `walletlock` already resets `nRelockTime` to `0`, so a callback that fires after an explicit lock is also correctly ignored.

**2. Restore the serialization `cs_main` used to provide** — `Serialize walletpassphrase and guard the RPC timer map`

Scoping the lock also removed the mutual exclusion that holding `cs_main` incidentally gave the two steps after a successful unlock — publishing `nRelockTime` and installing the timer:

- A new per-wallet `cs_unlock` is held across both, so two overlapping `walletpassphrase` calls cannot publish `nRelockTime` and schedule the timer in opposite orders, which would leave the wallet unlocked past its timeout. It deliberately is not `cs_wallet`: it is held across `RPCRunLater`, whose callback takes `cs_wallet`.
- `deadlineTimers` in `rpc/server.cpp` gets its own `cs_deadlineTimers`. It is a plain `std::map` that `RPCRunLater` erases from and emplaces into and that `StopRPC` clears, previously unserialized. This also closes the pre-existing `StopRPC` / in-flight-`walletpassphrase` race, since `StopRPC` (`init.cpp:267`) runs before the HTTP workers are joined by `StopHTTPServer` (`init.cpp:268`).

The resulting lock order is acyclic — `cs_unlock → cs_main → cs_wallet` and `cs_unlock → cs_deadlineTimers` — and no timer callback acquires either new lock.

**3. Validate the timeout** — `Validate walletpassphrase timeout before unlock`

Written by @reubenyap and cherry-picked in at his request; ported from upstream Core's `walletpassphrase` validation.

- A negative `timeout` is rejected with `RPC_INVALID_PARAMETER` instead of scheduling a relock in the past.
- The timeout is clamped to `100000000` seconds. Core's stated reason for that bound is that larger values trigger a macos/libevent bug; it also keeps `GetTime() + nSleepTime` from overflowing `nRelockTime`.
- Both checks run before `Unlock()`, so a rejected call leaves wallet state untouched. Previously the timeout was only parsed after `Unlock()` and `TopUpKeyPool()`, so a non-integer value threw with the wallet already unlocked and no relock scheduled at all.
- `qa/rpc-tests/wallet-encryption.py` covers the rejection and that the wallet stays locked afterwards.

### Not included

I kept `RPCRunLater` rather than porting Core's scheduler rework (#32862), to keep the change small. Happy to do the larger version instead if you prefer — it removes the "destroy an event from inside a lock its callback needs" pattern rather than working around it.

Core's `weak_ptr` unload guard from #18814 does not apply here: this build has a single static `pwalletMain` and no dynamic wallet unload.

## Testing

The deadlock was diagnosed from a symbolized `thread apply all bt` taken on a live hung node, which pins both sides of the cycle to exact call sites (see #1888).

`qa/rpc-tests/wallet-encryption.py` covers unlock, timeout relock, timeout extension and now negative-timeout rejection. It is listed in `qa/pull-tester/rpc-tests.py`, which the Jenkins pipeline runs as `qa/pull-tester/rpc-tests.py -extended`. The deadlock itself is a timing race that is impractical to test deterministically — upstream added no test for #18814 either.

I still do not have a build environment for this repo, so I have not compiled or run the patched binary myself. @reubenyap reports having compile-checked both the branch head and the timeout-validation commit locally. The Jenkins run is the real gate, and it has not run on this branch yet.
