### PR TITLE
Consensus: reject duplicate Spark mint coins

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -421,6 +421,7 @@ public:
         consensus.nSparkStartBlock = SPARK_START_BLOCK;
         // Disabled until a deployment height is selected.
         consensus.nSparkSingleInputStartBlock = 1355970;
+        consensus.nSparkDuplicateMintStartBlock = INT_MAX;
         consensus.nLelantusGracefulPeriod = LELANTUS_GRACEFUL_PERIOD;
         consensus.nSigmaEndBlock = ZC_SIGMA_END_BLOCK;
         consensus.nZerocoinV2MintMempoolGracefulPeriod = ZC_V2_MINT_GRACEFUL_MEMPOOL_PERIOD;
@@ -748,6 +749,7 @@ public:
         consensus.nLelantusFixesStartBlock = ZC_LELANTUS_TESTNET_FIXES_START_BLOCK;
         consensus.nSparkStartBlock = SPARK_TESTNET_START_BLOCK;
         consensus.nSparkSingleInputStartBlock = INT_MAX;
+        consensus.nSparkDuplicateMintStartBlock = INT_MAX;
         consensus.nLelantusGracefulPeriod = LELANTUS_TESTNET_GRACEFUL_PERIOD;
         consensus.nSigmaEndBlock = ZC_SIGMA_TESTNET_END_BLOCK;
         consensus.nZerocoinV2MintMempoolGracefulPeriod = ZC_V2_MINT_TESTNET_GRACEFUL_MEMPOOL_PERIOD;
@@ -1020,6 +1022,7 @@ public:
 
         consensus.nSparkStartBlock = 1500;
         consensus.nSparkSingleInputStartBlock = INT_MAX;
+        consensus.nSparkDuplicateMintStartBlock = INT_MAX;
         consensus.nLelantusGracefulPeriod = 6000;
         consensus.nSigmaEndBlock = 3600;
         consensus.nMaxSigmaInputPerBlock = ZC_SIGMA_INPUT_LIMIT_PER_BLOCK;
@@ -1272,6 +1275,7 @@ public:
         consensus.nLelantusFixesStartBlock = 1;
         consensus.nSparkStartBlock = 100;
         consensus.nSparkSingleInputStartBlock = 500;
+        consensus.nSparkDuplicateMintStartBlock = INT_MAX;
         consensus.nExchangeAddressStartBlock = 1000;
         consensus.nLelantusGracefulPeriod = 600;
         consensus.nSigmaEndBlock = 1;
@@ -1341,6 +1345,11 @@ public:
     {
         consensus.nSparkSingleInputStartBlock = height;
     }
+
+    void UpdateSparkDuplicateMintHeight(int height)
+    {
+        consensus.nSparkDuplicateMintStartBlock = height;
+    }
 };
 static CRegTestParams regTestParams;
 
@@ -1379,4 +1388,9 @@ void UpdateRegtestBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime,
 void UpdateRegtestSparkSingleInputHeight(int height)
 {
     regTestParams.UpdateSparkSingleInputHeight(height);
+}
+
+void UpdateRegtestSparkDuplicateMintHeight(int height)
+{
+    regTestParams.UpdateSparkDuplicateMintHeight(height);
 }

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -149,4 +149,7 @@ void UpdateRegtestBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime,
 /** Allows tests to exercise the single-input Spark consensus activation. */
 void UpdateRegtestSparkSingleInputHeight(int height);
 
