### PR TITLE
Wallet: Compute GUI balances in one wallet scan to fix per-block stutter

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -131,7 +131,7 @@ testScripts = [
     # 'mempool_limit.py',
     # 'merkle_blocks.py',
     'receivedby.py',
-    # 'abandonconflict.py',
+    'abandonconflict.py',
     # 'bip68-112-113-p2p.py',
     # 'rawtransactions.py',
     # vv Tests less than 30s vv

--- a/qa/rpc-tests/abandonconflict.py
+++ b/qa/rpc-tests/abandonconflict.py
@@ -6,6 +6,7 @@
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
+import os
 import urllib.parse
 
 class AbandonConflictTest(BitcoinTestFramework):
@@ -71,11 +72,10 @@ class AbandonConflictTest(BitcoinTestFramework):
         assert_equal(newbalance, balance - Decimal("30") + Decimal("24.9996"))
         balance = newbalance
 
-        # Restart the node with a higher min relay fee so the parent tx is no longer in mempool
-        # TODO: redo with eviction
-        # Note had to make sure tx did not have AllowFree priority
+        # Discard the persisted mempool and disable wallet reacceptance.
         stop_node(self.nodes[0],0)
-        self.nodes[0]=start_node(0, self.options.tmpdir, ["-debug","-logtimemicros","-minrelaytxfee=0.0001"])
+        os.remove(log_filename(self.options.tmpdir, 0, "mempool.dat"))
+        self.nodes[0]=start_node(0, self.options.tmpdir, ["-debug","-logtimemicros","-walletbroadcast=0"])
 
         # Verify txs no longer in mempool
         assert_equal(len(self.nodes[0].getrawmempool()), 0)
@@ -119,9 +119,10 @@ class AbandonConflictTest(BitcoinTestFramework):
         assert_equal(newbalance, balance - Decimal("10") - Decimal("14.99998") + Decimal("24.9996"))
         balance = newbalance
 
-        # Remove using high relay fee again
+        # Remove from the mempool the same way again.
         stop_node(self.nodes[0],0)
-        self.nodes[0]=start_node(0, self.options.tmpdir, ["-debug","-logtimemicros","-minrelaytxfee=0.0001"])
+        os.remove(log_filename(self.options.tmpdir, 0, "mempool.dat"))
+        self.nodes[0]=start_node(0, self.options.tmpdir, ["-debug","-logtimemicros","-walletbroadcast=0"])
         assert_equal(len(self.nodes[0].getrawmempool()), 0)
         newbalance = self.nodes[0].getbalance()
         assert_equal(newbalance, balance - Decimal("24.9996"))

--- a/qa/rpc-tests/abandonconflict.py
+++ b/qa/rpc-tests/abandonconflict.py
@@ -146,15 +146,16 @@ class AbandonConflictTest(BitcoinTestFramework):
         assert_equal(newbalance, balance + Decimal("20"))
         balance = newbalance
 
-        # There is currently a minor bug around this and so this test doesn't work.  See Issue #7315
-        # Invalidate the block with the double spend and B's 10 BTC output should no longer be available
-        # Don't think C's should either
-        self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
+        # Invalidate the block with the double spend. AB1 and its child are no longer
+        # conflicted, so B's and C's 10 BTC outputs are spent by them again.
+        conflict_block = self.nodes[0].getbestblockhash()
+        self.nodes[0].invalidateblock(conflict_block)
         newbalance = self.nodes[0].getbalance()
-        #assert_equal(newbalance, balance - Decimal("10"))
-        print("If balance has not declined after invalidateblock then out of mempool wallet tx which is no longer")
-        print("conflicted has not resumed causing its inputs to be seen as spent.  See Issue #7315")
-        print(str(balance) + " -> " + str(newbalance) + " ?")
+        assert_equal(newbalance, balance - Decimal("20"))
+
+        # Reconnecting the same conflict must release both outputs again.
+        self.nodes[0].reconsiderblock(conflict_block)
+        assert_equal(self.nodes[0].getbalance(), balance)
 
 if __name__ == '__main__':
     AbandonConflictTest().main()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3330,6 +3330,13 @@ bool static DisconnectTip(CValidationState& state, const CChainParams& chainpara
         }
     }
 #endif
