### PR TITLE
Qt: Make arbitrary funds private with Spark

### DIFF
--- a/src/qt/automintdialog.cpp
+++ b/src/qt/automintdialog.cpp
@@ -23,7 +23,7 @@ AutoMintSparkDialog::AutoMintSparkDialog(AutoMintSparkMode mode, QWidget *parent
     ENTER_CRITICAL_SECTION(pwalletMain->cs_wallet);
 
     ui->setupUi(this);
-    ui->buttonBox->button(QDialogButtonBox::Ok)->setText(tr("Anonymize"));
+    ui->buttonBox->button(QDialogButtonBox::Ok)->setText(tr("Make Private"));
     ui->buttonBox->button(QDialogButtonBox::Cancel)->setText(tr("Cancel"));
 }
 
@@ -108,7 +108,7 @@ void AutoMintSparkDialog::reject()
  * this function acquires the SparkModel critical section and leaves it only when the
  * dialog is destroyed. If the wallet is
  * currently unlocked, the passphrase input, passphrase label, and lock checkbox are
- * hidden, the lock warning text is changed to "Do you want to anonymize all transparent funds?",
+ * hidden, the lock warning text asks whether to make all transparent funds private with Spark,
  * and requiredPassphase is cleared.
  *
  * This method has the side effects of:
@@ -136,7 +136,7 @@ void AutoMintSparkDialog::setModel(WalletModel *model)
         ui->passLabel->setVisible(false);
         ui->passEdit->setVisible(false);
         ui->lockCheckBox->setVisible(false);
-        ui->lockWarningLabel->setText(QString(tr("Do you want to anonymize all transparent funds?")));
+        ui->lockWarningLabel->setText(QString(tr("Make all available transparent funds private with Spark?")));
 
         requiredPassphase = false;
     }
