### PR TITLE
Spark: Fix spend key buffer reuse

### DIFF
--- a/src/libspark/keys.cpp
+++ b/src/libspark/keys.cpp
@@ -17,28 +17,29 @@ SpendKey::SpendKey(const Params* params) {
 SpendKey::SpendKey(const Params* params, const Scalar& r_) {
     this->params = params;
     this->r = r_;
-    std::vector<unsigned char> data;
-    data.resize(32);
+    std::vector<unsigned char> data(32);
     r.serialize(data.data());
-    std::vector<unsigned char> result(CSHA256().OUTPUT_SIZE);
+    std::vector<unsigned char> result(CSHA256::OUTPUT_SIZE);
 
     CHash256 hash256;
     std::string prefix1 = "s1_generation";
     hash256.Write(reinterpret_cast<const unsigned char*>(prefix1.c_str()), prefix1.size());
     hash256.Write(data.data(), data.size());
-    hash256.Finalize(&result[0]);
-    this->s1.memberFromSeed(&result[0]);
+    hash256.Finalize(result.data());
+    this->s1.memberFromSeed(result.data());
 
-    data.clear();
-    result.clear();
+    // Keep the buffers sized while reusing them. clear() makes subsequent
+    // writes through data() undefined, even if the vector retains capacity.
+    memory_cleanse(data.data(), data.size());
+    memory_cleanse(result.data(), result.size());
     hash256.Reset();
     s1.serialize(data.data());
 
     std::string prefix2 = "s2_generation";
     hash256.Write(reinterpret_cast<const unsigned char*>(prefix2.c_str()), prefix2.size());
     hash256.Write(data.data(), data.size());
-    hash256.Finalize(&result[0]);
-    this->s2.memberFromSeed(&result[0]);
+    hash256.Finalize(result.data());
+    this->s2.memberFromSeed(result.data());
 }
 
 const Params* SpendKey::get_params() const {

--- a/src/libspark/test/address_test.cpp
+++ b/src/libspark/test/address_test.cpp
@@ -9,6 +9,17 @@ using namespace secp_primitives;
 
 BOOST_FIXTURE_TEST_SUITE(spark_address_tests, BasicTestingSetup)
 
+BOOST_AUTO_TEST_CASE(spend_key_recovery)
+{
+    const Params* params = Params::get_test();
+    const SpendKey original(params);
+    const SpendKey recovered1(params, original.get_r());
+    const SpendKey recovered2(params, original.get_r());
+
+    BOOST_CHECK(recovered1.get_s1() == recovered2.get_s1());
+    BOOST_CHECK(recovered1.get_s2() == recovered2.get_s2());
+}
+
 // Check that correct encoding and decoding succeed
 BOOST_AUTO_TEST_CASE(correctness)
 {


### PR DESCRIPTION
## PR intention

Prevent the Windows access violation observed after clicking **Anonymize All**.

Spark deterministic spend-key construction cleared its hash input and output vectors, then wrote through storage outside the vectors' live element ranges. This undefined behavior could corrupt memory and surface later in unrelated code, which explains the misleading `CNodeStats` and `std::string` frames in the reported stack trace.

## Code changes

- Keep both key-derivation buffers at their required sizes while they are reused.
- Reset sensitive intermediate material with `memory_cleanse` instead of shrinking the vectors with `clear()`.
- Use `vector::data()` only while the buffers contain live elements.
- Add a regression test for deterministic `s1` and `s2` derivation from the same spend-key scalar.

## Testing

- `git diff --check`
- Added `spark_address_tests/spend_key_recovery`
- Full Boost test execution is pending CI because this checkout has no configured build directory.