+/** Allows tests to exercise the duplicate Spark mint consensus activation. */
+void UpdateRegtestSparkDuplicateMintHeight(int height);
+
 #endif // BITCOIN_CHAINPARAMS_H

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -279,6 +279,9 @@ struct Params {
     // Activation height for the single-input Spark spend rule.
     int nSparkSingleInputStartBlock;
 
+    // Activation height for rejecting duplicate Spark mint coins.
+    int nSparkDuplicateMintStartBlock;
+
     int nSparkNamesStartBlock;
     int nSparkNamesV2StartBlock;        // v2 enables spark name transfer
     int nSparkNamesV21StartBlock;       // v2.1 tweaks rules for renewals and transfers

--- a/src/spark/state.cpp
+++ b/src/spark/state.cpp
@@ -10,6 +10,7 @@
 
 #include <memory>
 #include <set>
+#include <unordered_set>
 
 namespace spark {
 
@@ -38,15 +39,18 @@ void EraseCheckedSparkSpendTransaction(const uint256& hashTx)
 
 static CSparkState sparkState;
 
-static bool CheckSparkMintDuplicates(
+bool CheckSparkMintDuplicates(
         CValidationState& state,
         const std::vector<spark::Coin>& mints,
-        bool checkActiveState)
+        int nHeight)
 {
     std::unordered_set<uint256> blockMints;
     for (const auto& mint : mints) {
+        const auto mintedCoinHeightAndId =
+            sparkState.GetMintedCoinHeightAndId(mint);
         if (!blockMints.insert(mint.getHash()).second ||
-                (checkActiveState && sparkState.HasCoin(mint))) {
+                (mintedCoinHeightAndId.first >= 0 &&
+                 mintedCoinHeightAndId.first < nHeight)) {
             return state.DoS(100, false, REJECT_INVALID,
                              "bad-txns-spark-mint-duplicate");
         }
@@ -302,16 +306,6 @@ bool ConnectBlockSpark(
         }
 
         if (!CheckSparkBlock(state, *pblock, pindexNew->nHeight)) {
-            return false;
-        }
-
-        // VerifyDB rewinds its UTXO view, not global Spark state.
-        const bool checkActiveSparkState = pindexNew->pprev == chainActive.Tip();
-        if (pindexNew->nHeight >= chainparams.GetConsensus().nSparkDuplicateMintStartBlock &&
-                !CheckSparkMintDuplicates(
-                    state,
-                    pblock->sparkTxInfo->mints,
-                    checkActiveSparkState)) {
             return false;
         }
 
@@ -1384,10 +1378,17 @@ void CSparkState::RemoveBlock(CBlockIndex *index) {
             auto mintCoins = GetMints().equal_range(coin);
             auto coinIt = find_if(
                     mintCoins.first, mintCoins.second,
-                    [&coins](const std::unordered_map<spark::Coin, CMintedCoinInfo, spark::CoinHash>::value_type& v) {
-                        return v.second.coinGroupId == coins.first;
+                    [&coins, index](const std::unordered_map<spark::Coin, CMintedCoinInfo, spark::CoinHash>::value_type& v) {
+                        return v.second.coinGroupId == coins.first && v.second.nHeight == index->nHeight;
                     });
-            assert(coinIt != mintCoins.second);
+            // A legacy index may contain a duplicate that never entered mintedCoins.
+            // Do not remove an older occurrence while disconnecting that block.
+            if (coinIt == mintCoins.second) {
+                auto metaIt = mintMetaInfo.find(coins.first);
+                if (metaIt != mintMetaInfo.end() && metaIt->second > 0)
+                    --metaIt->second;
+                continue;
+            }
             RemoveMint(coinIt->first);
         }
     }

--- a/src/spark/state.cpp
+++ b/src/spark/state.cpp
@@ -38,6 +38,23 @@ void EraseCheckedSparkSpendTransaction(const uint256& hashTx)
 
 static CSparkState sparkState;
 
+static bool CheckSparkMintDuplicates(
+        CValidationState& state,
+        const std::vector<spark::Coin>& mints,
+        bool checkActiveState)
+{
+    std::unordered_set<uint256> blockMints;
+    for (const auto& mint : mints) {
+        if (!blockMints.insert(mint.getHash()).second ||
+                (checkActiveState && sparkState.HasCoin(mint))) {
+            return state.DoS(100, false, REJECT_INVALID,
+                             "bad-txns-spark-mint-duplicate");
+        }
+    }
+
+    return true;
+}
+
 static bool CheckLTag(
         CValidationState &state,
         CSparkTxInfo *sparkTxInfo,
@@ -285,6 +302,16 @@ bool ConnectBlockSpark(
         }
 
         if (!CheckSparkBlock(state, *pblock, pindexNew->nHeight)) {
+            return false;
+        }
+
+        // VerifyDB rewinds its UTXO view, not global Spark state.
+        const bool checkActiveSparkState = pindexNew->pprev == chainActive.Tip();
+        if (pindexNew->nHeight >= chainparams.GetConsensus().nSparkDuplicateMintStartBlock &&
+                !CheckSparkMintDuplicates(
+                    state,
+                    pblock->sparkTxInfo->mints,
+                    checkActiveSparkState)) {
             return false;
         }
 
@@ -1390,10 +1417,12 @@ void CSparkState::RemoveSpendFromMempool(const std::vector<GroupElement>& lTags)
     }
 }
 
-void CSparkState::AddMintsToMempool(const std::vector<spark::Coin>& coins) {
+void CSparkState::AddMintsToMempool(
+        const std::vector<spark::Coin>& coins,
+        const uint256& txHash) {
     LOCK(mempool.cs);
     for (const auto& coin : coins) {
-        mempool.sparkState.AddMintToMempool(coin);
+        mempool.sparkState.AddMintToMempool(coin, txHash);
     }
 }
 
@@ -1684,15 +1713,20 @@ size_t CSparkState::CountLastNCoins(int groupId, size_t required, CBlockIndex* &
 
 // CSparkMempoolState
 bool CSparkMempoolState::HasMint(const spark::Coin& coin) {
-    return mempoolMints.count(coin) > 0;
+    return mempoolMints.count(coin.getHash()) > 0;
 }
 
-void CSparkMempoolState::AddMintToMempool(const spark::Coin& coin) {
-    mempoolMints.insert(coin);
+void CSparkMempoolState::AddMintToMempool(const spark::Coin& coin, const uint256& txHash) {
+    mempoolMints.emplace(coin.getHash(), txHash);
 }
 
 void CSparkMempoolState::RemoveMintFromMempool(const spark::Coin& coin) {
-    mempoolMints.erase(coin);
+    mempoolMints.erase(coin.getHash());
+}
+
+uint256 CSparkMempoolState::GetMempoolConflictingMintTxHash(const spark::Coin& coin) {
+    const auto it = mempoolMints.find(coin.getHash());
+    return it == mempoolMints.end() ? uint256() : it->second;
 }
 
 bool CSparkMempoolState::HasLTag(const GroupElement& lTag) {

--- a/src/spark/state.h
+++ b/src/spark/state.h
@@ -94,7 +94,7 @@ bool BuildSparkStateFromIndex(CChain *chain);
 class CSparkMempoolState {
 private:
     // mints in the mempool
-    std::unordered_set<spark::Coin, spark::CoinHash> mempoolMints;
+    std::unordered_map<uint256, uint256> mempoolMints;
 
     // linking tags of spends currently in the mempool mapped to tx hashes
     std::unordered_map<GroupElement, uint256, spark::CLTagHash> mempoolLTags;
@@ -102,8 +102,9 @@ private:
 public:
     // Check if there is a conflicting tx in the blockchain or mempool
     bool HasMint(const spark::Coin& coin);
-    void AddMintToMempool(const spark::Coin& coin);
+    void AddMintToMempool(const spark::Coin& coin, const uint256& txHash);
     void RemoveMintFromMempool(const spark::Coin& coin);
+    uint256 GetMempoolConflictingMintTxHash(const spark::Coin& coin);
 
     // Check if there is a conflicting tx in the blockchain or mempool
     bool HasLTag(const GroupElement& lTag);
@@ -187,7 +188,9 @@ public:
     // Check if there is a coin with such serial in either blockchain or mempool
     bool AddSpendToMempool(const std::vector<GroupElement>& lTags, uint256 txHash);
 
-    void AddMintsToMempool(const std::vector<spark::Coin>& coins);
+    void AddMintsToMempool(
+        const std::vector<spark::Coin>& coins,
+        const uint256& txHash);
     void RemoveMintFromMempool(const spark::Coin& coin);
 
     // Get conflicting tx hash by coin linking tag

--- a/src/spark/state.h
+++ b/src/spark/state.h
@@ -61,6 +61,12 @@ CAmount GetSpendTransparentAmount(const CTransaction& tx);
 
 bool CheckSparkBlock(CValidationState &state, const CBlock& block, int nBlockHeight);
 
+/** Reject repeated Spark coin identities within a block or at an earlier height. */
+bool CheckSparkMintDuplicates(
+        CValidationState& state,
+        const std::vector<spark::Coin>& mints,
+        int nHeight);
+
 //void DisconnectTipLelantus(CBlock &block, CBlockIndex *pindexDelete);
 
 bool ConnectBlockSpark(

--- a/src/test/spark_state_test.cpp
+++ b/src/test/spark_state_test.cpp
@@ -230,14 +230,21 @@ BOOST_AUTO_TEST_CASE(mempool)
     const uint256 mintTxid = ArithToUint256(1);
     sparkState->AddMintsToMempool({randMint}, mintTxid);
     BOOST_CHECK(!sparkState->CanAddMintToMempool(randMint));
-    BOOST_CHECK(
-        mempool.sparkState.GetMempoolConflictingMintTxHash(randMint) == mintTxid);
+    {
+        LOCK(::mempool.cs);
+        BOOST_CHECK(
+            ::mempool.sparkState.GetMempoolConflictingMintTxHash(randMint) ==
+            mintTxid);
+    }
 
     // - remove from mempool then can add again
     sparkState->RemoveMintFromMempool(randMint);
     BOOST_CHECK(sparkState->CanAddMintToMempool(randMint));
-    BOOST_CHECK(
-        mempool.sparkState.GetMempoolConflictingMintTxHash(randMint).IsNull());
+    {
+        LOCK(::mempool.cs);
+        BOOST_CHECK(
+            ::mempool.sparkState.GetMempoolConflictingMintTxHash(randMint).IsNull());
+    }
 
     // test spend mempool
     // - can not add on-chain spend
@@ -283,26 +290,22 @@ BOOST_AUTO_TEST_CASE(duplicate_mint_consensus_activation)
     const spark::Coin mint = CreateCoin(spark::COIN_TYPE_MINT, 1 * COIN);
     const spark::Coin spendMint = CreateCoin(spark::COIN_TYPE_SPEND, 2 * COIN);
 
-    const auto check = [this](
+    const auto check = [](
             const std::vector<spark::Coin>& mints,
             int height,
-            CBlockIndex* previous,
             CValidationState& state) {
-        CBlock block;
-        PopulateSparkTxInfo(block, mints, {});
-        CBlockIndex index;
-        index.pprev = previous;
-        index.nHeight = height;
-        return ConnectBlockSpark(state, ::Params(), &index, &block, true);
+        if (height < ::Params().GetConsensus().nSparkDuplicateMintStartBlock)
+            return true;
+        return spark::CheckSparkMintDuplicates(state, mints, height);
     };
 
     CValidationState preActivationState;
     BOOST_CHECK(check(
-        {mint, mint}, activationHeight - 1, chainActive.Tip(), preActivationState));
+        {mint, mint}, activationHeight - 1, preActivationState));
 
     CValidationState mintDuplicateState;
     BOOST_CHECK(!check(
-        {mint, mint}, activationHeight, chainActive.Tip(), mintDuplicateState));
+        {mint, mint}, activationHeight, mintDuplicateState));
     int mintDuplicateDoS = 0;
     BOOST_REQUIRE(mintDuplicateState.IsInvalid(mintDuplicateDoS));
     BOOST_CHECK_EQUAL(mintDuplicateDoS, 100);
@@ -313,7 +316,6 @@ BOOST_AUTO_TEST_CASE(duplicate_mint_consensus_activation)
     BOOST_CHECK(!check(
         {spendMint, spendMint},
         activationHeight,
-        chainActive.Tip(),
         spendMintDuplicateState));
     BOOST_CHECK_EQUAL(
         spendMintDuplicateState.GetRejectReason(),
@@ -321,43 +323,108 @@ BOOST_AUTO_TEST_CASE(duplicate_mint_consensus_activation)
 
     CValidationState distinctState;
     BOOST_CHECK(check(
-        {mint, spendMint}, activationHeight, chainActive.Tip(), distinctState));
+        {mint, spendMint}, activationHeight, distinctState));
 
     sparkState->AddMint(
         mint, spark::CMintedCoinInfo::make(1, activationHeight - 1));
     CValidationState activeChainState;
     BOOST_CHECK(!check(
-        {mint}, activationHeight, chainActive.Tip(), activeChainState));
+        {mint}, activationHeight, activeChainState));
     BOOST_CHECK_EQUAL(
         activeChainState.GetRejectReason(), "bad-txns-spark-mint-duplicate");
 
-    // VerifyDB reconnects historical UTXO views without rewinding global Spark
-    // state, so only active-tip connections consult that state.
-    CValidationState historicalState;
+    // VerifyDB may see the candidate block's own mint in global Spark state.
+    // An occurrence at the candidate height is not an earlier duplicate.
+    const spark::Coin replayMint =
+        CreateCoin(spark::COIN_TYPE_MINT, 3 * COIN);
+    sparkState->AddMint(
+        replayMint, spark::CMintedCoinInfo::make(1, activationHeight));
+    CValidationState historicalReplayState;
     BOOST_CHECK(check(
-        {mint}, activationHeight, chainActive.Tip()->pprev, historicalState));
-
-    GroupElement lTag;
-    lTag.randomize();
-    CBlock rejectedBlock;
-    PopulateSparkTxInfo(rejectedBlock, {spendMint, spendMint}, {{lTag, 1}});
-    CBlockIndex rejectedIndex;
-    rejectedIndex.pprev = chainActive.Tip();
-    rejectedIndex.nHeight = activationHeight;
-    const std::size_t coinsBefore = sparkState->GetTotalCoins();
-    CValidationState rejectedState;
-    BOOST_CHECK(!ConnectBlockSpark(
-        rejectedState,
-        ::Params(),
-        &rejectedIndex,
-        &rejectedBlock,
-        false));
-    BOOST_CHECK_EQUAL(sparkState->GetTotalCoins(), coinsBefore);
-    BOOST_CHECK(!sparkState->IsUsedLTag(lTag));
-    BOOST_CHECK(rejectedIndex.sparkMintedCoins.empty());
-    BOOST_CHECK(rejectedIndex.spentLTags.empty());
+        {replayMint}, activationHeight, historicalReplayState));
 
     sparkState->Reset();
+}
+
+BOOST_AUTO_TEST_CASE(duplicate_mint_legacy_disconnect)
+{
+    const spark::Coin mint = CreateCoin(spark::COIN_TYPE_MINT, 1 * COIN);
+
+    CBlock firstBlock;
+    PopulateSparkTxInfo(firstBlock, {mint}, {});
+    CBlockIndex firstIndex;
+    firstIndex.pprev = chainActive.Tip();
+    firstIndex.nHeight = chainActive.Height() + 1;
+    sparkState->AddMintsToStateAndBlockIndex(&firstIndex, &firstBlock);
+
+    CBlock duplicateBlock;
+    PopulateSparkTxInfo(duplicateBlock, {mint, mint}, {});
+    CBlockIndex duplicateIndex;
+    duplicateIndex.pprev = &firstIndex;
+    duplicateIndex.nHeight = firstIndex.nHeight + 1;
+    sparkState->AddMintsToStateAndBlockIndex(&duplicateIndex, &duplicateBlock);
+
+    BOOST_REQUIRE_EQUAL(sparkState->GetTotalCoins(), 1U);
+    BOOST_REQUIRE_EQUAL(duplicateIndex.sparkMintedCoins.at(1).size(), 2U);
+
+    sparkState->RemoveBlock(&duplicateIndex);
+
+    BOOST_CHECK(sparkState->HasCoin(mint));
+    BOOST_CHECK(
+        sparkState->GetMintedCoinHeightAndId(mint) ==
+        std::make_pair(firstIndex.nHeight, 1));
+    spark::CSparkState::SparkCoinGroupInfo group;
+    BOOST_REQUIRE(sparkState->GetCoinGroupInfo(1, group));
+    BOOST_CHECK_EQUAL(group.nCoins, 1);
+    BOOST_CHECK(group.lastBlock == &firstIndex);
+
+    sparkState->RemoveBlock(&firstIndex);
+    BOOST_CHECK(!sparkState->HasCoin(mint));
+    BOOST_CHECK(!sparkState->GetCoinGroupInfo(1, group));
+
+    // Rebuilding from persisted block-index entries must preserve the same
+    // occurrence and remain safe to disconnect.
+    sparkState->AddBlock(&firstIndex);
+    sparkState->AddBlock(&duplicateIndex);
+    BOOST_REQUIRE_EQUAL(sparkState->GetTotalCoins(), 1U);
+    sparkState->RemoveBlock(&duplicateIndex);
+    BOOST_CHECK(
+        sparkState->GetMintedCoinHeightAndId(mint) ==
+        std::make_pair(firstIndex.nHeight, 1));
+    sparkState->RemoveBlock(&firstIndex);
+    BOOST_CHECK_EQUAL(sparkState->GetTotalCoins(), 0U);
+
+    // A later duplicate can also be indexed in a different anonymity-set
+    // group. Disconnecting that group must still preserve the earlier mint.
+    firstIndex.sparkMintedCoins.clear();
+    duplicateIndex.sparkMintedCoins.clear();
+    firstIndex.sparkMintedCoins[1].push_back(mint);
+    duplicateIndex.sparkMintedCoins[2].push_back(mint);
+    sparkState->AddBlock(&firstIndex);
+    sparkState->AddBlock(&duplicateIndex);
+    BOOST_REQUIRE_EQUAL(sparkState->GetLatestCoinID(), 2);
+
+    sparkState->RemoveBlock(&duplicateIndex);
+    BOOST_CHECK(
+        sparkState->GetMintedCoinHeightAndId(mint) ==
+        std::make_pair(firstIndex.nHeight, 1));
+    BOOST_CHECK_EQUAL(sparkState->GetLatestCoinID(), 1);
+    BOOST_CHECK(!sparkState->GetCoinGroupInfo(2, group));
+    sparkState->RemoveBlock(&firstIndex);
+    BOOST_CHECK_EQUAL(sparkState->GetTotalCoins(), 0U);
+
+    const spark::Coin sameBlockMint =
+        CreateCoin(spark::COIN_TYPE_MINT, 2 * COIN);
+    CBlock sameBlock;
+    PopulateSparkTxInfo(sameBlock, {sameBlockMint, sameBlockMint}, {});
+    CBlockIndex sameBlockIndex;
+    sameBlockIndex.pprev = chainActive.Tip();
+    sameBlockIndex.nHeight = chainActive.Height() + 1;
+    sparkState->AddMintsToStateAndBlockIndex(&sameBlockIndex, &sameBlock);
+
+    BOOST_REQUIRE_EQUAL(sparkState->GetTotalCoins(), 1U);
+    sparkState->RemoveBlock(&sameBlockIndex);
+    BOOST_CHECK_EQUAL(sparkState->GetTotalCoins(), 0U);
 }
 
 BOOST_AUTO_TEST_CASE(add_remove_block)