+
+#ifdef ENABLE_WALLET
+    // A disconnect can unconflict wallet transactions that are not otherwise
+    // notified, changing whether their inputs are spent.
+    if (!GetBoolArg("-disablewallet", false) && pwalletMain)
+        pwalletMain->MarkDirty();
+#endif
     // Let wallets know transactions went from 1-confirmed to
     // 0-confirmed or conflicted:
     for (const auto& tx : block.vtx) {

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -484,6 +484,8 @@ UniValue importwallet(const JSONRPCRequest& request)
     CKeyID masterKeyID = pwallet->GetHDChain().masterKeyID;
 
     pwallet->ShowProgress(_("Importing..."), 0); // show progress dialog in GUI
+    // A later malformed line can fail after earlier keys were imported.
+    pwallet->MarkDirty();
     while (file.good()) {
         pwallet->ShowProgress("", std::max(1, std::min(99, (int)(((double)file.tellg() / (double)nFilesize) * 100))));
         std::string line;
@@ -564,7 +566,6 @@ UniValue importwallet(const JSONRPCRequest& request)
 
     LogPrintf("Rescanning last %i blocks\n", pindex ? chainActive.Height() - pindex->nHeight + 1 : 0);
     pwallet->ScanForWalletTransactions(pindex);
-    pwallet->MarkDirty();
 
     if (!fGood)
         throw JSONRPCError(RPC_WALLET_ERROR, "Error adding some keys to wallet");

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1955,6 +1955,7 @@ UniValue addmultisigaddress(const JSONRPCRequest& request)
     CScript inner = _createmultisig_redeemScript(pwallet, request.params);
     CScriptID innerID(inner);
     pwallet->AddCScript(inner);
+    pwallet->MarkDirty();
 
     pwallet->SetAddressBook(innerID, strAccount, "send");
     return CBitcoinAddress(innerID).ToString();
@@ -2049,9 +2050,14 @@ UniValue addwitnessaddress(const JSONRPCRequest& request)
 
     Witnessifier w(pwallet);
     CTxDestination dest = address.Get();
-    bool ret = boost::apply_visitor(w, dest);
-    if (!ret) {
-        throw JSONRPCError(RPC_WALLET_ERROR, "Public key or redeemscript not known to wallet, or the key is uncompressed");
+    {
+        LOCK(pwallet->cs_wallet);
+        bool ret = boost::apply_visitor(w, dest);
+        if (!ret) {
+            throw JSONRPCError(RPC_WALLET_ERROR, "Public key or redeemscript not known to wallet, or the key is uncompressed");
+        }
+
+        pwallet->MarkDirty();
     }
 
     pwallet->SetAddressBook(w.result, "", "receive");

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1954,8 +1954,8 @@ UniValue addmultisigaddress(const JSONRPCRequest& request)
     // Construct using pay-to-script-hash:
     CScript inner = _createmultisig_redeemScript(pwallet, request.params);
     CScriptID innerID(inner);
-    pwallet->AddCScript(inner);
     pwallet->MarkDirty();
+    pwallet->AddCScript(inner);
 
     pwallet->SetAddressBook(innerID, strAccount, "send");
     return CBitcoinAddress(innerID).ToString();
@@ -2052,15 +2052,14 @@ UniValue addwitnessaddress(const JSONRPCRequest& request)
     CTxDestination dest = address.Get();
     {
         LOCK(pwallet->cs_wallet);
+        pwallet->MarkDirty();
         bool ret = boost::apply_visitor(w, dest);
         if (!ret) {
             throw JSONRPCError(RPC_WALLET_ERROR, "Public key or redeemscript not known to wallet, or the key is uncompressed");
         }
 
-        pwallet->MarkDirty();
+        pwallet->SetAddressBook(w.result, "", "receive");
     }
-
-    pwallet->SetAddressBook(w.result, "", "receive");
 
     return CBitcoinAddress(w.result).ToString();
 }

--- a/src/wallet/test/CMakeLists.txt
+++ b/src/wallet/test/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(test_firo
   ${CMAKE_CURRENT_SOURCE_DIR}/crypto_tests.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/mnemonic_tests.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/spark_wallet_tests.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/wallet_balances_tests.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/wallet_test_fixture.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/wallet_tests.cpp
 )

--- a/src/wallet/test/wallet_balances_tests.cpp
+++ b/src/wallet/test/wallet_balances_tests.cpp
@@ -5,6 +5,7 @@
 #include "wallet/wallet.h"
 
 #include "amount.h"
+#include "base58.h"
 #include "rpc/server.h"
 #include "script/standard.h"
 #include "test/test_bitcoin.h"
@@ -15,11 +16,14 @@
 #include "validation.h"
 #include "wallet/test/wallet_test_fixture.h"
 
+#include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
 
+#include <fstream>
 #include <vector>
 
 extern UniValue addmultisigaddress(const JSONRPCRequest& request);
+extern UniValue importwallet(const JSONRPCRequest& request);
 
 namespace
 {
@@ -288,6 +292,45 @@ BOOST_AUTO_TEST_CASE(keypool_generation_invalidates_cached_ownership)
 
     BOOST_REQUIRE(pwalletMain->TopUpKeyPool());
     BOOST_REQUIRE(pwalletMain->HaveKey(futurePubKey.GetID()));
+    BOOST_CHECK(!wtx.fAvailableCreditCached);
+    CheckBalances(8 * COIN, 0, 0, 8 * COIN);
+}
+
+BOOST_AUTO_TEST_CASE(importwallet_partial_failure_invalidates_cached_ownership)
+{
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    const CPubKey masterPubKey = pwalletMain->GenerateNewHDMasterKey();
+    BOOST_REQUIRE(pwalletMain->SetHDMasterKey(masterPubKey, CHDChain::VERSION_WITH_BIP44));
+
+    CKey importedKey;
+    importedKey.MakeNewKey(true);
+    CMutableTransaction tx;
+    tx.vin.resize(1);
+    tx.vin[0].prevout = ForeignOutPoint(1);
+    tx.vout.resize(2);
+    tx.vout[0] = CTxOut(1 * COIN, walletScript);
+    tx.vout[1] = CTxOut(7 * COIN, GetScriptForDestination(importedKey.GetPubKey().GetID()));
+    const CWalletTx& wtx = AddTx(tx, true);
+    BOOST_CHECK_EQUAL(wtx.GetAvailableCredit(), 1 * COIN);
+
+    CKey malformedKey;
+    malformedKey.MakeNewKey(true);
+    const auto dumpPath = pathTemp / "partial-import.dump";
+    {
+        std::ofstream dump(dumpPath.string());
+        BOOST_REQUIRE(dump.is_open());
+        dump << CBitcoinSecret(importedKey).ToString() << " 1970-01-01T00:00:01Z\n";
+        dump << CBitcoinSecret(malformedKey).ToString()
+             << " 1970-01-01T00:00:01Z hdKeypath=m/44'/136'/0'/x/0\n";
+    }
+
+    JSONRPCRequest request;
+    request.params = UniValue(UniValue::VARR);
+    request.params.push_back(dumpPath.string());
+    BOOST_CHECK_THROW(importwallet(request), boost::bad_lexical_cast);
+
+    BOOST_REQUIRE(pwalletMain->HaveKey(importedKey.GetPubKey().GetID()));
     BOOST_CHECK(!wtx.fAvailableCreditCached);
     CheckBalances(8 * COIN, 0, 0, 8 * COIN);
 }

--- a/src/wallet/test/wallet_balances_tests.cpp
+++ b/src/wallet/test/wallet_balances_tests.cpp
@@ -188,6 +188,35 @@ BOOST_AUTO_TEST_CASE(add_to_wallet_invalidates_input_credit)
     CheckBalances(9 * COIN, 0, 0, 9 * COIN);
 }
 
+BOOST_AUTO_TEST_CASE(add_to_wallet_parent_invalidates_spender_debit)
+{
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    CMutableTransaction parent;
+    parent.vin.resize(1);
+    parent.vin[0].prevout = ForeignOutPoint(1);
+    parent.vout.resize(1);
+    parent.vout[0] = CTxOut(10 * COIN, walletScript);
+
+    CMutableTransaction child;
+    child.vin.resize(1);
+    child.vin[0].prevout = COutPoint(parent.GetHash(), 0);
+    child.vout.resize(1);
+    child.vout[0] = CTxOut(9 * COIN, walletScript);
+    const CWalletTx& childWtx = AddTx(child, false);
+    AddToMempool(child);
+
+    CheckBalances(0, 9 * COIN, 0, 0);
+    BOOST_REQUIRE(childWtx.fDebitCached);
+    BOOST_CHECK_EQUAL(childWtx.nDebitCached, 0);
+
+    AddTx(parent, true);
+
+    BOOST_CHECK(!childWtx.fDebitCached);
+    BOOST_CHECK_EQUAL(childWtx.GetDebit(ISMINE_SPENDABLE), 10 * COIN);
+    CheckBalances(9 * COIN, 0, 0, 9 * COIN);
+}
+
 BOOST_AUTO_TEST_CASE(add_to_wallet_update_invalidates_input_credit)
 {
     LOCK2(cs_main, pwalletMain->cs_wallet);

--- a/src/wallet/test/wallet_balances_tests.cpp
+++ b/src/wallet/test/wallet_balances_tests.cpp
@@ -1,0 +1,295 @@
+// Copyright (c) 2026 The Firo Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit/.
+
+#include "wallet/wallet.h"
+
+#include "amount.h"
+#include "rpc/server.h"
+#include "script/standard.h"
+#include "test/test_bitcoin.h"
+#include "txmempool.h"
+#include "uint256.h"
+#include "util.h"
+#include "utilstrencodings.h"
+#include "validation.h"
+#include "wallet/test/wallet_test_fixture.h"
+
+#include <boost/test/unit_test.hpp>
+
+#include <vector>
+
+extern UniValue addmultisigaddress(const JSONRPCRequest& request);
+
+namespace
+{
+
+struct WalletBalancesTestingSetup : public WalletTestingSetup
+{
+    WalletBalancesTestingSetup() : WalletTestingSetup(CBaseChainParams::REGTEST)
+    {
+        LOCK(pwalletMain->cs_wallet);
+        walletPubKey = pwalletMain->GenerateNewKey();
+        walletScript = GetScriptForDestination(walletPubKey.GetID());
+    }
+
+    static COutPoint ForeignOutPoint(unsigned char tag)
+    {
+        return COutPoint(uint256S(strprintf("%02x", tag)), 0);
+    }
+
+    const CWalletTx& AddTx(const CMutableTransaction& tx, bool inChain, bool abandoned = false)
+    {
+        CWalletTx wtx(pwalletMain, MakeTransactionRef(tx));
+        if (inChain) {
+            wtx.SetMerkleBranch(chainActive.Tip(), 0);
+        } else if (abandoned) {
+            wtx.setAbandoned();
+        }
+        // Exercise the runtime path used by direct imports, not the
+        // cache-empty LoadToWallet database-loading path.
+        BOOST_REQUIRE(pwalletMain->AddToWallet(wtx, false));
+        std::map<uint256, CWalletTx>::const_iterator it = pwalletMain->mapWallet.find(wtx.GetHash());
+        BOOST_REQUIRE(it != pwalletMain->mapWallet.end());
+        return it->second;
+    }
+
+    void AddToMempool(const CMutableTransaction& tx)
+    {
+        TestMemPoolEntryHelper entry;
+        BOOST_REQUIRE(mempool.addUnchecked(tx.GetHash(), entry.FromTx(tx)));
+    }
+
+    void CheckBalances(CAmount expectedBalance,
+                       CAmount expectedUnconfirmed,
+                       CAmount expectedImmature,
+                       CAmount expectedMintable)
+    {
+        CAmount balance = -1;
+        CAmount unconfirmed = -1;
+        CAmount immature = -1;
+        CAmount mintable = -1;
+        BOOST_REQUIRE(pwalletMain->TryGetBalances(balance, unconfirmed, immature, mintable));
+        BOOST_CHECK_EQUAL(balance, expectedBalance);
+        BOOST_CHECK_EQUAL(unconfirmed, expectedUnconfirmed);
+        BOOST_CHECK_EQUAL(immature, expectedImmature);
+        BOOST_CHECK_EQUAL(mintable, expectedMintable);
+        BOOST_CHECK_EQUAL(balance, pwalletMain->GetBalance());
+        BOOST_CHECK_EQUAL(unconfirmed, pwalletMain->GetUnconfirmedBalance());
+        BOOST_CHECK_EQUAL(immature, pwalletMain->GetImmatureBalance());
+        BOOST_CHECK_EQUAL(mintable, pwalletMain->GetBalance(true));
+    }
+
+    CPubKey walletPubKey;
+    CScript walletScript;
+};
+
+} // namespace
+
+BOOST_FIXTURE_TEST_SUITE(wallet_balances_tests, WalletBalancesTestingSetup)
+
+BOOST_AUTO_TEST_CASE(try_get_balances_matches_individual_getters)
+{
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    CheckBalances(0, 0, 0, 0);
+
+    CMutableTransaction trusted;
+    trusted.vin.resize(1);
+    trusted.vin[0].prevout = ForeignOutPoint(1);
+    trusted.vout.resize(2);
+    trusted.vout[0] = CTxOut(10 * COIN, walletScript);
+    trusted.vout[1] = CTxOut(5 * COIN, walletScript);
+    AddTx(trusted, true);
+    CheckBalances(15 * COIN, 0, 0, 15 * COIN);
+
+    CMutableTransaction coinbase;
+    coinbase.vin.resize(1);
+    coinbase.vin[0].prevout.SetNull();
+    coinbase.vout.resize(1);
+    coinbase.vout[0] = CTxOut(25 * COIN, walletScript);
+    AddTx(coinbase, true);
+    CheckBalances(15 * COIN, 0, 25 * COIN, 15 * COIN);
+
+    CMutableTransaction unconfirmed;
+    unconfirmed.vin.resize(1);
+    unconfirmed.vin[0].prevout = ForeignOutPoint(2);
+    unconfirmed.vout.resize(1);
+    unconfirmed.vout[0] = CTxOut(3 * COIN, walletScript);
+    AddTx(unconfirmed, false);
+    CheckBalances(15 * COIN, 0, 25 * COIN, 15 * COIN);
+
+    AddToMempool(unconfirmed);
+    CheckBalances(15 * COIN, 3 * COIN, 25 * COIN, 15 * COIN);
+
+    const COutPoint lockedOutpoint(trusted.GetHash(), 1);
+    pwalletMain->LockCoin(lockedOutpoint);
+    CheckBalances(15 * COIN, 3 * COIN, 25 * COIN, 10 * COIN);
+
+    pwalletMain->UnlockCoin(lockedOutpoint);
+    CheckBalances(15 * COIN, 3 * COIN, 25 * COIN, 15 * COIN);
+}
+
+BOOST_AUTO_TEST_CASE(exclude_locked_credit_preserves_unfiltered_cache)
+{
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    CMutableTransaction tx;
+    tx.vin.resize(1);
+    tx.vin[0].prevout = ForeignOutPoint(1);
+    tx.vout.resize(2);
+    tx.vout[0] = CTxOut(10 * COIN, walletScript);
+    tx.vout[1] = CTxOut(5 * COIN, walletScript);
+    const CWalletTx& wtx = AddTx(tx, true);
+
+    BOOST_CHECK_EQUAL(wtx.GetAvailableCredit(false, false), 15 * COIN);
+    BOOST_REQUIRE(wtx.fAvailableCreditCached);
+    BOOST_CHECK_EQUAL(wtx.GetAvailableCredit(true, false), 15 * COIN);
+
+    pwalletMain->LockCoin(COutPoint(tx.GetHash(), 1));
+    BOOST_CHECK_EQUAL(wtx.GetAvailableCredit(true, true), 10 * COIN);
+    BOOST_CHECK(wtx.fAvailableCreditCached);
+    BOOST_CHECK_EQUAL(wtx.nAvailableCreditCached, 15 * COIN);
+
+    wtx.nAvailableCreditCached = 1;
+    BOOST_CHECK_EQUAL(wtx.GetAvailableCredit(false, true), 10 * COIN);
+    BOOST_CHECK(wtx.fAvailableCreditCached);
+    BOOST_CHECK_EQUAL(wtx.nAvailableCreditCached, 1);
+
+    BOOST_CHECK_EQUAL(wtx.GetAvailableCredit(false, false), 15 * COIN);
+    BOOST_CHECK_EQUAL(wtx.GetAvailableCredit(true, false), 15 * COIN);
+}
+
+BOOST_AUTO_TEST_CASE(add_to_wallet_invalidates_input_credit)
+{
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    CMutableTransaction parent;
+    parent.vin.resize(1);
+    parent.vin[0].prevout = ForeignOutPoint(1);
+    parent.vout.resize(1);
+    parent.vout[0] = CTxOut(10 * COIN, walletScript);
+    const CWalletTx& parentWtx = AddTx(parent, true);
+    BOOST_CHECK_EQUAL(parentWtx.GetAvailableCredit(), 10 * COIN);
+
+    CMutableTransaction child;
+    child.vin.resize(1);
+    child.vin[0].prevout = COutPoint(parent.GetHash(), 0);
+    child.vout.resize(1);
+    child.vout[0] = CTxOut(9 * COIN, walletScript);
+    AddTx(child, true);
+
+    BOOST_CHECK(pwalletMain->IsSpent(parent.GetHash(), 0));
+    BOOST_CHECK(!parentWtx.fAvailableCreditCached);
+    CheckBalances(9 * COIN, 0, 0, 9 * COIN);
+}
+
+BOOST_AUTO_TEST_CASE(add_to_wallet_update_invalidates_input_credit)
+{
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    CMutableTransaction parent;
+    parent.vin.resize(1);
+    parent.vin[0].prevout = ForeignOutPoint(1);
+    parent.vout.resize(1);
+    parent.vout[0] = CTxOut(10 * COIN, walletScript);
+    const CWalletTx& parentWtx = AddTx(parent, true);
+
+    CMutableTransaction child;
+    child.vin.resize(1);
+    child.vin[0].prevout = COutPoint(parent.GetHash(), 0);
+    child.vout.resize(1);
+    child.vout[0] = CTxOut(9 * COIN, walletScript);
+    AddTx(child, false, true);
+    BOOST_CHECK(!pwalletMain->IsSpent(parent.GetHash(), 0));
+    BOOST_CHECK_EQUAL(parentWtx.GetAvailableCredit(), 10 * COIN);
+
+    CWalletTx confirmedChild(pwalletMain, MakeTransactionRef(child));
+    confirmedChild.SetMerkleBranch(chainActive.Tip(), 0);
+    BOOST_REQUIRE(pwalletMain->AddToWallet(confirmedChild, false));
+
+    BOOST_CHECK(pwalletMain->IsSpent(parent.GetHash(), 0));
+    BOOST_CHECK(!parentWtx.fAvailableCreditCached);
+    CheckBalances(9 * COIN, 0, 0, 9 * COIN);
+}
+
+BOOST_AUTO_TEST_CASE(erase_from_wallet_invalidates_cached_balances)
+{
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    CMutableTransaction parent;
+    parent.vin.resize(1);
+    parent.vin[0].prevout = ForeignOutPoint(1);
+    parent.vout.resize(1);
+    parent.vout[0] = CTxOut(10 * COIN, walletScript);
+    const CWalletTx& parentWtx = AddTx(parent, true);
+
+    CMutableTransaction child;
+    child.vin.resize(1);
+    child.vin[0].prevout = COutPoint(parent.GetHash(), 0);
+    child.vout.resize(1);
+    child.vout[0] = CTxOut(9 * COIN, walletScript);
+    AddTx(child, true);
+    BOOST_CHECK_EQUAL(parentWtx.GetAvailableCredit(), 0);
+
+    BOOST_REQUIRE(pwalletMain->EraseFromWallet(child.GetHash()));
+    BOOST_CHECK(!pwalletMain->IsSpent(parent.GetHash(), 0));
+    BOOST_CHECK(!parentWtx.fAvailableCreditCached);
+    CheckBalances(10 * COIN, 0, 0, 10 * COIN);
+}
+
+BOOST_AUTO_TEST_CASE(addmultisigaddress_invalidates_cached_ownership)
+{
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    const CScript redeemScript = GetScriptForMultisig(1, std::vector<CPubKey>{walletPubKey});
+    CMutableTransaction tx;
+    tx.vin.resize(1);
+    tx.vin[0].prevout = ForeignOutPoint(1);
+    tx.vout.resize(2);
+    tx.vout[0] = CTxOut(1 * COIN, walletScript);
+    tx.vout[1] = CTxOut(7 * COIN, GetScriptForDestination(CScriptID(redeemScript)));
+    const CWalletTx& wtx = AddTx(tx, true);
+    BOOST_CHECK_EQUAL(wtx.GetAvailableCredit(), 1 * COIN);
+
+    UniValue keys(UniValue::VARR);
+    keys.push_back(HexStr(walletPubKey));
+    JSONRPCRequest request;
+    request.params = UniValue(UniValue::VARR);
+    request.params.push_back(1);
+    request.params.push_back(keys);
+    addmultisigaddress(request);
+
+    BOOST_CHECK(!wtx.fAvailableCreditCached);
+    CheckBalances(8 * COIN, 0, 0, 8 * COIN);
+}
+
+BOOST_AUTO_TEST_CASE(keypool_generation_invalidates_cached_ownership)
+{
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    const CPubKey masterPubKey = pwalletMain->GenerateNewHDMasterKey();
+    BOOST_REQUIRE(pwalletMain->SetHDMasterKey(masterPubKey, CHDChain::VERSION_WITH_BIP44));
+    BOOST_REQUIRE(pwalletMain->NewKeyPool());
+
+    CKey futureKey;
+    const uint32_t nextChild = pwalletMain->GetHDChain().nExternalChainCounters[0];
+    const CPubKey futurePubKey = pwalletMain->GetKeyFromKeypath(0, nextChild, futureKey);
+    BOOST_REQUIRE(!pwalletMain->HaveKey(futurePubKey.GetID()));
+
+    CMutableTransaction tx;
+    tx.vin.resize(1);
+    tx.vin[0].prevout = ForeignOutPoint(1);
+    tx.vout.resize(2);
+    tx.vout[0] = CTxOut(1 * COIN, walletScript);
+    tx.vout[1] = CTxOut(7 * COIN, GetScriptForDestination(futurePubKey.GetID()));
+    const CWalletTx& wtx = AddTx(tx, true);
+    BOOST_CHECK_EQUAL(wtx.GetAvailableCredit(), 1 * COIN);
+
+    BOOST_REQUIRE(pwalletMain->TopUpKeyPool());
+    BOOST_REQUIRE(pwalletMain->HaveKey(futurePubKey.GetID()));
+    BOOST_CHECK(!wtx.fAvailableCreditCached);
+    CheckBalances(8 * COIN, 0, 0, 8 * COIN);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1152,6 +1152,16 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose)
     bool fInsertedNew = ret.second;
     if (fInsertedNew)
     {
+        // A previously known spender can gain debit when its missing parent arrives.
+        TxSpends::const_iterator iter = mapTxSpends.lower_bound(COutPoint(hash, 0));
+        while (iter != mapTxSpends.end() && iter->first.hash == hash) {
+            std::map<uint256, CWalletTx>::iterator mi = mapWallet.find(iter->second);
+            if (mi != mapWallet.end()) {
+                mi->second.MarkDirty();
+            }
+            ++iter;
+        }
+
         wtx.nTimeReceived = GetAdjustedTime();
         wtx.nOrderPos = IncOrderPosNext(&walletdb);
         wtxOrdered.insert(make_pair(wtx.nOrderPos, TxPair(&wtx, (CAccountingEntry*)0)));

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2955,6 +2955,13 @@ void CWallet::AvailableCoins(std::vector <COutput> &vCoins, bool fOnlyConfirmed,
                 continue;
 
             int nDepth = pcoin->GetDepthInMainChain(false);
+            // Do not offer conflicted outputs or unconfirmed outputs absent from
+            // both local pools, unless InstantSend makes them trusted.
+            if (nDepth < 0 ||
+                (!fOnlyConfirmed && nDepth == 0 && !pcoin->InMempool() && !pcoin->InStempool() &&
+                 !pcoin->IsLockedByLLMQInstantSend()))
+                continue;
+
             // do not use IX for inputs that have less then nInstantSendConfirmationsRequired blockchain confirmations
             if (fUseInstantSend && nDepth < nInstantSendConfirmationsRequired)
                 continue;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1497,13 +1497,16 @@ void CWallet::MarkConflicted(const uint256& hashBlock, const uint256& hashTx)
         assert(mapWallet.count(now));
         CWalletTx& wtx = mapWallet[now];
         int currentconfirm = wtx.GetDepthInMainChain();
-        if (conflictconfirms < currentconfirm) {
-            // Block is 'more conflicted' than current confirm; update.
-            // Mark transaction as conflicted with this block.
-            wtx.nIndex = -1;
-            wtx.hashBlock = hashBlock;
+        const bool fSameConflict = conflictconfirms == currentconfirm && wtx.hashBlock == hashBlock;
+        if (conflictconfirms < currentconfirm || fSameConflict) {
+            // Reapplying the same conflict must also dirty descendants' inputs,
+            // but does not require another database write.
             wtx.MarkDirty();
-            walletdb.WriteTx(wtx);
+            if (!fSameConflict) {
+                wtx.nIndex = -1;
+                wtx.hashBlock = hashBlock;
+                walletdb.WriteTx(wtx);
+            }
             // Iterate over all its outputs, and mark transactions in the wallet that spend them conflicted too
             TxSpends::const_iterator iter = mapTxSpends.lower_bound(COutPoint(now, 0));
             while (iter != mapTxSpends.end() && iter->first.hash == now) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1240,6 +1240,17 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose)
         }
     }
 
+    if ((fInsertedNew || fUpdated) && !wtx.tx->HasNoRegularInputs()) {
+        // Adding a spender or changing its chain state can change whether its
+        // input transactions have available credit.
+        for (const CTxIn& txin : wtx.tx->vin) {
+            std::map<uint256, CWalletTx>::iterator mi = mapWallet.find(txin.prevout.hash);
+            if (mi != mapWallet.end()) {
+                mi->second.MarkDirty();
+            }
+        }
+    }
+
     //// debug print
     LogPrintf("AddToWallet %s  %s%s\n", wtxIn.GetHash().ToString(), (fInsertedNew ? "new" : ""), (fUpdated ? "update" : ""));
 
@@ -3840,8 +3851,10 @@ bool CWallet::EraseFromWallet(uint256 hash) {
         return false;
     {
         LOCK(cs_wallet);
-        if (mapWallet.erase(hash))
+        if (mapWallet.erase(hash)) {
+            MarkDirty();
             CWalletDB(strWalletFile).EraseTx(hash);
+        }
     }
     return true;
 }
@@ -4095,6 +4108,9 @@ DBErrors CWallet::ZapSelectTx(std::vector<uint256>& vHashIn, std::vector<uint256
     if (!fFileBacked)
         return DB_LOAD_OK;
     DBErrors nZapSelectTxRet = CWalletDB(strWalletFile,"cr+").ZapSelectTx(this, vHashIn, vHashOut);
+    // ZapSelectTx can remove in-memory transactions before reporting a
+    // database error, so invalidate caches regardless of its return value.
+    MarkDirty();
     if (nZapSelectTxRet == DB_NEED_REWRITE)
     {
         if (CDB::Rewrite(strWalletFile, "\x04pool"))
@@ -4110,8 +4126,6 @@ DBErrors CWallet::ZapSelectTx(std::vector<uint256>& vHashIn, std::vector<uint256
 
     if (nZapSelectTxRet != DB_LOAD_OK)
         return nZapSelectTxRet;
-
-    MarkDirty();
 
     return DB_LOAD_OK;
 
@@ -4242,6 +4256,8 @@ bool CWallet::NewKeyPool()
             return false;
 
         int64_t nKeys = std::max(GetArg("-keypool", DEFAULT_KEYPOOL_SIZE), (int64_t)0);
+        if (nKeys > 0)
+            MarkDirty();
         for (int i = 0; i < nKeys; i++)
         {
             int64_t nIndex = i+1;
@@ -4272,6 +4288,8 @@ bool CWallet::TopUpKeyPool(unsigned int kpSize)
         else
             nTargetSize = std::max(GetArg("-keypool", DEFAULT_KEYPOOL_SIZE), (int64_t) 0);
 
+        if (setKeyPool.size() < (nTargetSize + 1))
+            MarkDirty();
         while (setKeyPool.size() < (nTargetSize + 1))
         {
             int64_t nEnd = 1;
@@ -4349,6 +4367,7 @@ bool CWallet::GetKeyFromPool(CPubKey& result)
         if (nIndex == -1)
         {
             if (IsLocked()) return false;
+            MarkDirty();
             result = GenerateNewKey();
             return true;
         }
@@ -5327,6 +5346,8 @@ bip47::CPaymentCode CWallet::GeneratePcode(std::string const & label)
     {
         bip47::MyAddrContT addrs = newAcc.getMyNextAddresses();
         LOCK(cs_wallet);
+        if (!addrs.empty())
+            MarkDirty();
         for(bip47::MyAddrContT::value_type const & addr : addrs) {
             AddKey(addr.second);
         }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1426,7 +1426,7 @@ bool CWallet::AbandonTransaction(const uint256& hashTx)
             walletdb.WriteTx(wtx);
             NotifyTransactionChanged(this, wtx.GetHash(), CT_UPDATED);
             // Iterate over all its outputs, and mark transactions in the wallet that spend them abandoned too
-            TxSpends::const_iterator iter = mapTxSpends.lower_bound(COutPoint(hashTx, 0));
+            TxSpends::const_iterator iter = mapTxSpends.lower_bound(COutPoint(now, 0));
             while (iter != mapTxSpends.end() && iter->first.hash == now) {
                 if (!done.count(iter->second)) {
                     todo.insert(iter->second);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2440,11 +2440,14 @@ CAmount CWalletTx::GetAvailableCredit(bool fUseCache, bool fExcludeLocked) const
         }
     }
 
-    nAvailableCreditCached = nCredit;
-    fAvailableCreditCached = true;
-
-    if (fExcludeLocked)
-        fAvailableCreditCached = false;
+    // The exclude-locked variant never reads the cache (see above), so it
+    // must not overwrite the cached unfiltered credit either: doing so (and
+    // then flagging it invalid) forced the next unfiltered call on every
+    // transaction to recompute from scratch.
+    if (!fExcludeLocked) {
+        nAvailableCreditCached = nCredit;
+        fAvailableCreditCached = true;
+    }
 
     return nCredit;
 }
@@ -2804,10 +2807,33 @@ bool CWallet::TryGetBalances(CAmount& balance,
         return false;
     }
 
-    balance = GetBalance();
-    unconfirmedBalance = GetUnconfirmedBalance();
-    newImmatureBalance = GetImmatureBalance();
-    mintableBalance = GetBalance(true);
+    // This runs on the GUI thread for every new block, so compute all four
+    // balances in a single scan of mapWallet instead of one scan each
+    // (GetBalance, GetUnconfirmedBalance, GetImmatureBalance,
+    // GetBalance(true)), which called IsTrusted() up to three times per
+    // transaction. The per-transaction conditions and credit calls below are
+    // identical to those of the replaced getters.
+    balance = 0;
+    unconfirmedBalance = 0;
+    newImmatureBalance = 0;
+    mintableBalance = 0;
+    const bool fHasLockedCoins = !setLockedCoins.empty();
+    for (std::map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it) {
+        const CWalletTx* pcoin = &(*it).second;
+        if (pcoin->IsTrusted()) {
+            const CAmount nAvailable = pcoin->GetAvailableCredit();
+            balance += nAvailable;
+            // Excluding locked coins only skips outputs in setLockedCoins, so
+            // with none locked the mintable credit equals the available
+            // credit and the second, uncacheable computation can be skipped.
+            mintableBalance += fHasLockedCoins ? pcoin->GetAvailableCredit(true, true) : nAvailable;
+        } else if (pcoin->GetDepthInMainChain() == 0 &&
+                   (pcoin->InMempool() || pcoin->InStempool()) &&
+                   !pcoin->IsLockedByLLMQInstantSend()) {
+            unconfirmedBalance += pcoin->GetAvailableCredit();
+        }
+        newImmatureBalance += pcoin->GetImmatureCredit();
+    }
 
     return true;
 }


### PR DESCRIPTION
## PR intention

Remove the GUI stutter that follows block arrivals on large wallets. `CWallet::TryGetBalances` performed four full scans of `mapWallet`, and the mintable-balance scan also discarded the available-credit cache that the next poll needed.

The optimized path must remain exactly equivalent to the existing balance getters, including after transactions, keys, or scripts change wallet ownership or spentness.

## Code changes brief

- Compute available, unconfirmed, immature, and mintable balances in one `mapWallet` scan. When no coins are locked, reuse the available credit for the identical mintable value.
- Keep the unfiltered available-credit cache intact during exclude-locked calculations.
- Invalidate affected parent transactions when regular spenders are inserted or updated, and invalidate wallet transaction caches after removals or ownership changes from new keys and scripts. The hot `AddToWallet` path dirties only input parents, while key generation dirties once per batch.
- Add focused unit coverage that compares the consolidated results with all four existing getters across trusted, unconfirmed, immature, and locked states, and exercises the cache-invalidation regressions.

## Validation

- `git diff --check`
- Full PR CI passed at `e24c7cbd6b74a6ffef3e7986f703a7cb4303d7cc`: Linux Debug and RelWithDebInfo, unit tests, RPC tests, Windows and macOS builds, all Guix targets, and Jenkins branch/merge checks.
- Clean synthetic merge with current `master` (`4f0c771462b2f327e3a7ff7bf2532bc33c727713`).
- No local build was run.