@@ -148,7 +148,7 @@ void AutoMintSparkDialog::paintEvent(QPaintEvent *event)
     painter.begin(this);
 
     if (progress != AutoMintSparkProgress::Start) {
-        auto progressMessage = progress == AutoMintSparkProgress::Unlocking ? tr("Unlocking wallet...") : tr("Anonymizing...");
+        auto progressMessage = progress == AutoMintSparkProgress::Unlocking ? tr("Unlocking wallet...") : tr("Making funds private...");
         auto size = QFontMetrics(painter.font()).size(Qt::TextSingleLine, progressMessage);
         painter.drawText(
             (width() - size.width()) / 2,

--- a/src/qt/automintmodel.cpp
+++ b/src/qt/automintmodel.cpp
@@ -352,7 +352,7 @@ void AutoMintSparkModel::processAutoMintSparkAck(AutoMintSparkAck ack, CAmount m
     switch (ack)
     {
     case AutoMintSparkAck::Success:
-        msgParams.first = tr("Successfully anonymized %1")
+        msgParams.first = tr("Successfully made %1 private with Spark")
             .arg(BitcoinUnits::formatWithUnit(optionsModel->getDisplayUnit(), minted));
         msgParams.second = CClientUIInterface::MSG_INFORMATION;
         break;
@@ -371,5 +371,5 @@ void AutoMintSparkModel::processAutoMintSparkAck(AutoMintSparkAck ack, CAmount m
         return;
     };
 
-    Q_EMIT message(tr("Auto Anonymize"), msgParams.first, msgParams.second);
+    Q_EMIT message(tr("Automatic Spark Privacy"), msgParams.first, msgParams.second);
 }

--- a/src/qt/automintnotification.cpp
+++ b/src/qt/automintnotification.cpp
@@ -11,7 +11,7 @@ AutomintSparkNotification::AutomintSparkNotification(QWidget *parent) :
     sparkModel(nullptr)
 {
     ui->setupUi(this);
-    ui->buttonBox->button(QDialogButtonBox::Ok)->setText(tr("Anonymize"));
+    ui->buttonBox->button(QDialogButtonBox::Ok)->setText(tr("Make Private"));
     ui->buttonBox->button(QDialogButtonBox::Cancel)->setText(tr("Dismiss"));
 
     setWindowFlags(windowFlags() | Qt::FramelessWindowHint);

--- a/src/qt/forms/automintdialog.ui
+++ b/src/qt/forms/automintdialog.ui
@@ -23,7 +23,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>Anonymize Funds</string>
+   <string>Make Funds Private</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="sizeConstraint">
@@ -32,7 +32,7 @@
    <item>
     <widget class="QLabel" name="lockWarningLabel">
      <property name="text">
-      <string>Unlock your wallet to anonymize all transparent funds.</string>
+      <string>Unlock your wallet to make all transparent funds private with Spark.</string>
      </property>
     </widget>
    </item>
@@ -77,7 +77,7 @@
      <item row="2" column="1">
       <widget class="QCheckBox" name="lockCheckBox">
        <property name="text">
-        <string>Lock wallet immediately after anonymizing</string>
+        <string>Lock wallet immediately after making funds private</string>
        </property>
       </widget>
      </item>

--- a/src/qt/forms/automintnotification.ui
+++ b/src/qt/forms/automintnotification.ui
@@ -26,7 +26,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>Anonymize Funds</string>
+   <string>Make Funds Private</string>
   </property>
   <property name="modal">
    <bool>true</bool>
@@ -51,7 +51,7 @@
    <item>
     <widget class="QLabel" name="lockWarningLabel">
      <property name="text">
-      <string>Do you want to anonymize all transparent funds?</string>
+      <string>Make all available transparent funds private with Spark?</string>
      </property>
     </widget>
    </item>

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -185,10 +185,10 @@
           <item>
            <widget class="QCheckBox" name="autoAnonymize">
             <property name="toolTip">
-             <string>When enabled, the wallet can prompt to anonymize transparent funds using Spark.</string>
+             <string>When enabled, the wallet can prompt to make transparent funds private with Spark.</string>
             </property>
             <property name="text">
-             <string>Enable &amp;auto-anonymize features</string>
+             <string>Enable automatic Spark &amp;privacy</string>
             </property>
            </widget>
           </item>
@@ -205,10 +205,10 @@
           <item>
            <widget class="QCheckBox" name="sparkPage">
             <property name="toolTip">
-             <string>Show the Spark manual anonymize controls in the overview.</string>
+             <string>Show the Make Private control in the overview.</string>
             </property>
             <property name="text">
-             <string>Enable Spark &amp;manual-anonymize page</string>
+             <string>Show Spark &amp;privacy controls</string>
             </property>
            </widget>
           </item>

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -483,7 +483,7 @@
               </property>
              </widget>
             </item>
-            <item row="16" column="2">
+            <item row="16" column="3" alignment="Qt::AlignLeft">
              <widget class="QPushButton" name="anonymizeButton">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Minimum" vsizetype="Minimum">

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -188,7 +188,7 @@
             <item row="16" column="0">
              <widget class="QLabel" name="labelAnonymizableText">
               <property name="text">
-               <string>Anonymizable:</string>
+               <string>Available to make private:</string>
               </property>
              </widget>
             </item>
@@ -338,7 +338,7 @@
                <cursorShape>IBeamCursor</cursorShape>
               </property>
               <property name="toolTip">
-               <string>Total of anonymize transactions that have yet to be confirmed, and do not yet count toward the spendable balance</string>
+               <string>Total of Spark mint transactions that have yet to be confirmed, and do not yet count toward the spendable balance</string>
               </property>
               <property name="text">
                <string>0.000 000 00 FIRO</string>
@@ -483,7 +483,7 @@
               </property>
              </widget>
             </item>
-            <item row="16" column="4">
+            <item row="16" column="2">
              <widget class="QPushButton" name="anonymizeButton">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
@@ -497,7 +497,7 @@
                </font>
               </property>
               <property name="text">
-               <string>Anonymize All</string>
+               <string>Make Private...</string>
               </property>
              </widget>
             </item>
@@ -577,7 +577,7 @@
                <cursorShape>IBeamCursor</cursorShape>
               </property>
               <property name="toolTip">
-               <string>Your current spendable anonymized balance</string>
+               <string>Your current spendable private Spark balance</string>
               </property>
               <property name="text">
                <string>0.000 000 00 FIRO</string>

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -43,6 +43,9 @@
 #endif
 #include <boost/scoped_array.hpp>
 
+#include <exception>
+#include <thread>
+
 #include <QAbstractItemView>
 #include <QApplication>
 #include <QClipboard>
@@ -50,6 +53,7 @@
 #include <QDesktopServices>
 #include <QScreen>
 #include <QDoubleValidator>
+#include <QEventLoop>
 #include <QFileDialog>
 #include <QFont>
 #include <QLineEdit>
@@ -90,6 +94,34 @@ namespace GUIUtil {
 static QString stylesheetDirectory = ":css";
 static QString firoTheme = "firoTheme";
 static CCriticalSection cs_css;
+
+void runWalletOperation(const std::function<void()>& operation)
+{
+    std::exception_ptr exception;
+    QEventLoop waitLoop;
+    std::thread worker([&] {
+        try {
+            operation();
+        } catch (...) {
+            exception = std::current_exception();
+        }
+        QMetaObject::invokeMethod(&waitLoop, &QEventLoop::quit, Qt::QueuedConnection);
+    });
+    QApplication::setOverrideCursor(Qt::WaitCursor);
+    struct Cleanup {
+        std::thread& worker;
+        ~Cleanup()
+        {
+            if (worker.joinable())
+                worker.join();
+            QApplication::restoreOverrideCursor();
+        }
+    } cleanup{worker};
+    waitLoop.exec(QEventLoop::ExcludeUserInputEvents);
+    worker.join();
+    if (exception)
+        std::rethrow_exception(exception);
+}
 
 QString dateTimeStr(const QDateTime &date)
 {

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -7,6 +7,8 @@
 
 #include "amount.h"
 
+#include <functional>
+
 #include <QEvent>
 #include <QHeaderView>
 #include <QMessageBox>
@@ -35,6 +37,10 @@ QT_END_NAMESPACE
  */
 namespace GUIUtil
 {
+    /** Run a slow wallet operation on a worker while the GUI repaints.
+     * User input is excluded until completion and exceptions are rethrown. */
+    void runWalletOperation(const std::function<void()>& operation);
+
     // Create human-readable string from date
     QString dateTimeStr(const QDateTime &datetime);
     QString dateTimeStr(qint64 nTime);

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -51,7 +51,7 @@ public:
         Split,                  // bool
         enableRapAddresses,     // bool
         ReindexSpark,           // bool (wallet: zap Spark mints + reindex; QSettings bReindexSpark)
-        SparkPage,              // bool (show Spark manual-anonymize UI; QSettings fSparkPage)
+        SparkPage,              // bool (show Spark privacy controls; QSettings fSparkPage)
         OptionIDRowCount,
     };
 

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -5,11 +5,11 @@
 #include "overviewpage.h"
 #include "ui_overviewpage.h"
 
+#include "bitcoinamountfield.h"
 #include "bitcoinunits.h"
 #include "clientmodel.h"
 #include "guiconstants.h"
 #include "guiutil.h"
-#include "sparkmodel.h"
 #include "spark/state.h"
 #include "optionsmodel.h"
 #include "platformstyle.h"
@@ -28,7 +28,14 @@
 #include "compat.h"
 
 #include <QAbstractItemDelegate>
+#include <QDialog>
+#include <QDialogButtonBox>
+#include <QFormLayout>
+#include <QHBoxLayout>
+#include <QLabel>
 #include <QPainter>
+#include <QPushButton>
+#include <QVBoxLayout>
 
 #define DECORATION_SIZE 54
 #define NUM_ITEMS 5
@@ -131,6 +138,9 @@ OverviewPage::OverviewPage(const PlatformStyle *platformStyle, QWidget *parent) 
     currentWatchOnlyBalance(-1),
     currentWatchUnconfBalance(-1),
     currentWatchImmatureBalance(-1),
+    currentPrivateBalance(-1),
+    currentUnconfirmedPrivateBalance(-1),
+    currentAnonymizableBalance(-1),
     txdelegate(new TxViewDelegate(platformStyle, this))
 {
     ui->setupUi(this);
@@ -255,18 +265,152 @@ void OverviewPage::resizeEvent(QResizeEvent* event)
 
 void OverviewPage::on_anonymizeButton_clicked()
 {
-    if (!walletModel) {
+    auto wallet = walletModel ? walletModel->getWallet() : nullptr;
+    if (!walletModel || !walletModel->getOptionsModel() || !wallet || !wallet->sparkWallet ||
+        !spark::IsSparkAllowed() || currentAnonymizableBalance <= 0) {
         return;
     }
 
-    if (spark::IsSparkAllowed()) {
-        auto sparkModel = walletModel->getSparkModel();
-        if (!sparkModel) {
+    const int unit = walletModel->getOptionsModel()->getDisplayUnit();
+    const CAmount available = currentAnonymizableBalance;
+    QDialog amountDialog(this);
+    amountDialog.setWindowTitle(tr("Make Funds Private"));
+
+    auto layout = new QVBoxLayout(&amountDialog);
+    auto description = new QLabel(
+        tr("Move FIRO from your transparent balance into Spark, Firo's private balance."),
+        &amountDialog);
+    description->setWordWrap(true);
+    layout->addWidget(description);
+
+    auto form = new QFormLayout();
+    form->addRow(tr("From"), new QLabel(tr("Transparent balance"), &amountDialog));
+    form->addRow(tr("To"), new QLabel(tr("Private balance (Spark)"), &amountDialog));
+
+    auto amountLayout = new QHBoxLayout();
+    auto amountField = new BitcoinAmountField(&amountDialog);
+    amountField->setDisplayUnit(unit);
+    auto maxButton = new QPushButton(tr("Max"), &amountDialog);
+    amountLayout->addWidget(amountField);
+    amountLayout->addWidget(maxButton);
+    form->addRow(tr("Amount"), amountLayout);
+    form->addRow(
+        tr("Available"),
+        new QLabel(BitcoinUnits::formatWithUnit(unit, available), &amountDialog));
+    layout->addLayout(form);
+
+    auto buttons = new QDialogButtonBox(QDialogButtonBox::Cancel | QDialogButtonBox::Ok, &amountDialog);
+    buttons->button(QDialogButtonBox::Ok)->setText(tr("Review"));
+    layout->addWidget(buttons);
+
+    connect(maxButton, &QPushButton::clicked, [amountField, available] {
+        amountField->setValue(available);
+    });
+    connect(buttons, &QDialogButtonBox::rejected, &amountDialog, &QDialog::reject);
+    connect(buttons->button(QDialogButtonBox::Ok), &QPushButton::clicked, [&, available] {
+        bool valid = false;
+        const CAmount amount = amountField->value(&valid);
+        if (!valid || amount <= 0 || amount > available) {
+            amountField->setValid(false);
             return;
         }
+        amountDialog.accept();
+    });
 
-        sparkModel->mintSparkAll(AutoMintSparkMode::MintAll);
+    amountField->setFocus();
+    if (amountDialog.exec() != QDialog::Accepted) {
+        return;
     }
+
+    const CAmount amount = amountField->value();
+    WalletModel::UnlockContext unlockContext(walletModel->requestUnlock(tr("Make funds private")));
+    if (!unlockContext.isValid()) {
+        return;
+    }
+
+    SendCoinsRecipient recipient;
+    recipient.address = walletModel->generateSparkAddress();
+    recipient.amount = amount;
+    recipient.fSubtractFeeFromAmount = amount == available;
+
+    QList<SendCoinsRecipient> recipients;
+    recipients.append(recipient);
+    std::vector<WalletModelTransaction> transactions;
+    std::vector<std::pair<CWalletTx, CAmount>> transactionsAndFees;
+    std::list<CReserveKey> reserveKeys;
+
+    auto showError = [this, unit](const WalletModel::SendCoinsReturn& result) {
+        QString text;
+        switch (result.status) {
+        case WalletModel::AmountExceedsBalance:
+            text = tr("The amount exceeds your available transparent balance.");
+            break;
+        case WalletModel::AmountWithFeeExceedsBalance:
+            text = tr("The amount and transaction fee exceed your available transparent balance.");
+            break;
+        case WalletModel::AbsurdFee:
+            text = tr("The transaction fee is higher than the configured maximum of %1.")
+                .arg(BitcoinUnits::formatWithUnit(unit, maxTxFee));
+            break;
+        case WalletModel::TransactionCommitFailed:
+            text = tr("The transaction was rejected: %1").arg(result.reasonCommitFailed);
+            break;
+        default:
+            text = tr("Unable to create the Spark transaction.");
+            break;
+        }
+        QMessageBox::critical(this, tr("Unable to Make Funds Private"), text);
+    };
+
+    WalletModel::SendCoinsReturn prepareResult;
+    GUIUtil::runWalletOperation([&] {
+        prepareResult = walletModel->prepareMintSparkTransaction(
+            transactions, recipients, transactionsAndFees, reserveKeys, nullptr);
+    });
+    if (prepareResult.status != WalletModel::OK) {
+        showError(prepareResult);
+        return;
+    }
+
+    CAmount privateAmount = 0;
+    CAmount fee = 0;
+    for (auto& transaction : transactions) {
+        privateAmount += transaction.getTotalTransactionAmount();
+        fee += transaction.getTransactionFee();
+    }
+
+    QMessageBox confirmation(
+        QMessageBox::Question,
+        tr("Review Private Transfer"),
+        tr("Amount to make private: <b>%1</b><br>"
+           "Network fee: %2<br>"
+           "Total from transparent balance: %3")
+            .arg(BitcoinUnits::formatWithUnit(unit, privateAmount),
+                 BitcoinUnits::formatWithUnit(unit, fee),
+                 BitcoinUnits::formatWithUnit(unit, privateAmount + fee)),
+        QMessageBox::Cancel,
+        this);
+    auto confirmButton = confirmation.addButton(tr("Make Private"), QMessageBox::AcceptRole);
+    confirmation.setDefaultButton(QMessageBox::Cancel);
+    confirmation.exec();
+    if (confirmation.clickedButton() != confirmButton) {
+        return;
+    }
+
+    WalletModel::SendCoinsReturn sendResult;
+    GUIUtil::runWalletOperation([&] {
+        sendResult = walletModel->mintSparkCoins(transactions, transactionsAndFees, reserveKeys);
+    });
+    if (sendResult.status != WalletModel::OK) {
+        showError(sendResult);
+        return;
+    }
+
+    QMessageBox::information(
+        this,
+        tr("Funds Moving to Spark"),
+        tr("%1 is moving to your private Spark balance. It will become available after confirmation.")
+            .arg(BitcoinUnits::formatWithUnit(unit, privateAmount)));
 }
 
 void OverviewPage::setBalance(

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -294,6 +294,11 @@ void OverviewPage::on_anonymizeButton_clicked()
     amountLayout->addWidget(amountField);
     amountLayout->addWidget(maxButton);
     form->addRow(tr("Amount"), amountLayout);
+    auto feeNoteLabel = new QLabel(
+        tr("The network fee will be deducted from this amount."), &amountDialog);
+    feeNoteLabel->setWordWrap(true);
+    feeNoteLabel->setVisible(false);
+    form->addRow(QString(), feeNoteLabel);
     form->addRow(
         tr("Available"),
         new QLabel(BitcoinUnits::formatWithUnit(unit, available), &amountDialog));
@@ -305,6 +310,11 @@ void OverviewPage::on_anonymizeButton_clicked()
 
     connect(maxButton, &QPushButton::clicked, [amountField, available] {
         amountField->setValue(available);
+    });
+    connect(amountField, &BitcoinAmountField::valueChanged, [amountField, feeNoteLabel, available] {
+        bool valid = false;
+        const CAmount amount = amountField->value(&valid);
+        feeNoteLabel->setVisible(valid && amount == available);
     });
     connect(buttons, &QDialogButtonBox::rejected, &amountDialog, &QDialog::reject);
     connect(buttons->button(QDialogButtonBox::Ok), &QPushButton::clicked, [&, available] {
@@ -364,21 +374,32 @@ void OverviewPage::on_anonymizeButton_clicked()
                 transactions, recipients, transactionsAndFees, reserveKeys, nullptr);
         });
         if (prepareResult.status != WalletModel::OK) {
+            const bool amountTooHigh =
+                prepareResult.status == WalletModel::AmountExceedsBalance ||
+                prepareResult.status == WalletModel::AmountWithFeeExceedsBalance;
             QMessageBox error(
                 QMessageBox::Warning,
                 tr("Unable to Make Funds Private"),
                 tr("Firo could not create a Spark transaction for this amount."),
                 QMessageBox::Cancel,
                 this);
-            error.setInformativeText(tr("Change the amount and try again. No funds were moved."));
+            error.setInformativeText(amountTooHigh
+                ? tr("Use Maximum fills in the highest amount that can be made private, with the network fee deducted from it. No funds were moved.")
+                : tr("Change the amount and try again. No funds were moved."));
             const QString details = errorDetails(prepareResult);
             if (!details.isEmpty()) {
                 error.setDetailedText(details);
             }
+            QPushButton* useMaxButton = nullptr;
+            if (amountTooHigh) {
+                useMaxButton = error.addButton(tr("Use Maximum"), QMessageBox::AcceptRole);
+            }
             auto changeAmountButton = error.addButton(tr("Change Amount"), QMessageBox::AcceptRole);
             error.setDefaultButton(QMessageBox::Cancel);
             error.exec();
-            if (error.clickedButton() != changeAmountButton) {
+            if (useMaxButton && error.clickedButton() == useMaxButton) {
+                amountField->setValue(available);
+            } else if (error.clickedButton() != changeAmountButton) {
                 return;
             }
             amountField->setFocus();

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -415,10 +415,22 @@ void OverviewPage::on_anonymizeButton_clicked()
             sendResult = walletModel->mintSparkCoins(transactions, transactionsAndFees, reserveKeys);
         });
         if (sendResult.status != WalletModel::OK) {
-            QMessageBox::critical(
-                this,
+            // The wallet may have split the request into several transactions
+            // (e.g. with the Split option) and committed some before failing,
+            // so the message must not claim that nothing was sent.
+            QMessageBox error(
+                QMessageBox::Critical,
                 tr("Unable to Make Funds Private"),
-                errorDetails(sendResult));
+                transactionsAndFees.size() > 1
+                    ? tr("The transfer could not be fully completed. Part of it may already have been sent; check the Transactions tab before trying again.")
+                    : tr("The transfer could not be completed. No funds were moved."),
+                QMessageBox::Ok,
+                this);
+            const QString details = errorDetails(sendResult);
+            if (!details.isEmpty()) {
+                error.setDetailedText(details);
+            }
+            error.exec();
             return;
         }
 

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -661,5 +661,7 @@ void OverviewPage::updateSparkAnonymizeRowVisibility()
     const bool show = spark::IsSparkAllowed() && walletModel->getOptionsModel()->getSparkPage();
     ui->labelAnonymizableText->setVisible(show);
     ui->labelAnonymizable->setVisible(show);
-    ui->anonymizeButton->setVisible(show);
+    // Watch-only funds cannot be spent, so wallets with nothing eligible
+    // (e.g. watch-only wallets) get no dead Make Private control.
+    ui->anonymizeButton->setVisible(show && currentAnonymizableBalance > 0);
 }

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -322,95 +322,117 @@ void OverviewPage::on_anonymizeButton_clicked()
         return;
     }
 
-    const CAmount amount = amountField->value();
     WalletModel::UnlockContext unlockContext(walletModel->requestUnlock(tr("Make funds private")));
     if (!unlockContext.isValid()) {
         return;
     }
 
-    SendCoinsRecipient recipient;
-    recipient.address = walletModel->generateSparkAddress();
-    recipient.amount = amount;
-    recipient.fSubtractFeeFromAmount = amount == available;
-
-    QList<SendCoinsRecipient> recipients;
-    recipients.append(recipient);
-    std::vector<WalletModelTransaction> transactions;
-    std::vector<std::pair<CWalletTx, CAmount>> transactionsAndFees;
-    std::list<CReserveKey> reserveKeys;
-
-    auto showError = [this, unit](const WalletModel::SendCoinsReturn& result) {
-        QString text;
+    const QString sparkAddress = walletModel->generateSparkAddress();
+    auto errorDetails = [this, unit](const WalletModel::SendCoinsReturn& result) {
         switch (result.status) {
         case WalletModel::AmountExceedsBalance:
-            text = tr("The amount exceeds your available transparent balance.");
-            break;
+            return tr("The amount exceeds your available transparent balance.");
         case WalletModel::AmountWithFeeExceedsBalance:
-            text = tr("The amount and transaction fee exceed your available transparent balance.");
-            break;
+            return tr("The amount and transaction fee exceed your available transparent balance.");
         case WalletModel::AbsurdFee:
-            text = tr("The transaction fee is higher than the configured maximum of %1.")
+            return tr("The transaction fee is higher than the configured maximum of %1.")
                 .arg(BitcoinUnits::formatWithUnit(unit, maxTxFee));
-            break;
+        case WalletModel::TransactionCreationFailed:
+            return result.reasonCommitFailed;
         case WalletModel::TransactionCommitFailed:
-            text = tr("The transaction was rejected: %1").arg(result.reasonCommitFailed);
-            break;
+            return tr("The transaction was rejected: %1").arg(result.reasonCommitFailed);
         default:
-            text = tr("Unable to create the Spark transaction.");
-            break;
+            return tr("Unable to create the Spark transaction.");
         }
-        QMessageBox::critical(this, tr("Unable to Make Funds Private"), text);
     };
 
-    WalletModel::SendCoinsReturn prepareResult;
-    GUIUtil::runWalletOperation([&] {
-        prepareResult = walletModel->prepareMintSparkTransaction(
-            transactions, recipients, transactionsAndFees, reserveKeys, nullptr);
-    });
-    if (prepareResult.status != WalletModel::OK) {
-        showError(prepareResult);
+    while (true) {
+        const CAmount amount = amountField->value();
+        SendCoinsRecipient recipient;
+        recipient.address = sparkAddress;
+        recipient.amount = amount;
+        recipient.fSubtractFeeFromAmount = amount == available;
+
+        QList<SendCoinsRecipient> recipients;
+        recipients.append(recipient);
+        std::vector<WalletModelTransaction> transactions;
+        std::vector<std::pair<CWalletTx, CAmount>> transactionsAndFees;
+        std::list<CReserveKey> reserveKeys;
+
+        WalletModel::SendCoinsReturn prepareResult;
+        GUIUtil::runWalletOperation([&] {
+            prepareResult = walletModel->prepareMintSparkTransaction(
+                transactions, recipients, transactionsAndFees, reserveKeys, nullptr);
+        });
+        if (prepareResult.status != WalletModel::OK) {
+            QMessageBox error(
+                QMessageBox::Warning,
+                tr("Unable to Make Funds Private"),
+                tr("Firo could not create a Spark transaction for this amount."),
+                QMessageBox::Cancel,
+                this);
+            error.setInformativeText(tr("Change the amount and try again. No funds were moved."));
+            const QString details = errorDetails(prepareResult);
+            if (!details.isEmpty()) {
+                error.setDetailedText(details);
+            }
+            auto changeAmountButton = error.addButton(tr("Change Amount"), QMessageBox::AcceptRole);
+            error.setDefaultButton(QMessageBox::Cancel);
+            error.exec();
+            if (error.clickedButton() != changeAmountButton) {
+                return;
+            }
+            amountField->setFocus();
+            if (amountDialog.exec() != QDialog::Accepted) {
+                return;
+            }
+            continue;
+        }
+
+        CAmount privateAmount = 0;
+        CAmount fee = 0;
+        for (auto& transaction : transactions) {
+            privateAmount += transaction.getTotalTransactionAmount();
+            fee += transaction.getTransactionFee();
+        }
+
+        QMessageBox confirmation(
+            QMessageBox::Question,
+            tr("Review Private Transfer"),
+            tr("Amount to make private: <b>%1</b><br>"
+               "Network fee: %2<br>"
+               "Total from transparent balance: %3")
+                .arg(BitcoinUnits::formatWithUnit(unit, privateAmount),
+                     BitcoinUnits::formatWithUnit(unit, fee),
+                     BitcoinUnits::formatWithUnit(unit, privateAmount + fee)),
+            QMessageBox::Cancel,
+            this);
+        auto confirmButton = confirmation.addButton(tr("Make Private"), QMessageBox::AcceptRole);
+        confirmation.setDefaultButton(QMessageBox::Cancel);
+        confirmation.exec();
+        if (confirmation.clickedButton() != confirmButton) {
+            return;
+        }
+
+        WalletModel::SendCoinsReturn sendResult;
+        GUIUtil::runWalletOperation([&] {
+            sendResult = walletModel->mintSparkCoins(transactions, transactionsAndFees, reserveKeys);
+        });
+        if (sendResult.status != WalletModel::OK) {
+            QMessageBox::critical(
+                this,
+                tr("Unable to Make Funds Private"),
+                errorDetails(sendResult));
+            return;
+        }
+
+        QMessageBox::information(
+            this,
+            tr("Funds Moving to Spark"),
+            tr("%1 is moving to your private Spark balance. It will become available after confirmation.")
+                .arg(BitcoinUnits::formatWithUnit(unit, privateAmount)));
         return;
     }
-
-    CAmount privateAmount = 0;
-    CAmount fee = 0;
-    for (auto& transaction : transactions) {
-        privateAmount += transaction.getTotalTransactionAmount();
-        fee += transaction.getTransactionFee();
-    }
-
-    QMessageBox confirmation(
-        QMessageBox::Question,
-        tr("Review Private Transfer"),
-        tr("Amount to make private: <b>%1</b><br>"
-           "Network fee: %2<br>"
-           "Total from transparent balance: %3")
-            .arg(BitcoinUnits::formatWithUnit(unit, privateAmount),
-                 BitcoinUnits::formatWithUnit(unit, fee),
-                 BitcoinUnits::formatWithUnit(unit, privateAmount + fee)),
-        QMessageBox::Cancel,
-        this);
-    auto confirmButton = confirmation.addButton(tr("Make Private"), QMessageBox::AcceptRole);
-    confirmation.setDefaultButton(QMessageBox::Cancel);
-    confirmation.exec();
-    if (confirmation.clickedButton() != confirmButton) {
-        return;
-    }
-
-    WalletModel::SendCoinsReturn sendResult;
-    GUIUtil::runWalletOperation([&] {
-        sendResult = walletModel->mintSparkCoins(transactions, transactionsAndFees, reserveKeys);
-    });
-    if (sendResult.status != WalletModel::OK) {
-        showError(sendResult);
-        return;
-    }
-
-    QMessageBox::information(
-        this,
-        tr("Funds Moving to Spark"),
-        tr("%1 is moving to your private Spark balance. It will become available after confirmation.")
-            .arg(BitcoinUnits::formatWithUnit(unit, privateAmount)));
 }
 
 void OverviewPage::setBalance(

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -317,17 +317,6 @@ void OverviewPage::on_anonymizeButton_clicked()
         amountDialog.accept();
     });
 
-    amountField->setFocus();
-    if (amountDialog.exec() != QDialog::Accepted) {
-        return;
-    }
-
-    WalletModel::UnlockContext unlockContext(walletModel->requestUnlock(tr("Make funds private")));
-    if (!unlockContext.isValid()) {
-        return;
-    }
-
-    const QString sparkAddress = walletModel->generateSparkAddress();
     auto errorDetails = [this, unit](const WalletModel::SendCoinsReturn& result) {
         switch (result.status) {
         case WalletModel::AmountExceedsBalance:
@@ -346,7 +335,17 @@ void OverviewPage::on_anonymizeButton_clicked()
         }
     };
 
-    while (true) {
+    QString sparkAddress;
+    amountField->setFocus();
+    while (amountDialog.exec() == QDialog::Accepted) {
+        WalletModel::UnlockContext unlockContext(walletModel->requestUnlock(tr("Make funds private")));
+        if (!unlockContext.isValid()) {
+            return;
+        }
+        if (sparkAddress.isEmpty()) {
+            sparkAddress = walletModel->generateSparkAddress();
+        }
+
         const CAmount amount = amountField->value();
         SendCoinsRecipient recipient;
         recipient.address = sparkAddress;
@@ -383,9 +382,6 @@ void OverviewPage::on_anonymizeButton_clicked()
                 return;
             }
             amountField->setFocus();
-            if (amountDialog.exec() != QDialog::Accepted) {
-                return;
-            }
             continue;
         }
 

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -24,8 +24,6 @@
 #include "wallet/wallet.h"
 #include "overviewpage.h"
 
-#include <QApplication>
-#include <QEventLoop>
 #include <QFontMetrics>
 #include <QMessageBox>
 #include <QScrollBar>
@@ -33,9 +31,7 @@
 #include <QTextDocument>
 #include <QTimer>
 
-#include <exception>
 #include <functional>
-#include <thread>
 
 #define SEND_CONFIRM_DELAY   3
 
@@ -230,45 +226,12 @@ SendCoinsDialog::~SendCoinsDialog()
 }
 
 namespace {
-/** Run a slow wallet operation on a worker thread while keeping the GUI event
- * loop spinning, and return its result. Creating a transaction can take
- * several seconds: Spark spends generate zero-knowledge proofs, and both
- * creation and commit wait on cs_main/cs_wallet, which are contended while
- * incoming blocks and transactions are processed. Doing that work directly in
- * a slot freezes the whole GUI for its duration.
- *
- * User input is excluded from event processing while the operation runs, so
- * the calling code path behaves as if it were synchronous. */
 WalletModel::SendCoinsReturn runWalletOperation(std::function<WalletModel::SendCoinsReturn()> operation)
 {
     WalletModel::SendCoinsReturn result;
-    std::exception_ptr exception;
-    QEventLoop waitLoop;
-    std::thread worker([&] {
-        try {
-            result = operation();
-        } catch (...) {
-            exception = std::current_exception();
-        }
-        QMetaObject::invokeMethod(&waitLoop, &QEventLoop::quit, Qt::QueuedConnection);
+    GUIUtil::runWalletOperation([&] {
+        result = operation();
     });
-    QApplication::setOverrideCursor(Qt::WaitCursor);
-    // Restore the cursor and join the worker even if an exception escapes the
-    // nested event loop: destroying a joinable std::thread would call
-    // std::terminate().
-    struct Cleanup {
-        std::thread& worker;
-        ~Cleanup()
-        {
-            if (worker.joinable())
-                worker.join();
-            QApplication::restoreOverrideCursor();
-        }
-    } cleanup{worker};
-    waitLoop.exec(QEventLoop::ExcludeUserInputEvents);
-    worker.join();
-    if (exception)
-        std::rethrow_exception(exception);
     return result;
 }
 }

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -939,7 +939,9 @@ void SendCoinsDialog::processSendCoinsReturn(const WalletModel::SendCoinsReturn 
         msgParams.first = tr("Duplicate address found: addresses should only be used once each.");
         break;
     case WalletModel::TransactionCreationFailed:
-        msgParams.first = tr("Transaction creation failed!");
+        msgParams.first = sendCoinsReturn.reasonCommitFailed.isEmpty()
+            ? tr("Transaction creation failed!")
+            : tr("Transaction creation failed: %1").arg(sendCoinsReturn.reasonCommitFailed);
         msgParams.second = CClientUIInterface::MSG_ERROR;
         break;
     case WalletModel::TransactionCommitFailed:

--- a/src/qt/test/test_sendcoinsentry.cpp
+++ b/src/qt/test/test_sendcoinsentry.cpp
@@ -8,3 +8,12 @@ void TestSendCoinsEntry::testGenerateWarningText()
     QCOMPARE(SendCoinsEntry::generateWarningText("sr1ek2uspg2v4qu0lmccrnj90tfkdpp5zmpykr4ffdprqlf0s4devl8n0674s4d4cthxsa5w9p66s5x0zgw982t80xx9uzmxysxuawmupgfa0xecj9shm6pj7l3rshqxqtg94k88fg5u856r", true), QObject::tr(" You are sending Firo from a Spark address to another Spark address. This transaction is fully private."));
     QCOMPARE(SendCoinsEntry::generateWarningText("TLyNUvysvUyt2u6vL74NEkB6ed8LTQd3mz", true), QObject::tr(" You are sending Firo from a private Spark pool to a transparent address. Please note that some exchanges do not accept direct Spark deposits."));
 }
+
+void TestSendCoinsEntry::testTransactionCreationErrorDetails()
+{
+    const QString reason = "Transaction is too large. Select fewer inputs.";
+    const WalletModel::SendCoinsReturn result(WalletModel::TransactionCreationFailed, reason);
+
+    QCOMPARE(result.status, WalletModel::TransactionCreationFailed);
+    QCOMPARE(result.reasonCommitFailed, reason);
+}

--- a/src/qt/test/test_sendcoinsentry.h
+++ b/src/qt/test/test_sendcoinsentry.h
@@ -11,6 +11,7 @@ class TestSendCoinsEntry : public QObject
 
 private Q_SLOTS:
     void testGenerateWarningText();
+    void testTransactionCreationErrorDetails();
 };
 
 #endif // BITCOIN_QT_TEST_SENDCOINSENTRY_H

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -1207,9 +1207,7 @@ WalletModel::SendCoinsReturn WalletModel::prepareMintSparkTransaction(std::vecto
         }
         
         if (!fCreated) {
-            Q_EMIT message(tr("Mint Spark"), QString::fromStdString(strFailReason),
-                CClientUIInterface::MSG_ERROR);
-            return TransactionCreationFailed;
+            return SendCoinsReturn(TransactionCreationFailed, QString::fromStdString(strFailReason));
         }
 
         if (!fSubtractFeeFromAmount && (total + nFeeRequired) > nBalance) {


### PR DESCRIPTION
## PR intention

Make the Spark privacy action understandable without requiring users to know what Spark is, let them choose how much of their transparent balance to make private, and recover safely when the wallet cannot create the requested transaction.

## Code changes brief

- Replace the detached `Anonymize All` action with `Make Private...` beside the eligible transparent balance.
- Add a focused amount dialog with source and destination labels, an exact amount field, and a `Max` option.
- Reuse the existing Spark mint preparation and commit path, including fee subtraction for `Max` and an exact fee review before confirmation.
- If preparation fails, preserve the entered amount and offer `Change Amount` or `Cancel`. No automatic splitting, silent amount changes, or fund movement is added. Encrypted wallets relock before amount editing.
- Show the wallet's original transaction-creation error under `Details`, while keeping the main message concise.
- Preserve that error for the existing Send screen instead of emitting a duplicate wallet popup.
- Update related automatic privacy and settings copy to use the same user-facing language.
- Share the existing wallet worker helper so preparing and committing the Spark transaction does not freeze GUI repainting.

## Testing

- `git diff --check`
- Source-level checks for the recovery controls and propagated wallet error
- Added a Qt unit check that preserves transaction-creation error details
- Parsed all modified Qt `.ui` files as XML
- Local Qt build and test binary not run because this Windows checkout has no CMake/compiler toolchain and WSL is not installed