--- a/src/test/spark_state_test.cpp
+++ b/src/test/spark_state_test.cpp
@@ -64,6 +64,22 @@ public:
             block.sparkTxInfo->spentLTags.emplace(lTag);
         }
     }
+
+    spark::Coin CreateCoin(char type, CAmount value)
+    {
+        spark::SpendKey spendKey(params);
+        spark::FullViewKey fullViewKey(spendKey);
+        spark::IncomingViewKey incomingViewKey(fullViewKey);
+        spark::Address address(incomingViewKey, 1);
+        spark::Scalar k;
+        k.randomize();
+
+        spark::Coin coin(
+            params, type, k, address, value, "memo", random_char_vector());
+        // Spend coins do not serialize v, but keep local copies initialized.
+        coin.v = value;
+        return coin;
+    }
 public:
     spark::CSparkState* sparkState;
 };
@@ -211,12 +227,17 @@ BOOST_AUTO_TEST_CASE(mempool)
             );
 
     BOOST_CHECK(sparkState->CanAddMintToMempool(randMint));
-    sparkState->AddMintsToMempool({randMint});
+    const uint256 mintTxid = ArithToUint256(1);
+    sparkState->AddMintsToMempool({randMint}, mintTxid);
     BOOST_CHECK(!sparkState->CanAddMintToMempool(randMint));
