### PR TITLE
Net: ignore MNAUTH before blockchain sync

### DIFF
--- a/src/evo/mnauth.cpp
+++ b/src/evo/mnauth.cpp
@@ -46,19 +46,13 @@ void CMNAuth::PushMNAUTH(CNode* pnode, CConnman& connman)
 
 void CMNAuth::ProcessMessage(CNode* pnode, const std::string& strCommand, CDataStream& vRecv, CConnman& connman)
 {
-    if (strCommand != NetMsgType::MNAUTH)
+    if (strCommand != NetMsgType::MNAUTH || !masternodeSync.IsBlockchainSynced()) {
+        // we can't verify MNAUTH messages when we don't have the latest MN list
         return;
+    }
 
     CMNAuth mnauth;
     vRecv >> mnauth;
-
-    if (!masternodeSync.IsBlockchainSynced()) {
-        // we can't really verify MNAUTH messages when we don't have the latest MN list
-        // save verification for later
-        LOCK(pnode->cs_mnauth);
-        pnode->pendingMNVerification = new CMNAuth(mnauth);
-        return;
-    }
 
     ProcessMNAUTH(pnode, mnauth, connman);
 }

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -12,7 +12,6 @@
 #include "netmessagemaker.h"
 #include "ui_interface.h"
 #include "evo/deterministicmns.h"
-#include "evo/mnauth.h"
 
 class CMasternodeSync;
 CMasternodeSync masternodeSync;
@@ -271,26 +270,6 @@ void CMasternodeSync::UpdatedBlockTip(const CBlockIndex *pindexNew, bool fInitia
         // Reached best header while being in initial mode.
         // We must be at the tip already, let's move to the next asset.
         SwitchToNextAsset(connman);
-
-        // Process all pending MNAUTH messages we were unable to process before
-        LOCK(cs_main);
-        g_connman->ForEachNode([](CNode *pnode) {
-            uint256 verifiedProRegTxHash;
-            CMNAuth *pendingMNVerification;
-            {
-                LOCK(pnode->cs_mnauth);
-                verifiedProRegTxHash = pnode->verifiedProRegTxHash;
-                pendingMNVerification = pnode->pendingMNVerification;
-                pnode->pendingMNVerification = nullptr;
-            }
-
-            if (verifiedProRegTxHash.IsNull() && pendingMNVerification) {
-                LogPrint("mnsync", "CMasternodeSync::UpdatedBlockTip -- reverifying znode connection to node id=%d\n", pnode->id);
-                CMNAuth::ProcessMNAUTH(pnode, *pendingMNVerification, *g_connman);
-            }
-
-            delete pendingMNVerification;
-        });
     }
 }
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -28,7 +28,6 @@
 
 #include "masternode-sync.h"
 #include "llmq/quorums_instantsend.h"
-#include "evo/mnauth.h"
 
 #ifdef WIN32
 #include <string.h>
@@ -3540,7 +3539,6 @@ CNode::CNode(NodeId idIn, ServiceFlags nLocalServicesIn, int nMyStartingHeightIn
     fPauseRecv = false;
     fPauseSend = false;
     nProcessQueueSize = 0;
-    pendingMNVerification = nullptr;
 
     BOOST_FOREACH(const std::string &msg, getAllNetMessageTypes())
         mapRecvBytesPerMsgCmd[msg] = 0;
@@ -3558,9 +3556,6 @@ CNode::~CNode()
 
     if (pfilter)
         delete pfilter;
-
-    if (pendingMNVerification)
-        delete pendingMNVerification;
 }
 
 void CNode::AskFor(const CInv& inv, int64_t doubleRequestDelay)

--- a/src/net.h
+++ b/src/net.h
@@ -56,7 +56,6 @@ class CAddrMan;
 class CScheduler;
 class CNode;
 class CTxMemPool;
-class CMNAuth;
 
 namespace boost {
     class thread_group;
@@ -885,8 +884,6 @@ public:
     uint256 receivedMNAuthChallenge;
     uint256 verifiedProRegTxHash;
     uint256 verifiedPubKeyHash;
-    // pending verification from node
-    CMNAuth *pendingMNVerification;
 
     // If true, we will announce/send him plain recovered sigs (usually true for full nodes)
     std::atomic<bool> fSendRecSigs{false};

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -5,12 +5,15 @@
 // Unit tests for denial-of-service detection/prevention code
 
 #include "chainparams.h"
+#include "evo/mnauth.h"
 #include "keystore.h"
+#include "masternode-sync.h"
 #include "net.h"
 #include "net_processing.h"
 #include "pow.h"
 #include "script/sign.h"
 #include "serialize.h"
+#include "streams.h"
 #include "util.h"
 #include "validation.h"
 
@@ -44,6 +47,25 @@ CService ip(uint32_t i)
 static NodeId id = 0;
 
 BOOST_FIXTURE_TEST_SUITE(DoS_tests, TestingSetup)
+
+BOOST_AUTO_TEST_CASE(DoS_mnauth_ignored_while_unsynced)
+{
+    masternodeSync.Reset();
+    BOOST_REQUIRE(!masternodeSync.IsBlockchainSynced());
+
+    CAddress addr(ip(0xa0b0c001), NODE_NONE);
+    CNode dummyNode(id++, NODE_NETWORK, 0, INVALID_SOCKET, addr, 0, 0, "", true);
+
+    for (int i = 0; i < 2; ++i) {
+        CMNAuth mnauth;
+        CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
+        stream << mnauth;
+        const auto messageSize = stream.size();
+
+        BOOST_CHECK_NO_THROW(CMNAuth::ProcessMessage(&dummyNode, NetMsgType::MNAUTH, stream, *connman));
+        BOOST_CHECK_EQUAL(stream.size(), messageSize);
+    }
+}
 
 BOOST_AUTO_TEST_CASE(DoS_banning)
 {


### PR DESCRIPTION
## PR intention

Prevent unauthenticated peers from causing unbounded heap growth while a node is not blockchain-synced.

Firo deferred each pre-sync `MNAUTH` message in `CNode::pendingMNVerification`. Every repeated message allocated a new `CMNAuth` and overwrote the raw pointer, so all earlier allocations remained unreachable until process exit.

This restores the relevant [Dash behavior](https://github.com/dashpay/dash/blob/master/src/evo/mnauth.cpp#L51-L63): ignore `MNAUTH` while blockchain synchronization is incomplete, before deserializing or allocating message state.

This is a local P2P processing change. It does not alter the wire format, block or transaction validity, or consensus state, and does not require a hard fork.

## Code changes brief

- Return before `MNAUTH` deserialization when blockchain synchronization is incomplete.
- Remove the deferred raw pointer, its destructor cleanup, and the sync-transition replay path.
- Add a DoS regression test that submits repeated valid-shaped `MNAUTH` payloads while unsynced and verifies that neither payload is consumed.

## Validation

- `git diff --check`
- Confirmed that no `pendingMNVerification` references remain.
- Confirmed that the sync guard precedes `MNAUTH` deserialization.
- The targeted unit test was not run locally because this host does not have the Firo CMake/compiler toolchain. CI is expected to run the registered `DoS_tests` suite.