### PR TITLE
Validation: fully verify FiroPoW headers and harden ChainLocks

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -227,6 +227,9 @@ public:
     //! (memory only) Maximum nTime in the chain upto and including this block.
     unsigned int nTimeMax;
 
+    //! (memory only) Whether the full ProgPoW mix for this header was verified.
+    bool fProgPowHeaderVerified;
+
     //! Public coin values of mints in this block, ordered by serialized value of public coin
     //! Maps <denomination,id> to vector of public coins
     std::map<std::pair<int,int>, std::vector<CBigNum>> mintedPubCoins;
@@ -288,6 +291,7 @@ public:
         nStatus = 0;
         nSequenceId = 0;
         nTimeMax = 0;
+        fProgPowHeaderVerified = false;
 
         nVersion       = 0;
         hashMerkleRoot = uint256();

--- a/src/crypto/progpow.cpp
+++ b/src/crypto/progpow.cpp
@@ -40,15 +40,10 @@ static inline uint256 H256ToU256(const ethash::hash256& in) {
 
 uint256 progpow_hash_full(const CProgPowHeader& header, uint256& mix_hash)
 {
-    static ethash::epoch_context_ptr epochContext{nullptr,nullptr};
-    if (!epochContext || epochContext->epoch_number != ethash::get_epoch_number(header.nHeight))
-    {
-        epochContext.reset();
-        epochContext = ethash::create_epoch_context(ethash::get_epoch_number(header.nHeight));
-    }
+    const auto& epochContext = ethash::get_global_epoch_context(ethash::get_epoch_number(header.nHeight));
 
     const auto header_h256{U256ToH256(SerializeHash(header))};
-    const auto result = progpow::hash(*epochContext, header.nHeight, header_h256, header.nNonce64);
+    const auto result = progpow::hash(epochContext, header.nHeight, header_h256, header.nNonce64);
     mix_hash = H256ToU256(result.mix_hash);
     return H256ToU256(result.final_hash);
 }

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -125,11 +125,27 @@ void CChainLocksHandler::ProcessNewChainLock(NodeId from, const llmq::CChainLock
     {
         LOCK2(cs_main, cs);
 
-        if (InternalHasConflictingChainLock(clsig.nHeight, clsig.blockHash)) {
-            // This should not happen. If it happens, it means that a malicious entity controls a large part of the MN
-            // network. In this case, we don't allow him to reorg older chainlocks.
-            LogPrintf("CChainLocksHandler::%s -- new CLSIG (%s) tries to reorg previous CLSIG (%s), peer=%d\n",
-                      __func__, clsig.ToString(), bestChainLock.ToString(), from);
+        // Another CLSIG might have been accepted while the signature was being verified.
+        if (bestChainLock.nHeight != -1 && clsig.nHeight <= bestChainLock.nHeight) {
+            return;
+        }
+
+        auto blockIt = mapBlockIndex.find(clsig.blockHash);
+        const CBlockIndex* pindex = blockIt == mapBlockIndex.end() ? nullptr : blockIt->second;
+
+        if (pindex && pindex->nHeight != clsig.nHeight) {
+            LogPrintf("CChainLocksHandler::%s -- height of CLSIG (%s) does not match the specified block's height (%d)\n",
+                    __func__, clsig.ToString(), pindex->nHeight);
+            return;
+        }
+
+        if (isEnforced && pindex && bestChainLockBlockIndex &&
+                (pindex->nHeight < bestChainLockBlockIndex->nHeight ||
+                 pindex->GetAncestor(bestChainLockBlockIndex->nHeight) != bestChainLockBlockIndex)) {
+            // A valid higher-height signature does not prove ancestry. Never let it
+            // replace the last ChainLock whose block is known.
+            LogPrintf("CChainLocksHandler::%s -- new CLSIG (%s) tries to reorg known CLSIG (%s), peer=%d\n",
+                      __func__, clsig.ToString(), bestChainLockWithKnownBlock.ToString(), from);
             return;
         }
 
@@ -139,21 +155,12 @@ void CChainLocksHandler::ProcessNewChainLock(NodeId from, const llmq::CChainLock
         CInv inv(MSG_CLSIG, hash);
         g_connman->RelayInv(inv, LLMQS_PROTO_VERSION);
 
-        auto blockIt = mapBlockIndex.find(clsig.blockHash);
-        if (blockIt == mapBlockIndex.end()) {
-            // we don't know the block/header for this CLSIG yet, so bail out for now
-            // when the block or the header later comes in, we will enforce the correct chain
+        if (!pindex) {
+            // We don't know the block/header for this CLSIG yet. Its ancestry will
+            // be checked when the header arrives.
             return;
         }
 
-        if (blockIt->second->nHeight != clsig.nHeight) {
-            // Should not happen, same as the conflict check from above.
-            LogPrintf("CChainLocksHandler::%s -- height of CLSIG (%s) does not match the specified block's height (%d)\n",
-                    __func__, clsig.ToString(), blockIt->second->nHeight);
-            return;
-        }
-
-        const CBlockIndex* pindex = blockIt->second;
         bestChainLockWithKnownBlock = bestChainLock;
         bestChainLockBlockIndex = pindex;
     }
@@ -172,14 +179,28 @@ void CChainLocksHandler::AcceptedBlockHeader(const CBlockIndex* pindexNew)
     LOCK2(cs_main, cs);
 
     if (pindexNew->GetBlockHash() == bestChainLock.blockHash) {
-        LogPrintf("CChainLocksHandler::%s -- block header %s came in late, updating and enforcing\n", __func__, pindexNew->GetBlockHash().ToString());
+        auto restoreKnownChainLock = [&]() {
+            bestChainLock = bestChainLockWithKnownBlock;
+            bestChainLockHash = bestChainLock.nHeight == -1 ? uint256() : ::SerializeHash(bestChainLock);
+        };
 
         if (bestChainLock.nHeight != pindexNew->nHeight) {
-            // Should not happen, same as the conflict check from ProcessNewChainLock.
             LogPrintf("CChainLocksHandler::%s -- height of CLSIG (%s) does not match the specified block's height (%d)\n",
                       __func__, bestChainLock.ToString(), pindexNew->nHeight);
+            restoreKnownChainLock();
             return;
         }
+
+        if (isEnforced && bestChainLockBlockIndex &&
+                (pindexNew->nHeight < bestChainLockBlockIndex->nHeight ||
+                 pindexNew->GetAncestor(bestChainLockBlockIndex->nHeight) != bestChainLockBlockIndex)) {
+            LogPrintf("CChainLocksHandler::%s -- late block header for CLSIG (%s) tries to reorg known CLSIG (%s)\n",
+                      __func__, bestChainLock.ToString(), bestChainLockWithKnownBlock.ToString());
+            restoreKnownChainLock();
+            return;
+        }
+
+        LogPrintf("CChainLocksHandler::%s -- block header %s came in late, updating and enforcing\n", __func__, pindexNew->GetBlockHash().ToString());
 
         // when EnforceBestChainLock is called later, it might end up invalidating other chains but not activating the
         // CLSIG locked chain. This happens when only the header is known but the block is still missing yet. The usual
@@ -280,7 +301,15 @@ void CChainLocksHandler::TrySignChainTip()
             return;
         }
 
-        if (InternalHasConflictingChainLock(pindex->nHeight, pindex->GetBlockHash())) {
+        if (isEnforced && bestChainLock.blockHash != bestChainLockWithKnownBlock.blockHash) {
+            // The newest CLSIG references a block whose header is not known yet, so
+            // its ancestry is unproven. Don't risk signing a conflicting tip.
+            return;
+        }
+
+        if (isEnforced && bestChainLockBlockIndex &&
+                (pindex->nHeight < bestChainLockBlockIndex->nHeight ||
+                 pindex->GetAncestor(bestChainLockBlockIndex->nHeight) != bestChainLockBlockIndex)) {
             // don't sign if another conflicting CLSIG is already present. EnforceBestChainLock will later enforce
             // the correct chain.
             return;
@@ -340,8 +369,19 @@ void CChainLocksHandler::TrySignChainTip()
 
     {
         LOCK(cs);
+        if (!isChainLocksActive) {
+            return;
+        }
         if (bestChainLock.nHeight >= pindex->nHeight) {
             // might have happened while we didn't hold cs
+            return;
+        }
+        if (isEnforced && bestChainLock.blockHash != bestChainLockWithKnownBlock.blockHash) {
+            return;
+        }
+        if (isEnforced && bestChainLockBlockIndex &&
+                (pindex->nHeight < bestChainLockBlockIndex->nHeight ||
+                 pindex->GetAncestor(bestChainLockBlockIndex->nHeight) != bestChainLockBlockIndex)) {
             return;
         }
         lastSignedHeight = pindex->nHeight;

--- a/src/test/progpow_tests.cpp
+++ b/src/test/progpow_tests.cpp
@@ -8,6 +8,7 @@
 #include "utilmoneystr.h"
 #include "validation.h"
 #include "validationinterface.h"
+#include "warnings.h"
 #include "test/test_bitcoin.h"
 #include "script/standard.h"
 #include <consensus/merkle.h>
@@ -43,6 +44,7 @@ struct ProgpowTestingSetup : public TestChain100Setup
     ~ProgpowTestingSetup() {
         mutableParams = originalParams;
         SetMockTime(0);
+        SetfLargeWorkInvalidChainFound(false);
         ethash::ethash_clamp_memory_usage(INT_MAX, INT_MAX);
     }
 
@@ -193,6 +195,107 @@ BOOST_AUTO_TEST_CASE(header_mix_hash_mismatch)
         BOOST_REQUIRE(validIndex != nullptr);
         BOOST_CHECK(validIndex->fProgPowHeaderVerified);
     }
+}
+
+BOOST_AUTO_TEST_CASE(invalidate_header_only_descendants)
+{
+    mutableParams.nPPSwitchTime = INT_MAX;
+    SetfLargeWorkInvalidChainFound(false);
+
+    uint256 forkHash;
+    uint32_t forkTime;
+    {
+        LOCK(cs_main);
+        forkHash = chainActive.Tip()->GetBlockHash();
+        forkTime = chainActive.Tip()->nTime;
+    }
+
+    CBlockHeader base = CreateBlock({}, m_coinbaseKey).GetBlockHeader();
+    auto makeHeader = [&](const uint256& prevHash, uint32_t prevTime, unsigned char tag) {
+        CBlockHeader header = base;
+        header.hashPrevBlock = prevHash;
+        header.hashMerkleRoot.SetNull();
+        header.hashMerkleRoot.begin()[0] = tag;
+        header.nTime = prevTime + 1;
+        header.nNonce = 0;
+        header.cachedPoWHash.SetNull();
+        while (!CheckProofOfWork(header.GetHash(), header.nBits, mutableParams))
+            ++header.nNonce;
+        return header;
+    };
+
+    CBlockHeader badRoot = makeHeader(forkHash, forkTime, 1);
+    CBlockHeader badChild = makeHeader(badRoot.GetHash(), badRoot.nTime, 2);
+    CBlockHeader badTipHeader = makeHeader(badChild.GetHash(), badChild.nTime, 3);
+    CBlockHeader badSibling = makeHeader(badRoot.GetHash(), badRoot.nTime, 5);
+    std::vector<CBlockHeader> badBranch{badRoot, badChild, badTipHeader};
+    for (unsigned char tag = 20; badBranch.size() < 10; ++tag) {
+        const CBlockHeader& previous = badBranch.back();
+        badBranch.emplace_back(makeHeader(previous.GetHash(), previous.nTime, tag));
+    }
+    std::vector<CBlockHeader> siblingBranch{badSibling};
+    for (unsigned char tag = 40; siblingBranch.size() < 8; ++tag) {
+        const CBlockHeader& previous = siblingBranch.back();
+        siblingBranch.emplace_back(makeHeader(previous.GetHash(), previous.nTime, tag));
+    }
+    CBlockHeader goodRoot = makeHeader(forkHash, forkTime, 11);
+    CBlockHeader goodTipHeader = makeHeader(goodRoot.GetHash(), goodRoot.nTime, 12);
+    CBlockHeader extension = makeHeader(badBranch.back().GetHash(), badBranch.back().nTime, 4);
+
+    const CBlockIndex* badTip = nullptr;
+    CValidationState badState;
+    BOOST_REQUIRE(ProcessNewBlockHeaders(badBranch, badState, Params(), &badTip));
+    CValidationState siblingState;
+    BOOST_REQUIRE(ProcessNewBlockHeaders(siblingBranch, siblingState, Params()));
+
+    const CBlockIndex* goodTip = nullptr;
+    CValidationState goodState;
+    BOOST_REQUIRE(ProcessNewBlockHeaders({goodRoot, goodTipHeader}, goodState, Params(), &goodTip));
+
+    CBlockIndex* badRootIndex;
+    CBlockIndex* badTipIndex;
+    {
+        LOCK(cs_main);
+        badRootIndex = mapBlockIndex.at(badRoot.GetHash());
+        badTipIndex = mapBlockIndex.at(badBranch.back().GetHash());
+        CValidationState state;
+        BOOST_REQUIRE(InvalidateBlock(state, Params(), badRootIndex));
+        BOOST_CHECK(badRootIndex->nStatus & BLOCK_FAILED_VALID);
+        BOOST_CHECK(mapBlockIndex.at(badChild.GetHash())->nStatus & BLOCK_FAILED_CHILD);
+        BOOST_CHECK(mapBlockIndex.at(badTipHeader.GetHash())->nStatus & BLOCK_FAILED_CHILD);
+        BOOST_CHECK(mapBlockIndex.at(badSibling.GetHash())->nStatus & BLOCK_FAILED_CHILD);
+        BOOST_CHECK(pindexBestHeader == goodTip);
+        BOOST_CHECK(GetfLargeWorkInvalidChainFound());
+    }
+
+    CValidationState rejectState;
+    BOOST_CHECK(!ProcessNewBlockHeaders({extension}, rejectState, Params()));
+    BOOST_CHECK_EQUAL(rejectState.GetRejectReason(), "bad-prevblk");
+    {
+        LOCK(cs_main);
+        BOOST_CHECK_EQUAL(mapBlockIndex.count(extension.GetHash()), 0);
+    }
+
+    {
+        LOCK(cs_main);
+        BOOST_REQUIRE(ResetBlockFailureFlags(badTipIndex));
+        BOOST_CHECK_EQUAL(badRootIndex->nStatus & BLOCK_FAILED_MASK, 0);
+        BOOST_CHECK_EQUAL(mapBlockIndex.at(badChild.GetHash())->nStatus & BLOCK_FAILED_MASK, 0);
+        BOOST_CHECK_EQUAL(mapBlockIndex.at(badTipHeader.GetHash())->nStatus & BLOCK_FAILED_MASK, 0);
+        BOOST_CHECK(mapBlockIndex.at(badSibling.GetHash())->nStatus & BLOCK_FAILED_VALID);
+        BOOST_CHECK(pindexBestHeader == badTip);
+        BOOST_CHECK(GetfLargeWorkInvalidChainFound());
+    }
+
+    const CBlockIndex* extensionIndex = nullptr;
+    CValidationState retryState;
+    BOOST_REQUIRE(ProcessNewBlockHeaders({extension}, retryState, Params(), &extensionIndex));
+    BOOST_CHECK(extensionIndex != nullptr);
+
+    // Updating the active chain reevaluates warnings. The preserved sibling is
+    // still more than six blocks ahead and must keep the warning active.
+    CreateAndProcessBlock({}, m_coinbaseKey);
+    BOOST_CHECK(GetfLargeWorkInvalidChainFound());
 }
 
 BOOST_AUTO_TEST_CASE(limit)

--- a/src/test/progpow_tests.cpp
+++ b/src/test/progpow_tests.cpp
@@ -152,9 +152,47 @@ BOOST_AUTO_TEST_CASE(header_height_mismatch)
     std::vector<CBlockHeader> headers{block};
     BOOST_CHECK(!ProcessNewBlockHeaders(headers, state, Params()));
     BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-blk-progpow");
+    BOOST_CHECK(!state.CorruptionPossible());
 
     LOCK(cs_main);
     BOOST_CHECK_EQUAL(mapBlockIndex.count(block.GetHash()), 0);
+}
+
+BOOST_AUTO_TEST_CASE(header_mix_hash_mismatch)
+{
+    mutableParams.nPPSwitchTime = (uint32_t)(chainActive.Tip()->GetMedianTimePast()+10);
+    SetMockTime(mutableParams.nPPSwitchTime+1);
+
+    CBlock block = CreateBlock({}, m_coinbaseKey);
+    BOOST_REQUIRE(block.IsProgPow());
+
+    CBlockHeader forged = block.GetBlockHeader();
+    forged.mix_hash.begin()[0] ^= 1;
+    while (!CheckProofOfWork(forged.GetProgPowHashLight(), forged.nBits, mutableParams))
+        ++forged.nNonce64;
+    BOOST_REQUIRE(CheckProofOfWork(forged.GetProgPowHashLight(), forged.nBits, mutableParams));
+
+    uint256 expectedMixHash;
+    forged.GetProgPowHashFull(expectedMixHash);
+    BOOST_REQUIRE(expectedMixHash != forged.mix_hash);
+
+    CValidationState state;
+    BOOST_CHECK(!ProcessNewBlockHeaders({forged}, state, Params()));
+    BOOST_CHECK_EQUAL(state.GetRejectReason(), "invalid-mixhash");
+
+    {
+        LOCK(cs_main);
+        BOOST_CHECK_EQUAL(mapBlockIndex.count(forged.GetHash()), 0);
+    }
+
+    const CBlockIndex* validIndex = nullptr;
+    CValidationState validState;
+    BOOST_REQUIRE(ProcessNewBlockHeaders({block.GetBlockHeader()}, validState, Params(), &validIndex));
+    {
+        LOCK(cs_main);
+        BOOST_REQUIRE(validIndex != nullptr);
+        BOOST_CHECK(validIndex->fProgPowHeaderVerified);
+    }
 }
 
 BOOST_AUTO_TEST_CASE(limit)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2515,7 +2515,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         return error("%s: Consensus::CheckBlock: %s", __func__, FormatStateMessage(state));
     }
 
-    if (block.IsProgPow() && !fJustCheck)
+    if (block.IsProgPow() && !fJustCheck && !pindex->fProgPowHeaderVerified)
     {
         // do full PP hash check
 
@@ -2536,6 +2536,8 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         {
             return state.DoS(50, false, REJECT_INVALID, "high-hash", false, "proof of work failed");
         }
+
+        pindex->fProgPowHeaderVerified = true;
     }
 
     // verify that the view's current state corresponds to the previous block
@@ -4122,9 +4124,8 @@ bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, const 
         {
             if (block.mix_hash.IsNull())
                 return state.DoS(50, false, REJECT_INVALID, "invalid-mixhash", false, "mix_hash cannot be null");
-            // If we use GetProgPowHashFull user may experience very slow header sync
-            // We use simplified function for header check and then will use full check in ConnectBlock()
-            // This won't make sync faster but it will give user a better experience
+            // Use the supplied mix as a cheap target prefilter. Header acceptance
+            // recomputes it after contextual validation binds the block height.
             final_hash = block.GetProgPowHashLight();
         }
         else
@@ -4313,7 +4314,7 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
 		return state.Invalid(false, REJECT_OBSOLETE, strprintf("bad-version(0x%08x)", block.nVersion),strprintf("rejected nVersion=0x%08x block", block.nVersion));
 
     if (block.IsProgPow() && block.nHeight != static_cast<uint32_t>(pindexPrev->nHeight + 1))
-        return state.DoS(100, false, REJECT_INVALID, "bad-blk-progpow", "ProgPOW height doesn't match chain height");
+        return state.DoS(100, false, REJECT_INVALID, "bad-blk-progpow", false, "ProgPOW height doesn't match chain height");
 
 	// Check proof of work
     if (block.nBits != GetNextWorkRequired(pindexPrev, &block, consensusParams))
@@ -4382,7 +4383,7 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, const Co
         return state.Invalid(false, REJECT_INVALID, "bad-blk-stage3-state", "Cannot go back to 5 minutes between blocks");
 
     if (block.IsProgPow() && block.nHeight != nHeight)
-        return state.DoS(100, false, REJECT_INVALID, "bad-blk-progpow", "ProgPOW height doesn't match chain height");
+        return state.DoS(100, false, REJECT_INVALID, "bad-blk-progpow", false, "ProgPOW height doesn't match chain height");
 
     // Start enforcing BIP113 (Median Time Past) using versionbits logic.
     int nLockTimeFlags = 0;
@@ -4523,6 +4524,7 @@ static bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state
     AssertLockHeld(cs_main);
     // Check for duplicate
     uint256 hash = block.GetHash();
+    bool fProgPowHeaderVerified = false;
     BlockMap::iterator miSelf = mapBlockIndex.find(hash);
     CBlockIndex *pindex = NULL;
     if (hash != chainparams.GetConsensus().hashGenesisBlock) {
@@ -4555,9 +4557,24 @@ static bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state
 
         if (!ContextualCheckBlockHeader(block, state, chainparams.GetConsensus(), pindexPrev, GetAdjustedTime()))
             return error("%s: Consensus::ContextualCheckBlockHeader: %s, %s", __func__, hash.ToString(), FormatStateMessage(state));
+
+        if (fCheckPOW && block.IsProgPow()) {
+            // Full verification must happen after the claimed ProgPoW height has been
+            // bound to pindexPrev, otherwise an untrusted height selects the epoch.
+            if (block.nHeight >= progpow::epoch_length * 2000)
+                return state.DoS(50, false, REJECT_INVALID, "invalid-progpow-epoch", false, "invalid epoch number");
+
+            uint256 expectedMixHash;
+            block.GetProgPowHashFull(expectedMixHash);
+            if (expectedMixHash != block.mix_hash)
+                return state.DoS(50, false, REJECT_INVALID, "invalid-mixhash", false, "mix_hash validity failed");
+            fProgPowHeaderVerified = true;
+        }
     }
     if (pindex == NULL)
         pindex = AddToBlockIndex(block);
+    if (fProgPowHeaderVerified)
+        pindex->fProgPowHeaderVerified = true;
 
     if (ppindex)
         *ppindex = pindex;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1872,11 +1872,57 @@ void static InvalidChainFound(CBlockIndex* pindexNew)
     CheckForkWarningConditions();
 }
 
+static void RecalculateBestBlockIndexes()
+{
+    AssertLockHeld(cs_main);
+
+    pindexBestHeader = nullptr;
+    pindexBestInvalid = nullptr;
+    for (const auto& entry : mapBlockIndex) {
+        CBlockIndex* pindex = entry.second;
+        if (pindex->IsValid(BLOCK_VALID_TREE) &&
+                (!pindexBestHeader || CBlockIndexWorkComparator()(pindexBestHeader, pindex))) {
+            pindexBestHeader = pindex;
+        }
+        if ((pindex->nStatus & BLOCK_FAILED_MASK) &&
+                (!pindexBestInvalid || pindex->nChainWork > pindexBestInvalid->nChainWork)) {
+            pindexBestInvalid = pindex;
+        }
+    }
+}
+
+static void MarkBlockFailedDescendants(CBlockIndex* pindex)
+{
+    AssertLockHeld(cs_main);
+
+    std::vector<CBlockIndex*> queue{pindex};
+    for (size_t i = 0; i < queue.size(); ++i) {
+        auto range = mapPrevBlockIndex.equal_range(queue[i]->GetBlockHash());
+        for (auto it = range.first; it != range.second; ++it) {
+            CBlockIndex* pindexChild = it->second;
+            if (!(pindexChild->nStatus & BLOCK_FAILED_MASK)) {
+                pindexChild->nStatus |= BLOCK_FAILED_CHILD;
+                setDirtyBlockIndex.insert(pindexChild);
+            }
+            setBlockIndexCandidates.erase(pindexChild);
+            // These blocks can no longer reach the pindexBestInvalid tracking in
+            // FindMostWorkChain, so account for their work here.
+            if (!pindexBestInvalid || pindexChild->nChainWork > pindexBestInvalid->nChainWork)
+                pindexBestInvalid = pindexChild;
+            queue.emplace_back(pindexChild);
+        }
+    }
+
+    if (!pindexBestHeader || (pindexBestHeader->nStatus & BLOCK_FAILED_MASK))
+        RecalculateBestBlockIndexes();
+}
+
 void static InvalidBlockFound(CBlockIndex *pindex, const CValidationState &state) {
     if (!state.CorruptionPossible()) {
         pindex->nStatus |= BLOCK_FAILED_VALID;
         setDirtyBlockIndex.insert(pindex);
         setBlockIndexCandidates.erase(pindex);
+        MarkBlockFailedDescendants(pindex);
         InvalidChainFound(pindex);
     }
 }
@@ -3861,6 +3907,7 @@ bool InvalidateBlock(CValidationState& state, const CChainParams& chainparams, C
     pindex->nStatus |= BLOCK_FAILED_VALID;
     setDirtyBlockIndex.insert(pindex);
     setBlockIndexCandidates.erase(pindex);
+    MarkBlockFailedDescendants(pindex);
 
     while (chainActive.Contains(pindex)) {
         CBlockIndex *pindexWalk = chainActive.Tip();
@@ -3901,19 +3948,17 @@ bool ResetBlockFailureFlags(CBlockIndex *pindex) {
     AssertLockHeld(cs_main);
 
     int nHeight = pindex->nHeight;
+    bool fClearedFailure = false;
 
     // Remove the invalidity flag from this block and all its descendants.
     BlockMap::iterator it = mapBlockIndex.begin();
     while (it != mapBlockIndex.end()) {
-        if (!it->second->IsValid() && it->second->GetAncestor(nHeight) == pindex) {
+        if ((it->second->nStatus & BLOCK_FAILED_MASK) && it->second->GetAncestor(nHeight) == pindex) {
             it->second->nStatus &= ~BLOCK_FAILED_MASK;
+            fClearedFailure = true;
             setDirtyBlockIndex.insert(it->second);
             if (it->second->IsValid(BLOCK_VALID_TRANSACTIONS) && it->second->nChainTx && setBlockIndexCandidates.value_comp()(chainActive.Tip(), it->second)) {
                 setBlockIndexCandidates.insert(it->second);
-            }
-            if (it->second == pindexBestInvalid) {
-                // Reset invalid block marker if it was pointing to one of those.
-                pindexBestInvalid = NULL;
             }
         }
         it++;
@@ -3923,9 +3968,27 @@ bool ResetBlockFailureFlags(CBlockIndex *pindex) {
     while (pindex != NULL) {
         if (pindex->nStatus & BLOCK_FAILED_MASK) {
             pindex->nStatus &= ~BLOCK_FAILED_MASK;
+            fClearedFailure = true;
             setDirtyBlockIndex.insert(pindex);
+
+            // Keep sibling subtrees invalid when reconsidering only one branch.
+            auto range = mapPrevBlockIndex.equal_range(pindex->GetBlockHash());
+            for (auto childIt = range.first; childIt != range.second; ++childIt) {
+                CBlockIndex* pindexChild = childIt->second;
+                if (pindexChild->nStatus & BLOCK_FAILED_CHILD) {
+                    pindexChild->nStatus |= BLOCK_FAILED_VALID;
+                    setDirtyBlockIndex.insert(pindexChild);
+                    setBlockIndexCandidates.erase(pindexChild);
+                }
+            }
         }
         pindex = pindex->pprev;
+    }
+    if (fClearedFailure) {
+        // Cleared blocks may now be eligible again, while preserved invalid
+        // siblings must continue to participate in invalid-chain warnings.
+        RecalculateBestBlockIndexes();
+        CheckForkWarningConditions();
     }
     return true;
 }
@@ -4653,6 +4716,9 @@ static bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidation
         if (state.IsInvalid() && !state.CorruptionPossible()) {
             pindex->nStatus |= BLOCK_FAILED_VALID;
             setDirtyBlockIndex.insert(pindex);
+            setBlockIndexCandidates.erase(pindex);
+            MarkBlockFailedDescendants(pindex);
+            InvalidChainFound(pindex);
         }
         return error("%s: %s", __func__, FormatStateMessage(state));
     }
@@ -4962,6 +5028,8 @@ bool static LoadBlockIndexDB(const CChainParams& chainparams)
 
     boost::this_thread::interruption_point();
 
+    mapPrevBlockIndex.clear();
+
     // Calculate nChainWork
     std::vector<std::pair<int, CBlockIndex*> > vSortedByHeight;
     vSortedByHeight.reserve(mapBlockIndex.size());
@@ -4981,6 +5049,16 @@ bool static LoadBlockIndexDB(const CChainParams& chainparams)
         CBlockIndex* pindex = item.second;
         pindex->nChainWork = (pindex->pprev ? pindex->pprev->nChainWork : 0) + GetBlockProof(*pindex);
         pindex->nTimeMax = (pindex->pprev ? std::max(pindex->pprev->nTimeMax, pindex->nTime) : pindex->nTime);
+        if (pindex->pprev && (pindex->pprev->nStatus & BLOCK_FAILED_MASK) && !(pindex->nStatus & BLOCK_FAILED_MASK)) {
+            pindex->nStatus |= BLOCK_FAILED_CHILD;
+            setDirtyBlockIndex.insert(pindex);
+        } else if ((pindex->nStatus & BLOCK_FAILED_CHILD) && !(pindex->nStatus & BLOCK_FAILED_VALID) &&
+                (!pindex->pprev || !(pindex->pprev->nStatus & BLOCK_FAILED_MASK))) {
+            // Preserve a legacy orphaned failure flag by making this block the
+            // invalid root of its subtree.
+            pindex->nStatus |= BLOCK_FAILED_VALID;
+            setDirtyBlockIndex.insert(pindex);
+        }
         // We can link the chain of blocks for which we've received transactions at some point.
         // Pruned nodes may have deleted the block.
         if (pindex->nTx > 0) {
@@ -5303,6 +5381,8 @@ void UnloadBlockIndex()
     for (int b = 0; b < VERSIONBITS_NUM_BITS; b++) {
         warningcache[b].clear();
     }
+
+    mapPrevBlockIndex.clear();
 
     BOOST_FOREACH(BlockMap::value_type& entry, mapBlockIndex) {
         delete entry.second;


### PR DESCRIPTION
## Summary

- Fully recompute the FiroPoW mix for newly accepted headers after contextual validation binds `nHeight` to the previous block.
- Cache successful full header verification in memory so `ConnectBlock` does not repeat the expensive calculation.
- Use Ethash's thread-safe managed epoch context, preserving parallel mining while header validation also performs full hashing.
- Propagate invalid status through already-known header descendants, repair best-header and invalid-chain warning tracking, and preserve failure-tree invariants across reconsideration and startup.
- Require an enforced higher ChainLock with a known block to descend from the last known ChainLock, and prevent masternodes from signing a conflicting or ancestry-unverified tip.

## Root cause

The header path checked the proof-of-work target using the peer-supplied mix hash, but did not recompute the mix. PR #1898 binds the serialized FiroPoW height to chain context, which closes the untrusted-height gap, but the mix still needed full verification.

Separately, invalidating a block did not mark header-only descendants already present in the block index. That could leave `pindexBestHeader` on an invalid subtree. The higher-height ChainLock conflict check also did not prove that the new locked block descended from the last known locked block.

## Commit structure

1. `crypto: use managed ProgPoW epoch context`
2. `validation: fully verify ProgPoW headers before indexing`
3. `validation: propagate failed status through indexed descendants`
4. `llmq: enforce ancestry for higher ChainLocks`

Each commit contains one complete invariant and its directly related tests or consistency repairs. The empty CI-retrigger commit was removed. The recovered-signature diagnostic correction was also removed from this PR because it is already present on `master` through #1899.

## Compatibility

This does not require a hard fork. Fully validated blocks already had to pass the same FiroPoW mix and target checks in `ConnectBlock`; this change applies that existing rule when a new header is accepted.

The verification cache is memory-only and is deliberately not serialized. Persisted header-only entries are not eagerly reverified during startup. A node whose block index was materially poisoned before upgrading may need `-reindex`.

Same-height ChainLock selection remains the existing first-seen policy. The patch does not add a historical ChainLock ancestry sweep. The existing single pending-CLSIG slot can still delay progress in the exceptional case where a cryptographically valid conflicting unknown CLSIG replaces another pending CLSIG.

## Tests

Added Boost regression coverage for:

- a forged mix hash that satisfies the light target check but fails full header verification;
- successful cache marking for a fully verified header;
- recursive invalidation of known header-only descendants;
- best-header repair, extension rejection, and targeted reconsideration with sibling failure preservation;
- preservation of large-invalid-chain warning state after targeted reconsideration;
- correct non-corruption classification for a mismatched FiroPoW height.

Local checks:

- `git diff --check` on the full series and each reviewed working diff;
- clean, dependency-ordered four-commit diff against current `master`;
- independent static reviews of the ProgPoW, ChainLock, and block-index paths.

A local C++ toolchain and Boost execution were not available in this environment. CI must provide compiled and runtime validation. The PR does not add a focused test that constructs cryptographically valid conflicting ChainLock signatures.