+    BOOST_CHECK(
+        mempool.sparkState.GetMempoolConflictingMintTxHash(randMint) == mintTxid);
 
     // - remove from mempool then can add again
     sparkState->RemoveMintFromMempool(randMint);
     BOOST_CHECK(sparkState->CanAddMintToMempool(randMint));
+    BOOST_CHECK(
+        mempool.sparkState.GetMempoolConflictingMintTxHash(randMint).IsNull());
 
     // test spend mempool
     // - can not add on-chain spend
@@ -226,7 +247,7 @@ BOOST_AUTO_TEST_CASE(mempool)
     GroupElement anotherLTag;
     anotherLTag.randomize();
 
-    auto txid = ArithToUint256(1);
+    auto txid = ArithToUint256(2);
 
     BOOST_CHECK(sparkState->CanAddSpendToMempool(anotherLTag));
     sparkState->AddSpendToMempool({anotherLTag}, txid);
@@ -243,6 +264,98 @@ BOOST_AUTO_TEST_CASE(mempool)
     BOOST_CHECK(sparkState->CanAddSpendToMempool(anotherLTag));
     sparkState->AddSpendToMempool({anotherLTag}, txid);
     BOOST_CHECK(!sparkState->CanAddSpendToMempool(anotherLTag));
+
+    sparkState->Reset();
+}
+
+BOOST_AUTO_TEST_CASE(duplicate_mint_consensus_activation)
+{
+    struct ResetActivationHeight {
+        ~ResetActivationHeight()
+        {
+            UpdateRegtestSparkDuplicateMintHeight(INT_MAX);
+        }
+    } resetActivationHeight;
+
+    const int activationHeight = chainActive.Height() + 2;
+    UpdateRegtestSparkDuplicateMintHeight(activationHeight);
+
+    const spark::Coin mint = CreateCoin(spark::COIN_TYPE_MINT, 1 * COIN);
+    const spark::Coin spendMint = CreateCoin(spark::COIN_TYPE_SPEND, 2 * COIN);
+
+    const auto check = [this](
+            const std::vector<spark::Coin>& mints,
+            int height,
+            CBlockIndex* previous,
+            CValidationState& state) {
+        CBlock block;
+        PopulateSparkTxInfo(block, mints, {});
+        CBlockIndex index;
+        index.pprev = previous;
+        index.nHeight = height;
+        return ConnectBlockSpark(state, ::Params(), &index, &block, true);
+    };
+
+    CValidationState preActivationState;
+    BOOST_CHECK(check(
+        {mint, mint}, activationHeight - 1, chainActive.Tip(), preActivationState));
+
+    CValidationState mintDuplicateState;
+    BOOST_CHECK(!check(
+        {mint, mint}, activationHeight, chainActive.Tip(), mintDuplicateState));
+    int mintDuplicateDoS = 0;
+    BOOST_REQUIRE(mintDuplicateState.IsInvalid(mintDuplicateDoS));
+    BOOST_CHECK_EQUAL(mintDuplicateDoS, 100);
+    BOOST_CHECK_EQUAL(
+        mintDuplicateState.GetRejectReason(), "bad-txns-spark-mint-duplicate");
+
+    CValidationState spendMintDuplicateState;
+    BOOST_CHECK(!check(
+        {spendMint, spendMint},
+        activationHeight,
+        chainActive.Tip(),
+        spendMintDuplicateState));
+    BOOST_CHECK_EQUAL(
+        spendMintDuplicateState.GetRejectReason(),
+        "bad-txns-spark-mint-duplicate");
+
+    CValidationState distinctState;
+    BOOST_CHECK(check(
+        {mint, spendMint}, activationHeight, chainActive.Tip(), distinctState));
+
+    sparkState->AddMint(
+        mint, spark::CMintedCoinInfo::make(1, activationHeight - 1));
+    CValidationState activeChainState;
+    BOOST_CHECK(!check(
+        {mint}, activationHeight, chainActive.Tip(), activeChainState));
+    BOOST_CHECK_EQUAL(
+        activeChainState.GetRejectReason(), "bad-txns-spark-mint-duplicate");
+
+    // VerifyDB reconnects historical UTXO views without rewinding global Spark
+    // state, so only active-tip connections consult that state.
+    CValidationState historicalState;
+    BOOST_CHECK(check(
+        {mint}, activationHeight, chainActive.Tip()->pprev, historicalState));
+
+    GroupElement lTag;
+    lTag.randomize();
+    CBlock rejectedBlock;
+    PopulateSparkTxInfo(rejectedBlock, {spendMint, spendMint}, {{lTag, 1}});
+    CBlockIndex rejectedIndex;
+    rejectedIndex.pprev = chainActive.Tip();
+    rejectedIndex.nHeight = activationHeight;
+    const std::size_t coinsBefore = sparkState->GetTotalCoins();
+    CValidationState rejectedState;
+    BOOST_CHECK(!ConnectBlockSpark(
+        rejectedState,
+        ::Params(),
+        &rejectedIndex,
+        &rejectedBlock,
+        false));
+    BOOST_CHECK_EQUAL(sparkState->GetTotalCoins(), coinsBefore);
+    BOOST_CHECK(!sparkState->IsUsedLTag(lTag));
+    BOOST_CHECK(rejectedIndex.sparkMintedCoins.empty());
+    BOOST_CHECK(rejectedIndex.spentLTags.empty());
 
     sparkState->Reset();
 }

