### PR TITLE
Qt: speed up wallet model startup

### DIFF
--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -9,7 +9,6 @@
 
 #include "base58.h"
 #include "wallet/wallet.h"
-#include "validation.h"
 #include "bip47/defs.h"
 #include "bip47/paymentchannel.h"
 #include "../sparkname.h"
@@ -133,16 +132,20 @@ private:
     }
 
 public:
-    AddressTablePriv(CWallet *_wallet, AddressTableModel *_parent):
-        wallet(_wallet), parent(_parent) {
+    AddressTablePriv(CWallet *_wallet, AddressTableModel *_parent, bool subscribe):
+        wallet(_wallet), parent(_parent), subscribed(subscribe) {
 
-        uiInterface.NotifySparkNameAdded.connect(boost::bind(&AddressTablePriv::sparkNameAdded, this, _1));
-        uiInterface.NotifySparkNameRemoved.connect(boost::bind(&AddressTablePriv::sparkNameRemoved, this, _1));
+        if (subscribed) {
+            uiInterface.NotifySparkNameAdded.connect(boost::bind(&AddressTablePriv::sparkNameAdded, this, _1));
+            uiInterface.NotifySparkNameRemoved.connect(boost::bind(&AddressTablePriv::sparkNameRemoved, this, _1));
+        }
     }
 
     ~AddressTablePriv() {
-        uiInterface.NotifySparkNameAdded.disconnect(boost::bind(&AddressTablePriv::sparkNameAdded, this, _1));
-        uiInterface.NotifySparkNameRemoved.disconnect(boost::bind(&AddressTablePriv::sparkNameRemoved, this, _1));
+        if (subscribed) {
+            uiInterface.NotifySparkNameAdded.disconnect(boost::bind(&AddressTablePriv::sparkNameAdded, this, _1));
+            uiInterface.NotifySparkNameRemoved.disconnect(boost::bind(&AddressTablePriv::sparkNameRemoved, this, _1));
+        }
     }
 
     void refreshSparkNames()
@@ -167,7 +170,6 @@ public:
     {
         cachedAddressTable.clear();
         {
-            LOCK(cs_main);      // for CSparkNameManager
             LOCK(wallet->cs_wallet);
 
             BOOST_FOREACH(const PAIRTYPE(CTxDestination, CAddressBookData)& item, wallet->mapAddressBook)
@@ -360,14 +362,23 @@ public:
                     changeType);
         }
     }
+
+private:
+    bool subscribed;
 };
 
 AddressTableModel::AddressTableModel(CWallet *_wallet, WalletModel *parent) :
+    AddressTableModel(_wallet, parent, true)
+{
+}
+
+AddressTableModel::AddressTableModel(CWallet *_wallet, WalletModel *parent, bool loadAddressBook) :
     QAbstractTableModel(parent),walletModel(parent),wallet(_wallet),priv(0)
 {
     columns << tr("Label") << tr("Address") << tr("Address Type");
-    priv = new AddressTablePriv(wallet, this);
-    priv->refreshAddressTable();
+    priv = new AddressTablePriv(wallet, this, loadAddressBook);
+    if (loadAddressBook)
+        priv->refreshAddressTable();
 }
 
 AddressTableModel::~AddressTableModel()
@@ -830,7 +841,7 @@ static void NotifyPcodeLabeled(PcodeAddressTableModel *walletmodel, std::string 
 }
 
 PcodeAddressTableModel::PcodeAddressTableModel(CWallet *wallet_, WalletModel *parent)
-:AddressTableModel(wallet_, parent)
+:AddressTableModel(wallet_, parent, false)
 {
     // columns[AddressTableModel::Address] = tr("RAP payment code");
     updatePcodeData();
@@ -881,6 +892,13 @@ QVariant PcodeAddressTableModel::data(const QModelIndex &index, int role) const
         return font;
     }
     return QVariant();
+}
+
+QModelIndex PcodeAddressTableModel::index(int row, int column, const QModelIndex &parent) const
+{
+    if (parent.isValid() || row < 0 || row >= rowCount(parent) || column < 0 || column >= columnCount(parent))
+        return QModelIndex();
+    return createIndex(row, column);
 }
 
 bool PcodeAddressTableModel::setData(const QModelIndex &index, const QVariant &value, int role)

--- a/src/qt/addresstablemodel.h
+++ b/src/qt/addresstablemodel.h
@@ -97,6 +97,8 @@ public:
 
     WalletModel *getWalletModel() const { return walletModel; }
 protected:
