### PR TITLE
Consensus: skip Spark state updates during VerifyDB reconnect

### DIFF
--- a/src/libspark/coin.h
+++ b/src/libspark/coin.h
@@ -90,7 +90,7 @@ public:
     bool operator==(const Coin& other) const;
     bool operator!=(const Coin& other) const;
 
-    // type and v are not included in hash
+    // Hash of the serialized coin; covers type, and v for mint-type coins
     uint256 getHash() const;
 
     void setParams(const Params* params);

--- a/src/test/spark_state_test.cpp
+++ b/src/test/spark_state_test.cpp
@@ -247,6 +247,53 @@ BOOST_AUTO_TEST_CASE(mempool)
     sparkState->Reset();
 }
 
+BOOST_AUTO_TEST_CASE(verifydb_preserves_spark_state)
+{
+    GenerateBlocks(501);
+
+    // Two separate mint blocks so a reconnect that re-ran the Spark connect
+    // logic would hit the last-block ordering assertion, plus a spend block
+    // whose lTag is already in state.
+    std::vector<CMutableTransaction> mintTxs;
+    GenerateMints({50 * COIN, 60 * COIN}, mintTxs);
+    BOOST_REQUIRE(GenerateBlock(mintTxs));
+    GenerateBlocks(5);
+
+    std::vector<CMutableTransaction> moreMintTxs;
+    GenerateMints({70 * COIN}, moreMintTxs);
+    BOOST_REQUIRE(GenerateBlock(moreMintTxs));
+    GenerateBlocks(1);
+
+    const CTransaction spendTx = GenerateSparkSpend({30 * COIN}, {}, nullptr);
+    BOOST_REQUIRE(GenerateBlock({CMutableTransaction(spendTx)}));
+    GenerateBlocks(2);
+
+    const std::size_t coinsBefore = sparkState->GetMints().size();
+    const std::size_t spendsBefore = sparkState->GetSpends().size();
+    BOOST_REQUIRE(coinsBefore >= 3);
+    BOOST_REQUIRE_EQUAL(spendsBefore, 1U);
+    spark::CSparkState::SparkCoinGroupInfo groupBefore;
+    BOOST_REQUIRE(sparkState->GetCoinGroupInfo(1, groupBefore));
+
+    // -checklevel=4 verification disconnects recent blocks against a throwaway
+    // UTXO view and reconnects them; global Spark state is not rewound in the
+    // process and must come out of the reconnection untouched.
+    FlushStateToDisk(); // VerifyDB reads the database view, as at startup
+    BOOST_CHECK(CVerifyDB().VerifyDB(::Params(), pcoinsdbview, 4, 20));
+
+    BOOST_CHECK_EQUAL(sparkState->GetMints().size(), coinsBefore);
+    BOOST_CHECK_EQUAL(sparkState->GetSpends().size(), spendsBefore);
+    spark::CSparkState::SparkCoinGroupInfo groupAfter;
+    BOOST_REQUIRE(sparkState->GetCoinGroupInfo(1, groupAfter));
+    BOOST_CHECK_EQUAL(groupAfter.nCoins, groupBefore.nCoins);
+    BOOST_CHECK(groupAfter.firstBlock == groupBefore.firstBlock);
+    BOOST_CHECK(groupAfter.lastBlock == groupBefore.lastBlock);
+
+    // the mempool test case class shadows the global mempool here
+    ::mempool.clear();
+    sparkState->Reset();
+}
+
 BOOST_AUTO_TEST_CASE(add_remove_block)
 {
     GenerateBlocks(501);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2502,7 +2502,7 @@ static int64_t nTimeCallbacks = 0;
 static int64_t nTimeTotal = 0;
 
 bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pindex,
-                  CCoinsViewCache& view, const CChainParams& chainparams, bool fJustCheck)
+                  CCoinsViewCache& view, const CChainParams& chainparams, bool fJustCheck, bool isVerifyDB)
 {
     AssertLockHeld(cs_main);
 
@@ -2898,7 +2898,11 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         }
     }
 
-    if (!spark::ConnectBlockSpark(state, chainparams, pindex, &block, fJustCheck))
+    // VerifyDB rewinds only its throwaway UTXO view; global Spark state and the
+    // Spark entries of the block index are never rolled back. Re-running the
+    // Spark connect logic on such a reconnect double-counts mints and fails the
+    // used-lTag check against state that still contains this block, so skip it.
+    if (!isVerifyDB && !spark::ConnectBlockSpark(state, chainparams, pindex, &block, fJustCheck))
         return false;
 
     if (!sporkManager->IsBlockAllowed(block, pindex, state))