--- a/src/test/spark_tests.cpp
+++ b/src/test/spark_tests.cpp
@@ -1,5 +1,6 @@
 #include "../chainparams.h"
 #include "../batchproof_container.h"
+#include "../script/sign.h"
 #include "../script/standard.h"
 #include "../validation.h"
 #include "../wallet/coincontrol.h"
@@ -671,18 +672,65 @@ BOOST_AUTO_TEST_CASE(checktransaction)
     sparkState->Reset();
 }
 
-BOOST_AUTO_TEST_CASE(spark_duplicate_mint_mempool_policy)
+BOOST_AUTO_TEST_CASE(spark_duplicate_mint_policy_and_block_activation)
 {
+    struct ResetActivationHeight {
+        ~ResetActivationHeight()
+        {
+            UpdateRegtestSparkDuplicateMintHeight(INT_MAX);
+        }
+    } resetActivationHeight;
+
     GenerateBlocks(500);
 
     std::vector<CMutableTransaction> mintTransactions;
-    GenerateMints({5 * COIN}, mintTransactions);
-    BOOST_REQUIRE_EQUAL(mintTransactions.size(), 1U);
-    mempool.clear();
+    GenerateMints({5 * COIN, 5 * COIN}, mintTransactions);
+    BOOST_REQUIRE_EQUAL(mintTransactions.size(), 2U);
+
+    const auto firstMintOutput = std::find_if(
+        mintTransactions[0].vout.cbegin(),
+        mintTransactions[0].vout.cend(),
+        [](const CTxOut& output) { return output.scriptPubKey.IsSparkMint(); });
+    auto duplicateMintOutput = std::find_if(
+        mintTransactions[1].vout.begin(),
+        mintTransactions[1].vout.end(),
+        [](const CTxOut& output) { return output.scriptPubKey.IsSparkMint(); });
+    BOOST_REQUIRE(firstMintOutput != mintTransactions[0].vout.cend());
+    BOOST_REQUIRE(duplicateMintOutput != mintTransactions[1].vout.end());
+    *duplicateMintOutput = *firstMintOutput;
+
+    // Re-sign the independently funded transaction after replacing its output.
+    for (size_t input = 0; input < mintTransactions[1].vin.size(); ++input) {
+        CTransactionRef previousTransaction;
+        uint256 previousBlock;
+        BOOST_REQUIRE(GetTransaction(
+            mintTransactions[1].vin[input].prevout.hash,
+            previousTransaction,
+            ::Params().GetConsensus(),
+            previousBlock,
+            true));
+        LOCK(pwalletMain->cs_wallet);
+        BOOST_REQUIRE(SignSignature(
+            *pwalletMain,
+            *previousTransaction,
+            mintTransactions[1],
+            input,
+            SIGHASH_ALL));
+    }
+
+    txpools.clear();
 
     const CTransactionRef mintTx = MakeTransactionRef(mintTransactions.front());
+    const CTransactionRef crossTransactionDuplicate =
+        MakeTransactionRef(mintTransactions.back());
     const std::vector<spark::Coin> mintCoins = GetSparkMintCoins(*mintTx);
+    const std::vector<spark::Coin> duplicateMintCoins =
+        GetSparkMintCoins(*crossTransactionDuplicate);
     BOOST_REQUIRE_EQUAL(mintCoins.size(), 1U);
+    BOOST_REQUIRE_EQUAL(duplicateMintCoins.size(), 1U);
+    BOOST_REQUIRE(mintTx->GetHash() != crossTransactionDuplicate->GetHash());
+    BOOST_REQUIRE(
+        mintCoins.front().getHash() == duplicateMintCoins.front().getHash());
 
     {
         LOCK(cs_main);
@@ -693,12 +741,13 @@ BOOST_AUTO_TEST_CASE(spark_duplicate_mint_mempool_policy)
         BOOST_CHECK(!missingInputs);
     }
     BOOST_CHECK_EQUAL(mempool.size(), 1U);
-    BOOST_CHECK(
-        mempool.sparkState.GetMempoolConflictingMintTxHash(mintCoins.front()) ==
-        mintTx->GetHash());
+    {
+        LOCK(mempool.cs);
+        BOOST_CHECK(
+            mempool.sparkState.GetMempoolConflictingMintTxHash(mintCoins.front()) ==
+            mintTx->GetHash());
+    }
 
-    CMutableTransaction crossTransactionDuplicate(*mintTx);
-    crossTransactionDuplicate.vin.front().scriptSig << OP_0;
     {
         LOCK(cs_main);
         CValidationState state;
@@ -706,7 +755,7 @@ BOOST_AUTO_TEST_CASE(spark_duplicate_mint_mempool_policy)
         BOOST_CHECK(!AcceptToMemoryPool(
             mempool,
             state,
-            MakeTransactionRef(crossTransactionDuplicate),
+            crossTransactionDuplicate,
             false,
             &missingInputs));
         int dos = -1;
@@ -720,9 +769,12 @@ BOOST_AUTO_TEST_CASE(spark_duplicate_mint_mempool_policy)
         LOCK(cs_main);
         mempool.removeRecursive(*mintTx);
     }
-    BOOST_CHECK(!mempool.sparkState.HasMint(mintCoins.front()));
-    BOOST_CHECK(
-        mempool.sparkState.GetMempoolConflictingMintTxHash(mintCoins.front()).IsNull());
+    {
+        LOCK(mempool.cs);
+        BOOST_CHECK(!mempool.sparkState.HasMint(mintCoins.front()));
+        BOOST_CHECK(
+            mempool.sparkState.GetMempoolConflictingMintTxHash(mintCoins.front()).IsNull());
+    }
 
     CMutableTransaction withinTransactionDuplicate(*mintTx);
     const auto mintOutput = std::find_if(
@@ -749,7 +801,51 @@ BOOST_AUTO_TEST_CASE(spark_duplicate_mint_mempool_policy)
         BOOST_CHECK(!missingInputs);
     }
 
-    mempool.clear();
+    // Removing the owner must release the mint identity for future admission.
+    {
+        LOCK(cs_main);
+        CValidationState state;
+        bool missingInputs = true;
+        BOOST_REQUIRE(AcceptToMemoryPool(
+            mempool, state, mintTx, false, &missingInputs));
+        BOOST_CHECK(!missingInputs);
+    }
+
+    txpools.clear();
+
+    // Exercise the full block path with valid transactions on both sides of
+    // the activation boundary.
+    const int candidateHeight = chainActive.Height() + 1;
+    const CBlock duplicateBlock = CreateBlock(mintTransactions, script);
+    UpdateRegtestSparkDuplicateMintHeight(candidateHeight + 1);
+    {
+        LOCK(cs_main);
+        CValidationState preActivationState;
+        BOOST_REQUIRE(TestBlockValidity(
+            preActivationState,
+            ::Params(),
+            duplicateBlock,
+            chainActive.Tip()));
+    }
+
+    UpdateRegtestSparkDuplicateMintHeight(candidateHeight);
+    {
+        LOCK(cs_main);
+        CValidationState activationState;
+        BOOST_CHECK(!TestBlockValidity(
+            activationState,
+            ::Params(),
+            duplicateBlock,
+            chainActive.Tip()));
+        int dos = -1;
+        BOOST_REQUIRE(activationState.IsInvalid(dos));
+        BOOST_CHECK_EQUAL(dos, 100);
+        BOOST_CHECK_EQUAL(
+            activationState.GetRejectReason(),
+            "bad-txns-spark-mint-duplicate");
+    }
+
+    txpools.clear();
     sparkState->Reset();
 }
 

