### PR TITLE
Consensus: Bind FiroPoW header height

### DIFF
--- a/src/test/progpow_tests.cpp
+++ b/src/test/progpow_tests.cpp
@@ -152,6 +152,9 @@ BOOST_AUTO_TEST_CASE(header_height_mismatch)
     std::vector<CBlockHeader> headers{block};
     BOOST_CHECK(!ProcessNewBlockHeaders(headers, state, Params()));
     BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-blk-progpow");
+
+    LOCK(cs_main);
+    BOOST_CHECK_EQUAL(mapBlockIndex.count(block.GetHash()), 0);
 }
 
 BOOST_AUTO_TEST_CASE(limit)

--- a/src/test/progpow_tests.cpp
+++ b/src/test/progpow_tests.cpp
@@ -136,6 +136,24 @@ BOOST_AUTO_TEST_CASE(corruption)
     BOOST_ASSERT(VerifyBlockCheckStatus(block, ""));
 }
 
+BOOST_AUTO_TEST_CASE(header_height_mismatch)
+{
+    mutableParams.nPPSwitchTime = (uint32_t)(chainActive.Tip()->GetMedianTimePast()+10);
+    SetMockTime(mutableParams.nPPSwitchTime+1);
+
+    CBlock block = CreateBlock({}, m_coinbaseKey);
+    BOOST_REQUIRE(block.IsProgPow());
+    block.nHeight = 0;
+
+    while (!CheckProofOfWork(block.GetProgPowHashLight(), block.nBits, mutableParams))
+        ++block.nNonce64;
+
+    CValidationState state;
+    std::vector<CBlockHeader> headers{block};
+    BOOST_CHECK(!ProcessNewBlockHeaders(headers, state, Params()));
+    BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-blk-progpow");
+}
+
 BOOST_AUTO_TEST_CASE(limit)
 {
     mutableParams.nPPSwitchTime = INT_MAX;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4311,6 +4311,9 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
     if (block.IsMTP() != fBlockHasMTP)
 		return state.Invalid(false, REJECT_OBSOLETE, strprintf("bad-version(0x%08x)", block.nVersion),strprintf("rejected nVersion=0x%08x block", block.nVersion));
 
+    if (block.IsProgPow() && block.nHeight != static_cast<uint32_t>(pindexPrev->nHeight + 1))
+        return state.DoS(100, false, REJECT_INVALID, "bad-blk-progpow", "ProgPOW height doesn't match chain height");
+
 	// Check proof of work
     if (block.nBits != GetNextWorkRequired(pindexPrev, &block, consensusParams))
         return state.DoS(100, false, REJECT_INVALID, "bad-diffbits", false, "incorrect proof of work");


### PR DESCRIPTION
## PR intention

FiroPoW headers serialize an `nHeight` field supplied by the peer. Full-block validation already requires that field to match `pindexPrev->nHeight + 1`, but headers-only validation did not enforce the same invariant before adding a header to the block index.

Require the serialized FiroPoW height to match the parent-derived height in `ContextualCheckBlockHeader`. This rejects malformed headers before indexing and preserves the assumption used when block-index entries reconstruct FiroPoW headers.

The valid-block set is unchanged because full-block validation already applies the same rule. No hard-fork activation is required.

## Code changes brief

- Reject a FiroPoW header with `bad-blk-progpow` when its serialized height differs from the next contextual chain height.
- Add a regression test that creates a post-activation header above the height-100 test chain, changes its serialized height to zero, solves its light FiroPoW hash, and verifies that headers-only processing rejects it.
- Confirm that the rejected malformed header is absent from `mapBlockIndex`.

## Testing

- `git diff --check`
- The previous head built and passed unit tests in GitHub Actions. The index-absence assertion has triggered a fresh CI run.
- The unit test was not run locally because this Windows host has no CMake/C++ build toolchain or WSL installation.