### PR TITLE
Consensus: Bind FiroPoW header height

### DIFF
--- a/src/test/main_tests.cpp
+++ b/src/test/main_tests.cpp
@@ -36,6 +36,21 @@ BOOST_AUTO_TEST_CASE(block_subsidy_test)
     //TestBlockSubsidyHalvings(1000); // Just another interval
 }
 
+BOOST_AUTO_TEST_CASE(progpow_header_height_must_match_chain_height)
+{
+    const Consensus::Params& consensusParams = Params().GetConsensus();
+    CBlockIndex previous;
+    previous.nHeight = 100;
+
+    CBlockHeader header;
+    header.nTime = consensusParams.nPPSwitchTime;
+    header.nHeight = 0;
+
+    CValidationState state;
+    BOOST_CHECK(!ContextualCheckBlockHeader(header, state, consensusParams, &previous, header.nTime));
+    BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-blk-progpow");
+}
+
 bool ReturnFalse() { return false; }
 bool ReturnTrue() { return true; }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4305,6 +4305,11 @@ std::vector<unsigned char> GenerateCoinbaseCommitment(CBlock& block, const CBloc
 
 bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, CBlockIndex * const pindexPrev, int64_t nAdjustedTime)
 {
+    // The ProgPoW height is serialized and contributes to the header hash. Bind it
+    // to the parent before accepting the header into the block index.
+    if (block.IsProgPow() && block.nHeight != static_cast<uint32_t>(pindexPrev->nHeight + 1))
+        return state.DoS(100, false, REJECT_INVALID, "bad-blk-progpow", "ProgPOW height doesn't match chain height");
+
 	// Firo - MTP
     bool fBlockHasMTP = (block.nVersion & 4096) != 0 || (pindexPrev && consensusParams.nMTPSwitchTime == 0);
 


### PR DESCRIPTION
### Motivation

- Prevent a header-level trust boundary where a serialized FiroPoW `nHeight` can differ from the chain context and allow a header to bypass full ProgPoW mix verification or create an index/header inconsistency. 

### Description

- Add a contextual header check in `ContextualCheckBlockHeader` to require that for ProgPoW headers `block.nHeight == pindexPrev->nHeight + 1`, and reject headers that do not match that invariant. 
- Add a unit test `progpow_header_height_must_match_chain_height` in `src/test/main_tests.cpp` that constructs a post-activation header with a mismatched `nHeight` and asserts it is rejected with `bad-blk-progpow`. 
- This change prevents malformed ProgPoW headers from entering the block index and avoids reconstructed-header/hash mismatches later in the load/serve path.

### Testing

- `git diff --check` and `git status --short` were run to validate the working tree state and reported no whitespace/format errors. 
- Building and running the unit test target with `cmake --build build --target test_firo -j2` could not be completed in this environment because the repository has no configured `build` directory, so the new test was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7aa10cbf74832fa34e5fbdbb4af41f)