--- a/src/test/spark_tests.cpp
+++ b/src/test/spark_tests.cpp
@@ -671,6 +671,88 @@ BOOST_AUTO_TEST_CASE(checktransaction)
     sparkState->Reset();
 }
 
+BOOST_AUTO_TEST_CASE(spark_duplicate_mint_mempool_policy)
+{
+    GenerateBlocks(500);
+
+    std::vector<CMutableTransaction> mintTransactions;
+    GenerateMints({5 * COIN}, mintTransactions);
+    BOOST_REQUIRE_EQUAL(mintTransactions.size(), 1U);
+    mempool.clear();
+
+    const CTransactionRef mintTx = MakeTransactionRef(mintTransactions.front());
+    const std::vector<spark::Coin> mintCoins = GetSparkMintCoins(*mintTx);
+    BOOST_REQUIRE_EQUAL(mintCoins.size(), 1U);
+
+    {
+        LOCK(cs_main);
+        CValidationState state;
+        bool missingInputs = true;
+        BOOST_REQUIRE(AcceptToMemoryPool(
+            mempool, state, mintTx, false, &missingInputs));
+        BOOST_CHECK(!missingInputs);
+    }
+    BOOST_CHECK_EQUAL(mempool.size(), 1U);
+    BOOST_CHECK(
+        mempool.sparkState.GetMempoolConflictingMintTxHash(mintCoins.front()) ==
+        mintTx->GetHash());
+
+    CMutableTransaction crossTransactionDuplicate(*mintTx);
+    crossTransactionDuplicate.vin.front().scriptSig << OP_0;
+    {
+        LOCK(cs_main);
+        CValidationState state;
+        bool missingInputs = true;
+        BOOST_CHECK(!AcceptToMemoryPool(
+            mempool,
+            state,
+            MakeTransactionRef(crossTransactionDuplicate),
+            false,
+            &missingInputs));
+        int dos = -1;
+        BOOST_REQUIRE(state.IsInvalid(dos));
+        BOOST_CHECK_EQUAL(dos, 0);
+        BOOST_CHECK_EQUAL(state.GetRejectReason(), "txn-mempool-conflict");
+        BOOST_CHECK(!missingInputs);
+    }
+
+    {
+        LOCK(cs_main);
+        mempool.removeRecursive(*mintTx);
+    }
+    BOOST_CHECK(!mempool.sparkState.HasMint(mintCoins.front()));
+    BOOST_CHECK(
+        mempool.sparkState.GetMempoolConflictingMintTxHash(mintCoins.front()).IsNull());
+
+    CMutableTransaction withinTransactionDuplicate(*mintTx);
+    const auto mintOutput = std::find_if(
+        withinTransactionDuplicate.vout.begin(),
+        withinTransactionDuplicate.vout.end(),
+        [](const CTxOut& output) { return output.scriptPubKey.IsSparkMint(); });
+    BOOST_REQUIRE(mintOutput != withinTransactionDuplicate.vout.end());
+    const CTxOut duplicateOutput = *mintOutput;
+    withinTransactionDuplicate.vout.push_back(duplicateOutput);
+    {
+        LOCK(cs_main);
+        CValidationState state;
+        bool missingInputs = true;
+        BOOST_CHECK(!AcceptToMemoryPool(
+            mempool,
+            state,
+            MakeTransactionRef(withinTransactionDuplicate),
+            false,
+            &missingInputs));
+        int dos = -1;
+        BOOST_REQUIRE(state.IsInvalid(dos));
+        BOOST_CHECK_EQUAL(dos, 0);
+        BOOST_CHECK_EQUAL(state.GetRejectReason(), "txn-mempool-conflict");
+        BOOST_CHECK(!missingInputs);
+    }
+
+    mempool.clear();
+    sparkState->Reset();
+}
+
 BOOST_AUTO_TEST_CASE(spark_single_input_mempool_policy)
 {
     GenerateBlocks(200);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2809,6 +2809,11 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     }
 
     block.sparkTxInfo->Complete();
