### PR TITLE
Spark: fix out-of-range vector writes in SpendKey derivation

### DIFF
--- a/src/libspark/keys.cpp
+++ b/src/libspark/keys.cpp
@@ -17,28 +17,31 @@ SpendKey::SpendKey(const Params* params) {
 SpendKey::SpendKey(const Params* params, const Scalar& r_) {
     this->params = params;
     this->r = r_;
-    std::vector<unsigned char> data;
-    data.resize(32);
+    std::vector<unsigned char> data(32);
     r.serialize(data.data());
-    std::vector<unsigned char> result(CSHA256().OUTPUT_SIZE);
+    std::vector<unsigned char> result(CSHA256::OUTPUT_SIZE);
 
     CHash256 hash256;
     std::string prefix1 = "s1_generation";
     hash256.Write(reinterpret_cast<const unsigned char*>(prefix1.c_str()), prefix1.size());
     hash256.Write(data.data(), data.size());
-    hash256.Finalize(&result[0]);
-    this->s1.memberFromSeed(&result[0]);
+    hash256.Finalize(result.data());
+    this->s1.memberFromSeed(result.data());
 
-    data.clear();
-    result.clear();
     hash256.Reset();
-    s1.serialize(data.data());
 
+    // Consensus-critical: the s2 seed commits only to the prefix below. The
+    // historical code cleared `data` before this point, so its Write()
+    // contributed zero bytes; every deployed wallet derives s2 that way.
+    // Hashing anything else here (e.g. s1) changes all existing view keys
+    // and addresses. See spend_key_derivation in test/address_test.cpp.
     std::string prefix2 = "s2_generation";
     hash256.Write(reinterpret_cast<const unsigned char*>(prefix2.c_str()), prefix2.size());
-    hash256.Write(data.data(), data.size());
-    hash256.Finalize(&result[0]);
-    this->s2.memberFromSeed(&result[0]);
+    hash256.Finalize(result.data());
+    this->s2.memberFromSeed(result.data());
+
+    memory_cleanse(data.data(), data.size());
+    memory_cleanse(result.data(), result.size());
 }
 
 const Params* SpendKey::get_params() const {

--- a/src/libspark/test/address_test.cpp
+++ b/src/libspark/test/address_test.cpp
@@ -1,5 +1,6 @@
 #include "../keys.h"
 
+#include "../../hash.h"
 #include "../../test/test_bitcoin.h"
 #include <boost/test/unit_test.hpp>
 
@@ -8,6 +9,57 @@ namespace spark {
 using namespace secp_primitives;
 
 BOOST_FIXTURE_TEST_SUITE(spark_address_tests, BasicTestingSetup)
+
+// The deterministic derivation of s1 and s2 from r is consensus-critical for
+// wallets: changing it changes every wallet's view keys and addresses,
+// orphaning previously received funds. These checks pin the deployed
+// derivation:
+//   s1 = memberFromSeed(SHA256d("s1_generation" || ser(r)))
+//   s2 = memberFromSeed(SHA256d("s2_generation"))
+// The s2 seed intentionally commits to nothing but its prefix (a historical
+// quirk that must be kept for compatibility), so s2 is the same scalar for
+// every spend key and must not depend on r or s1.
+BOOST_AUTO_TEST_CASE(spend_key_derivation)
+{
+    const Params* params = Params::get_test();
+
+    Scalar r1, r2;
+    r1.randomize();
+    r2.randomize();
+    const SpendKey key1(params, r1);
+    const SpendKey key2(params, r2);
+
+    // Derivation is deterministic in r
+    const SpendKey key1_again(params, r1);
+    BOOST_CHECK(key1.get_s1() == key1_again.get_s1());
+    BOOST_CHECK(key1.get_s2() == key1_again.get_s2());
+
+    // s1 depends on r; s2 does not
+    BOOST_CHECK(key1.get_s1() != key2.get_s1());
+    BOOST_CHECK(key1.get_s2() == key2.get_s2());
+
+    // s1 matches the pinned derivation
+    unsigned char seed[CSHA256::OUTPUT_SIZE];
+    std::vector<unsigned char> r_bytes(32);
+    r1.serialize(r_bytes.data());
+    const std::string prefix1 = "s1_generation";
+    CHash256 hasher;
+    hasher.Write(reinterpret_cast<const unsigned char*>(prefix1.data()), prefix1.size());
+    hasher.Write(r_bytes.data(), r_bytes.size());
+    hasher.Finalize(seed);
+    Scalar expected_s1;
+    expected_s1.memberFromSeed(seed);
+    BOOST_CHECK(key1.get_s1() == expected_s1);
+
+    // s2 matches the pinned derivation: the seed hash covers only the prefix
+    const std::string prefix2 = "s2_generation";
+    hasher.Reset();
+    hasher.Write(reinterpret_cast<const unsigned char*>(prefix2.data()), prefix2.size());
+    hasher.Finalize(seed);
+    Scalar expected_s2;
+    expected_s2.memberFromSeed(seed);
+    BOOST_CHECK(key1.get_s2() == expected_s2);
+}
 
 // Check that correct encoding and decoding succeed
 BOOST_AUTO_TEST_CASE(correctness)


### PR DESCRIPTION
## PR intention

Replaces #1893 with a version that cleans up the undefined behavior in `SpendKey::SpendKey(const Params*, const Scalar&)` **without changing key derivation**.

The current code clears its hash input and output vectors and then keeps writing through `data()` / `&result[0]` on empty vectors. That is undefined behavior on paper (and asserts in MSVC debug builds), but in practice the writes stay inside the retained capacity of the same allocations, so it never corrupted memory in release builds — it does not explain the reported Windows access violations.

The dangerous part of #1893 (and of #1767 before it, reverted in #1784) is that keeping the buffers sized silently changes the `s2` seed hash from `SHA256d("s2_generation")` to `SHA256d("s2_generation" || ser(s1))`. Since `P2 = F*s2 + D` feeds the full/incoming view keys and every address's `Q2`, that would change every existing wallet's addresses on upgrade or seed restore, orphaning previously received funds. The constant-`s2` derivation is a known, accepted quirk (it makes incoming view keys effectively full view keys) and is consensus-frozen for wallet compatibility.

## Code changes brief

- `Tests:` add `spark_address_tests/spend_key_derivation`, which pins the deployed derivation before any code change: determinism of `(s1, s2)` in `r`, `s1` depends on `r` while `s2` does not, and both scalars match an explicit re-derivation via `CHash256` with the `s2` seed hashing **only** the `"s2_generation"` prefix. Any future derivation drift (as attempted by #1767 and #1893) now fails CI.
- `Spark:` keep both buffers at their required sizes for the whole derivation (no writes outside the vectors' live element range), drop the dead `s1.serialize()` into a never-hashed buffer, wipe the buffers with `memory_cleanse()` before scope exit instead of `clear()` (so key material is not left readable in freed heap memory), and document the frozen `s2` derivation in place.

The `s2` seed hash input remains byte-for-byte identical to the deployed derivation, so existing wallets keep their view keys and addresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HVp6JH7LvzRpZXU4VEjdDG

---
_Generated by [Claude Code](https://claude.ai/code/session_01HVp6JH7LvzRpZXU4VEjdDG)_