@@ -5169,7 +5173,7 @@ bool CVerifyDB::VerifyDB(const CChainParams& chainparams, CCoinsView *coinsview,
             CBlock block;
             if (!ReadBlockFromDisk(block, pindex, chainparams.GetConsensus()))
                 return error("VerifyDB(): *** ReadBlockFromDisk failed at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
-            if (!ConnectBlock(block, state, pindex, coins, chainparams))
+            if (!ConnectBlock(block, state, pindex, coins, chainparams, false, true /* isVerifyDB */))
                 return error("VerifyDB(): *** found unconnectable block at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
         }
     }

--- a/src/validation.h
+++ b/src/validation.h
@@ -547,9 +547,12 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, const Co
 
 /** Apply the effects of this block (with given index) on the UTXO set represented by coins.
  *  Validity checks that depend on the UTXO set are also done; ConnectBlock()
- *  can fail if those validity checks fail (among other reasons). */
+ *  can fail if those validity checks fail (among other reasons).
+ *  isVerifyDB must be set when reconnecting blocks against a throwaway coins
+ *  view (CVerifyDB): it skips updates to global state that VerifyDB's
+ *  in-memory disconnects never roll back. */
 bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pindex, CCoinsViewCache& coins,
-                  const CChainParams& chainparams, bool fJustCheck = false);
+                  const CChainParams& chainparams, bool fJustCheck = false, bool isVerifyDB = false);
 
 /** Reprocess a number of blocks to try and get on the correct chain again **/
 bool DisconnectBlocks(int blocks);


### PR DESCRIPTION
## PR intention

Fix a pre-existing `-checklevel=4` startup crash/corruption found while reviewing #1902.

`CVerifyDB` level 3 disconnects recent blocks against a throwaway coins view and level 4 reconnects them through `ConnectBlock`, but global Spark state and the Spark entries of the block index are never rolled back in the process (`DisconnectBlock` with `pfClean` performs "no real disconnect", and `DisconnectTipSpark` is never invoked). Level-4 reconnection therefore re-runs `ConnectBlockSpark` against state that still contains those blocks:

- a block with Spark mints double-counts the coin group size and mint metadata, or aborts on `assert(coinGroup.lastBlock->nHeight <= index->nHeight)` in `AddMintsToStateAndBlockIndex` when a later block already holds mints of the same group;
- a block with a Spark spend fails the `CheckLTag` used-lTag check, so VerifyDB reports an unconnectable block and the node refuses to start;
- Spark name expiry is replayed at historical heights, and the rewritten block-index Spark entries can later be flushed to disk.

The new regression test reproduces the abort on current master (assertion failure in `spark/state.cpp` `AddMintsToStateAndBlockIndex` during level-4 reconnection) and passes with the fix.

## Code changes brief

- Thread an `isVerifyDB` flag through `ConnectBlock` (default `false`) and pass it from `CVerifyDB::VerifyDB`'s level-4 reconnection loop.
- Skip `ConnectBlockSpark` when the flag is set. Stateful Spark checks are meaningless against un-rewound state, while the stateless per-transaction Spark checks still run through `CheckBlock`/`CheckTransaction` inside `ConnectBlock`, whose lTag check already tolerates recorded lTags outside tip connection. Real block connection (`ConnectTip`, `TestBlockValidity`) is unchanged.
- Add `spark_state_tests/verifydb_preserves_spark_state`: builds two Spark mint blocks and a spend block, runs `-checklevel=4`-style verification via `CVerifyDB`, and asserts the mint map, spend map, and coin-group bookkeeping come out untouched.
- Separately fix the stale comment on `spark::Coin::getHash()` claiming type and v are excluded from the hash; they are part of the serialization it hashes.

Verified locally on Linux: `test_firo --run_test=spark_state_tests,spark_tests,spark_mintspend` passes (25 cases, no errors detected). With the validation change reverted to master, the new test aborts exactly as a `-checklevel=4` node would.

Independent of #1902 and textually non-conflicting: the hunks touch different regions of `validation.cpp` and this PR does not modify `spark/state.cpp` logic. If both land, #1902's active-state gate in `ConnectBlockSpark` simply never sees a VerifyDB reconnection anymore, which is compatible with its intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LphSq9aU2w13j6DWs7m6Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01LphSq9aU2w13j6DWs7m6Ry)_