+    AddressTableModel(CWallet *wallet, WalletModel *parent, bool loadAddressBook);
+
     WalletModel *walletModel;
     CWallet *wallet;
     EditStatus editStatus;
@@ -140,6 +142,7 @@ public:
     int rowCount(const QModelIndex &parent) const override;
     int columnCount(const QModelIndex &parent) const override;
     QVariant data(const QModelIndex &index, int role) const override;
+    QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const override;
     bool setData(const QModelIndex &index, const QVariant &value, int role) override;
     QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
     bool removeRows(int row, int count, const QModelIndex &parent = QModelIndex()) override;

--- a/src/spark/sparkwallet.cpp
+++ b/src/spark/sparkwallet.cpp
@@ -331,10 +331,6 @@ bool CSparkWallet::isAddressMine(const std::string& encodedAddr) {
 
 bool CSparkWallet::isAddressMine(const spark::Address& address) {
     LOCK(cs_spark_wallet);
-    for (const auto& itr : addresses) {
-        if (itr.second.get_Q1() == address.get_Q1() && itr.second.get_Q2() == address.get_Q2())
-            return true;
-    }
 
     uint64_t d;
 
@@ -344,7 +340,7 @@ bool CSparkWallet::isAddressMine(const spark::Address& address) {
         return false;
     }
 
-    spark::Address newAddr = getAddress(int32_t(d));
+    const spark::Address newAddr(viewKey, int32_t(d));
     if (newAddr.get_Q1() == address.get_Q1() && newAddr.get_Q2() == address.get_Q2())
         return true;
 

--- a/src/test/spark_tests.cpp
+++ b/src/test/spark_tests.cpp
@@ -83,6 +83,27 @@ BOOST_AUTO_TEST_CASE(is_spark_allowed)
     BOOST_CHECK(IsSparkAllowed(start + 1));
 }
 
+BOOST_AUTO_TEST_CASE(wallet_address_ownership)
+{
+    auto params = Params::get_default();
+    CSparkWallet* wallet = pwalletMain->sparkWallet.get();
+    Address ownAddress = wallet->generateNewAddress();
+
+    BOOST_CHECK(wallet->isAddressMine(ownAddress));
+    BOOST_CHECK(wallet->isAddressMine(ownAddress.encode(GetNetworkType())));
+    BOOST_CHECK(wallet->isAddressMine(wallet->getAddress(123)));
+    BOOST_CHECK(wallet->isAddressMine(wallet->getChangeAddress()));
+
+    const SpendKey foreignSpendKey(params);
+    const FullViewKey foreignFullViewKey(foreignSpendKey);
+    const IncomingViewKey foreignViewKey(foreignFullViewKey);
+    const Address foreignAddress(foreignViewKey, 1);
+
+    BOOST_CHECK(!wallet->isAddressMine(foreignAddress));
+    BOOST_CHECK(!wallet->isAddressMine(foreignAddress.encode(GetNetworkType())));
+    BOOST_CHECK(!wallet->isAddressMine("not a Spark address"));
+}
+
 BOOST_AUTO_TEST_CASE(parse_spark_mintscript)
 {
     auto params = Params::get_default();


### PR DESCRIPTION
## PR intention

Reduce the GUI-thread work performed after core initialization, when the splash screen can appear frozen on "Starting network threads...".

The wallet model currently constructs both an `AddressTableModel` and a `PcodeAddressTableModel`. Because the payment-code model derives from the address model, its base constructor rebuilds the complete address and Spark Name table a second time even though the payment-code model does not use that cache. Spark Name ownership checks also linearly scan every generated Spark address before performing the authoritative view-key derivation, and the address refresh holds `cs_main` even though `CSparkNameManager::DumpSparkNameData()` uses its own lock.

## Code changes brief

- Let the payment-code model skip the unused address-table cache and Spark Name signal subscription, while providing its own row index implementation.
- Resolve Spark address ownership directly through the incoming view key and retain the full Q1/Q2 equality check.
- Stop taking `cs_main` during address table refresh. Wallet maps remain protected by `cs_wallet`.
- Add wallet address ownership coverage for generated, encoded, uncached, change, foreign, and malformed addresses.

No wallet database, balance, transaction, consensus, or RPC behavior changes. The optimized data is limited to Qt view construction and Spark address ownership lookup.

## Validation

- `git diff --check`
- Added `spark_tests/wallet_address_ownership`
- Local compilation and test execution were not available in this Windows checkout because CMake, Ninja, WSL, and a configured build directory are absent. CI is expected to provide build and test coverage.