+    if (pindex->nHeight >= chainparams.GetConsensus().nSparkDuplicateMintStartBlock &&
+            !spark::CheckSparkMintDuplicates(
+                state, block.sparkTxInfo->mints, pindex->nHeight)) {
+        return false;
+    }
 
     int64_t nTime3 = GetTimeMicros(); nTimeConnect += nTime3 - nTime2;
     LogPrint("bench", "      - Connect %u transactions: %.2fms (%.3fms/tx, %.3fms/txin) [%.2fs]\n", (unsigned)block.vtx.size(), 0.001 * (nTime3 - nTime2), 0.001 * (nTime3 - nTime2) / block.vtx.size(), nInputs <= 1 ? 0 : 0.001 * (nTime3 - nTime2) / (nInputs-1), nTimeConnect * 0.000001);
@@ -3032,7 +3037,8 @@ void static RemoveConflictingSparkMintsFromMempool(CTxMemPool& pool, const CBloc
                     if (!conflictingTxHash.IsNull() && conflictingTxHash != tx->GetHash()) {
                         auto pTx = pool.get(conflictingTxHash);
                         if (pTx)
-                            pool.removeRecursive(*pTx);
+                            pool.removeRecursive(
+                                *pTx, MemPoolRemovalReason::CONFLICT);
                         LogPrintf("ConnectBlock: removed conflicting Spark mint tx %s from the mempool\n",
                                   conflictingTxHash.ToString());
                     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -70,6 +70,7 @@
 #include <atomic>
 #include <sstream>
 #include <chrono>
+#include <unordered_set>
 
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/join.hpp>
@@ -860,6 +861,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
     // Spark
     spark::CSparkState *sparkState = spark::CSparkState::GetState();
     std::vector<spark::Coin> sparkMintCoins;
+    std::unordered_set<uint256> txSparkMints;
     std::vector<GroupElement> sparkUsedLTags;
 
     CSparkNameTxData sparkNameData;
@@ -907,8 +909,9 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
             }
 
             for (const auto& coin : sparkMintCoins) {
-                if (sparkState->HasCoin(coin) || pool.sparkState.HasMint(coin)) {
-                    LogPrintf("AcceptToMemoryPool(): Spark mint with the same value %s is already in the mempool\n", coin.getHash().GetHex());
+                if (!txSparkMints.insert(coin.getHash()).second ||
+                        sparkState->HasCoin(coin) || pool.sparkState.HasMint(coin)) {
+                    LogPrintf("AcceptToMemoryPool(): duplicate Spark mint coin %s\n", coin.getHash().GetHex());
                     return state.Invalid(false, REJECT_CONFLICT, "txn-mempool-conflict");
                 }
             }
@@ -1406,6 +1409,9 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
 
             // Store transaction in memory
             pool.addUnchecked(hash, entry, setAncestors, validForFeeEstimation);
+            for (const auto& coin : sparkMintCoins) {
+                pool.sparkState.AddMintToMempool(coin, hash);
+            }
 
             // Add memory address index
             if (fAddressIndex) {
@@ -2973,13 +2979,10 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     return true;
 }
 
-/**
- * Erase all of sigma/lelantus transactions conflicting with given block from the mempool
- */
-void static RemoveConflictingPrivacyTransactionsFromMempool(const CBlock &block) {
+/** Erase Spark spends conflicting with the given block from the mempool. */
+void static RemoveConflictingSparkSpendsFromMempool(const CBlock &block) {
     LOCK(mempool.cs);
 
-    // Erase conflicting sigma/lelantus txs from the mempool
     spark::CSparkState *sparkState = spark::CSparkState::GetState();
     BOOST_FOREACH(CTransactionRef tx, block.vtx) {
         if (tx->IsSparkSpend()) {
@@ -2998,7 +3001,6 @@ void static RemoveConflictingPrivacyTransactionsFromMempool(const CBlock &block)
                     break;
             }
             if (!conflictingTxHash.IsNull() && conflictingTxHash != thisTxHash) {
-                std::list<CTransaction> removed;
                 auto pTx = mempool.get(conflictingTxHash);
                 if (pTx)
                     mempool.removeRecursive(*pTx);
@@ -3009,6 +3011,14 @@ void static RemoveConflictingPrivacyTransactionsFromMempool(const CBlock &block)
             // In any case we need to remove lTags from mempool set
             sparkState->RemoveSpendFromMempool(lTags);
         }
+    }
+}
+
+/** Erase Spark mint transactions conflicting with the given block from a pool. */
+void static RemoveConflictingSparkMintsFromMempool(CTxMemPool& pool, const CBlock &block) {
+    LOCK(pool.cs);
+
+    BOOST_FOREACH(CTransactionRef tx, block.vtx) {
         BOOST_FOREACH(const CTxOut &txout, tx->vout)
         {
             if (txout.scriptPubKey.IsSparkMint() || txout.scriptPubKey.IsSparkSMint()) {
@@ -3017,7 +3027,16 @@ void static RemoveConflictingPrivacyTransactionsFromMempool(const CBlock &block)
 
                     spark::Coin txCoin(params);
                     spark::ParseSparkMintCoin(txout.scriptPubKey, txCoin);
-                    sparkState->RemoveMintFromMempool(txCoin);
+                    const uint256 conflictingTxHash =
+                        pool.sparkState.GetMempoolConflictingMintTxHash(txCoin);
+                    if (!conflictingTxHash.IsNull() && conflictingTxHash != tx->GetHash()) {
+                        auto pTx = pool.get(conflictingTxHash);
+                        if (pTx)
+                            pool.removeRecursive(*pTx);
+                        LogPrintf("ConnectBlock: removed conflicting Spark mint tx %s from the mempool\n",
+                                  conflictingTxHash.ToString());
+                    }
+                    pool.sparkState.RemoveMintFromMempool(txCoin);
                 } catch (std::invalid_argument&) {
                     // nothing
                 }
@@ -3384,8 +3403,12 @@ bool static ConnectTip(CValidationState& state, const CChainParams& chainparams,
 
         CCoinsViewCache view(pcoinsTip);
         bool rv = ConnectBlock(blockConnecting, state, pindexNew, view, chainparams);
-        if (rv)
-            RemoveConflictingPrivacyTransactionsFromMempool(blockConnecting);
+        if (rv) {
+            RemoveConflictingSparkSpendsFromMempool(blockConnecting);
+            RemoveConflictingSparkMintsFromMempool(mempool, blockConnecting);
+            RemoveConflictingSparkMintsFromMempool(
+                txpools.getStemTxPool(), blockConnecting);
+        }
         GetMainSignals().BlockChecked(blockConnecting, state);
         if (!rv) {
             LogPrintf("ConnectTip(): ConnectBlock failed at height=%d, hash=%s: %s\n",


### PR DESCRIPTION
## PR intention

Prevent duplicate Spark mint coins from corrupting the relationship between Spark coin-group counts, block-index mint entries, and the active minted-coin map. A duplicate can otherwise be counted and indexed more than once while the map stores it once, making a later disconnect capable of removing the wrong occurrence, asserting, or dereferencing a missing map entry.

Provenance: this PR splits and reconstructs the duplicate-mint hardening from public commit [`28251a690`](https://github.com/firoorg/firo/commit/28251a6906c14847cfd1d77376d83f72fd66444c), authored June 19, 2026 on the public [`spark-coin-type-fix`](https://github.com/firoorg/firo/tree/spark-coin-type-fix) branch. That work predates the later external vulnerability report. This PR carries Firo's earlier hardening forward as a separate, current-`master` change. It was not initiated in response to that report.

The earlier commit is not cherry-picked unchanged because it depends on its parent coin-type commit, only covers direct `OP_SPARKMINT` outputs within one block, ties uniqueness to an unrelated activation, and has no dedicated tests. This reconstruction is semantically independent of #1901 and also covers `OP_SPARKSMINT`, earlier active-chain occurrences, legacy disconnects, and mempool behavior. If #1901 lands first, this branch will need a mechanical rebase because both PRs add chain parameters and Spark tests.

Related PR #1903 fixes the pre-existing VerifyDB level-4 Spark state mutation found during this review. It remains separate to avoid mixing that broader verification bug into this duplicate-mint PR. The height-aware duplicate lookup here is behaviorally compatible with #1903 and allows the early `ConnectBlock` check to examine a block already represented at the same height. Both PRs add tests at the same location, so a small test-file conflict must be resolved if #1903 lands first.

## Code changes brief

- Reject repeated Spark coin hashes across all mint-producing transactions in one block immediately after the completed Spark mint vector is built, before later MTP, spork, Spark state, or block-index handling.
- Reject a candidate block when the same Spark coin is recorded at an earlier height, while allowing its own equal-height representation during historical verification.
- Cover direct `OP_SPARKMINT` coins and `OP_SPARKSMINT` coins created by Spark spends through the shared completed mint vector.
- Preserve an older mint occurrence when disconnecting a legacy duplicate index entry. Metadata is decremented for every indexed occurrence even when the unique minted-coin map has no corresponding entry.
- Track Spark mint reservations and owning transaction IDs independently in the main mempool and stem pool.
- Reject duplicate coins within one transaction or across mempool transactions without assigning peer misbehavior points.
- Remove a different-transaction mempool conflict when a block confirms the same Spark coin, using the normal conflict-removal reason so wallet observers receive the expected notification.
- Gate block-consensus enforcement behind a separate activation height. Public-network and regtest defaults remain disabled at `INT_MAX` in this draft pending historical-chain review and coordinated deployment heights.

## Validation

- Added a full `TestBlockValidity` regression using two valid, separately signed mint transactions with the same Spark output. The block passes immediately before activation and fails at activation with DoS 100 and `bad-txns-spark-mint-duplicate`.
- Added coverage for both Spark coin types, earlier-height and equal-height state, main-mempool ownership and cleanup, same-block duplicates, same-group and cross-group legacy disconnects, and state rebuild from persisted block-index entries.
- `git diff --check` passes, apart from the checkout's existing LF-to-CRLF notices.
- Local compilation is unavailable in this Windows checkout because CMake is not installed on PATH and the existing cache lacks `bls-dash`. The pushed head relies on the repository CI matrix for native build and test execution.
- Exact-head CI has passed macOS and Windows Release/Debug builds, the Linux Release build, all 92 Release and Debug unit targets, and the full Linux Release RPC suite. The Linux Debug RPC suite had one unrelated failure in unchanged `dip3-deterministicmns.py` at its immediate post-`invalidateblock()` masternode-list assertion; all other RPC tests passed. Rerun only that failed job after the Guix jobs finish and GitHub enables reruns.
- Guix reproducible-build jobs are still running.

Before this draft is made ready, active network histories must be scanned for existing duplicate Spark coin identities, concrete activation heights must be selected, #1901 and #1903 must be reconciled if merged first, the unrelated Debug RPC failure must pass on rerun, and the remaining CI jobs must pass.