### PR TITLE
Backport upstream networking and Evo security fixes

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -126,6 +126,7 @@ testScripts = [
     # 'p2p-segwit.py',
     'listtransactions.py',
     # vv Tests less than 60s vv
+    'p2p-block-source.py',
     # 'sendheaders.py',
     # 'importmulti.py',
     # 'mempool_limit.py',

--- a/qa/rpc-tests/p2p-block-source.py
+++ b/qa/rpc-tests/p2p-block-source.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Firo developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from copy import deepcopy
+
+from test_framework.blocktools import create_block, create_coinbase, create_transaction
+from test_framework.mininode import (
+    HeaderAndShortIDs,
+    NetworkThread,
+    NodeConn,
+    SingleNodeConnCB,
+    mininode_lock,
+    msg_block,
+    msg_blocktxn,
+    msg_cmpctblock,
+    msg_ping,
+    wait_until,
+)
+from test_framework.script import CScript, OP_TRUE
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, p2p_port
+
+
+class BlockSourcePeer(SingleNodeConnCB):
+    def __init__(self):
+        super().__init__()
+        self.last_getblocktxn = None
+        self.peer_disconnected = False
+
+    def on_getblocktxn(self, conn, message):
+        self.last_getblocktxn = message
+
+    def on_inv(self, conn, message):
+        pass
+
+    def on_close(self, conn):
+        self.peer_disconnected = True
+
+    def wait_for_getblocktxn(self):
+        return wait_until(lambda: self.last_getblocktxn is not None, timeout=10)
+
+    def send_and_sync_or_disconnect(self, message):
+        nonce = self.ping_counter
+        self.send_message(message)
+        self.send_message(msg_ping(nonce=nonce))
+        processed = wait_until(
+            lambda: self.peer_disconnected or self.last_pong.nonce == nonce,
+            timeout=10,
+        )
+        self.ping_counter += 1
+        return processed
+
+
+class BlockSourceTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    @staticmethod
+    def build_block(node, transactions=None):
+        transactions = transactions or []
+        height = node.getblockcount() + 1
+        tip = node.getbestblockhash()
+        block_time = node.getblockheader(tip)["mediantime"] + 1
+        block = create_block(int(tip, 16), create_coinbase(height), block_time)
+        block.nVersion = 4
+        block.vtx.extend(transactions)
+        block.hashMerkleRoot = block.calc_merkle_root()
+        block.rehash()
+        block.solve()
+        return block
+
+    def run_test(self):
+        node = self.nodes[0]
+        honest_peer = BlockSourcePeer()
+        attacker_peer = BlockSourcePeer()
+        delivery_peer = BlockSourcePeer()
+
+        honest_connection = NodeConn(
+            "127.0.0.1", p2p_port(0), node, honest_peer
+        )
+        attacker_connection = NodeConn(
+            "127.0.0.1", p2p_port(0), node, attacker_peer
+        )
+        delivery_connection = NodeConn(
+            "127.0.0.1", p2p_port(0), node, delivery_peer
+        )
+        honest_peer.add_connection(honest_connection)
+        attacker_peer.add_connection(attacker_connection)
+        delivery_peer.add_connection(delivery_connection)
+
+        NetworkThread().start()
+        honest_peer.wait_for_verack()
+        attacker_peer.wait_for_verack()
+        delivery_peer.wait_for_verack()
+
+        mature_block = self.build_block(node)
+        honest_peer.send_and_ping(msg_block(mature_block))
+        assert_equal(int(node.getbestblockhash(), 16), mature_block.sha256)
+        node.generate(100)
+
+        spend_value = mature_block.vtx[0].vout[0].nValue
+        first_spend = create_transaction(
+            mature_block.vtx[0],
+            0,
+            b"",
+            spend_value - 1000,
+            CScript([OP_TRUE]),
+        )
+        second_spend = create_transaction(
+            first_spend,
+            0,
+            b"",
+            first_spend.vout[0].nValue - 1000,
+            CScript([OP_TRUE]),
+        )
+        valid_block = self.build_block(node, [first_spend, second_spend])
+        previous_tip = int(node.getbestblockhash(), 16)
+
+        # Leave a compact reconstruction owned by the honest peer.
+        compact_block = HeaderAndShortIDs()
+        compact_block.initialize_from_block(valid_block)
+        honest_peer.send_and_ping(msg_cmpctblock(compact_block.to_p2p()))
+        assert honest_peer.wait_for_getblocktxn()
+
+        with mininode_lock:
+            request = honest_peer.last_getblocktxn.block_txn_request
+            assert_equal(request.blockhash, valid_block.sha256)
+            requested_indexes = request.to_absolute()
+        assert_equal(requested_indexes, [1, 2])
+
+        # Duplicating the odd Merkle tree's final leaf preserves the header.
+        mutated_block = deepcopy(valid_block)
+        mutated_block.vtx.append(deepcopy(mutated_block.vtx[-1]))
+        assert_equal(mutated_block.calc_merkle_root(), valid_block.hashMerkleRoot)
+        mutated_block.rehash()
+        assert_equal(mutated_block.sha256, valid_block.sha256)
+
+        assert attacker_peer.send_and_sync_or_disconnect(msg_block(mutated_block))
+        assert_equal(int(node.getbestblockhash(), 16), previous_tip)
+        assert honest_peer.sync_with_ping(timeout=10)
+
+        response = msg_blocktxn()
+        response.block_transactions.blockhash = valid_block.sha256
+        response.block_transactions.transactions = [
+            valid_block.vtx[index] for index in requested_indexes
+        ]
+        honest_peer.send_and_ping(response)
+        assert_equal(int(node.getbestblockhash(), 16), valid_block.sha256)
+
+        # A valid full block from another peer must clear the residual owner.
+        final_spend = create_transaction(
+            second_spend,
+            0,
+            b"",
+            second_spend.vout[0].nValue - 1000,
+            CScript([OP_TRUE]),
+        )
+        delivered_block = self.build_block(node, [final_spend])
+        with mininode_lock:
+            honest_peer.last_getblocktxn = None
+
+        compact_block = HeaderAndShortIDs()
+        compact_block.initialize_from_block(delivered_block)
+        honest_peer.send_and_ping(msg_cmpctblock(compact_block.to_p2p()))
+        assert honest_peer.wait_for_getblocktxn()
+        with mininode_lock:
+            request = honest_peer.last_getblocktxn.block_txn_request
+            assert_equal(request.blockhash, delivered_block.sha256)
+            assert_equal(request.to_absolute(), [1])
+
+        delivery_peer.send_and_ping(msg_block(delivered_block))
+        assert_equal(int(node.getbestblockhash(), 16), delivered_block.sha256)
+
+        late_response = msg_blocktxn()
+        late_response.block_transactions.blockhash = delivered_block.sha256
+        honest_peer.send_and_ping(late_response)
+        assert not honest_peer.peer_disconnected
+
+
+if __name__ == "__main__":
+    BlockSourceTest().main()

--- a/qa/rpc-tests/p2p-block-source.py
+++ b/qa/rpc-tests/p2p-block-source.py
@@ -7,6 +7,7 @@ from copy import deepcopy
 
 from test_framework.blocktools import create_block, create_coinbase, create_transaction
 from test_framework.mininode import (
+    CTxInWitness,
     HeaderAndShortIDs,
     NetworkThread,
     NodeConn,
@@ -16,6 +17,7 @@ from test_framework.mininode import (
     msg_blocktxn,
     msg_cmpctblock,
     msg_ping,
+    msg_witness_block,
     wait_until,
 )
 from test_framework.script import CScript, OP_TRUE
@@ -132,14 +134,23 @@ class BlockSourceTest(BitcoinTestFramework):
             requested_indexes = request.to_absolute()
         assert_equal(requested_indexes, [1, 2])
 
-        # Duplicating the odd Merkle tree's final leaf preserves the header.
+        # Adding non-committed witness data preserves the header.
         mutated_block = deepcopy(valid_block)
-        mutated_block.vtx.append(deepcopy(mutated_block.vtx[-1]))
+        mutated_tx = mutated_block.vtx[-1]
+        original_txid = mutated_tx.sha256
+        original_wtxid = mutated_tx.calc_sha256(with_witness=True)
+        mutated_tx.wit.vtxinwit = [CTxInWitness() for _ in mutated_tx.vin]
+        mutated_tx.wit.vtxinwit[0].scriptWitness.stack = [b"\x01"]
+        mutated_tx.rehash()
+        assert_equal(mutated_tx.sha256, original_txid)
+        assert mutated_tx.calc_sha256(with_witness=True) != original_wtxid
         assert_equal(mutated_block.calc_merkle_root(), valid_block.hashMerkleRoot)
         mutated_block.rehash()
         assert_equal(mutated_block.sha256, valid_block.sha256)
 
-        assert attacker_peer.send_and_sync_or_disconnect(msg_block(mutated_block))
+        assert attacker_peer.send_and_sync_or_disconnect(
+            msg_witness_block(mutated_block)
+        )
         assert_equal(int(node.getbestblockhash(), 16), previous_tip)
         assert honest_peer.sync_with_ping(timeout=10)
 

--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -67,22 +67,22 @@ double CAddrInfo::GetChance(int64_t nNow) const
     return fChance;
 }
 
-CAddrInfo* CAddrMan::Find(const CNetAddr& addr, int* pnId)
+CAddrInfo* CAddrMan::Find(const CNetAddr& addr, nid_type* pnId)
 {
-    std::map<CNetAddr, int>::iterator it = mapAddr.find(addr);
+    std::map<CNetAddr, nid_type>::iterator it = mapAddr.find(addr);
     if (it == mapAddr.end())
         return NULL;
     if (pnId)
         *pnId = (*it).second;
-    std::map<int, CAddrInfo>::iterator it2 = mapInfo.find((*it).second);
+    std::map<nid_type, CAddrInfo>::iterator it2 = mapInfo.find((*it).second);
     if (it2 != mapInfo.end())
         return &(*it2).second;
     return NULL;
 }
 
-CAddrInfo* CAddrMan::Create(const CAddress& addr, const CNetAddr& addrSource, int* pnId)
+CAddrInfo* CAddrMan::Create(const CAddress& addr, const CNetAddr& addrSource, nid_type* pnId)
 {
-    int nId = nIdCount++;
+    nid_type nId = nIdCount++;
     mapInfo[nId] = CAddrInfo(addr, addrSource);
     mapAddr[addr] = nId;
     mapInfo[nId].nRandomPos = vRandom.size();
@@ -99,8 +99,8 @@ void CAddrMan::SwapRandom(unsigned int nRndPos1, unsigned int nRndPos2)
 
     assert(nRndPos1 < vRandom.size() && nRndPos2 < vRandom.size());
 
-    int nId1 = vRandom[nRndPos1];
-    int nId2 = vRandom[nRndPos2];
+    nid_type nId1 = vRandom[nRndPos1];
+    nid_type nId2 = vRandom[nRndPos2];
 
     assert(mapInfo.count(nId1) == 1);
     assert(mapInfo.count(nId2) == 1);
@@ -112,7 +112,7 @@ void CAddrMan::SwapRandom(unsigned int nRndPos1, unsigned int nRndPos2)
     vRandom[nRndPos2] = nId1;
 }
 
-void CAddrMan::Delete(int nId)
+void CAddrMan::Delete(nid_type nId)
 {
     assert(mapInfo.count(nId) != 0);
     CAddrInfo& info = mapInfo[nId];
@@ -130,7 +130,7 @@ void CAddrMan::ClearNew(int nUBucket, int nUBucketPos)
 {
     // if there is an entry in the specified bucket, delete it.
     if (vvNew[nUBucket][nUBucketPos] != -1) {
-        int nIdDelete = vvNew[nUBucket][nUBucketPos];
+        nid_type nIdDelete = vvNew[nUBucket][nUBucketPos];
         CAddrInfo& infoDelete = mapInfo[nIdDelete];
         assert(infoDelete.nRefCount > 0);
         infoDelete.nRefCount--;
@@ -141,7 +141,7 @@ void CAddrMan::ClearNew(int nUBucket, int nUBucketPos)
     }
 }
 
-void CAddrMan::MakeTried(CAddrInfo& info, int nId)
+void CAddrMan::MakeTried(CAddrInfo& info, nid_type nId)
 {
     // remove the entry from all new buckets
     for (int bucket = 0; bucket < ADDRMAN_NEW_BUCKET_COUNT; bucket++) {
@@ -162,7 +162,7 @@ void CAddrMan::MakeTried(CAddrInfo& info, int nId)
     // first make space to add it (the existing tried entry there is moved to new, deleting whatever is there).
     if (vvTried[nKBucket][nKBucketPos] != -1) {
         // find an item to evict
-        int nIdEvict = vvTried[nKBucket][nKBucketPos];
+        nid_type nIdEvict = vvTried[nKBucket][nKBucketPos];
         assert(mapInfo.count(nIdEvict) == 1);
         CAddrInfo& infoOld = mapInfo[nIdEvict];
 
@@ -191,7 +191,7 @@ void CAddrMan::MakeTried(CAddrInfo& info, int nId)
 
 void CAddrMan::Good_(const CService& addr, int64_t nTime)
 {
-    int nId;
+    nid_type nId;
 
     nLastGood = nTime;
 
@@ -247,7 +247,7 @@ bool CAddrMan::Add_(const CAddress& addr, const CNetAddr& source, int64_t nTimeP
         return false;
 
     bool fNew = false;
-    int nId;
+    nid_type nId;
     CAddrInfo* pinfo = Find(addr, &nId);
 
     // Do not set a penalty for a source's self-announcement
@@ -356,7 +356,7 @@ CAddrInfo CAddrMan::Select_(bool newOnly)
                 nKBucket = (nKBucket + insecure_rand.randbits(ADDRMAN_TRIED_BUCKET_COUNT_LOG2)) % ADDRMAN_TRIED_BUCKET_COUNT;
                 nKBucketPos = (nKBucketPos + insecure_rand.randbits(ADDRMAN_BUCKET_SIZE_LOG2)) % ADDRMAN_BUCKET_SIZE;
             }
-            int nId = vvTried[nKBucket][nKBucketPos];
+            nid_type nId = vvTried[nKBucket][nKBucketPos];
             assert(mapInfo.count(nId) == 1);
             CAddrInfo& info = mapInfo[nId];
             if (RandomInt(1 << 30) < fChanceFactor * info.GetChance() * (1 << 30))
@@ -373,7 +373,7 @@ CAddrInfo CAddrMan::Select_(bool newOnly)
                 nUBucket = (nUBucket + insecure_rand.randbits(ADDRMAN_NEW_BUCKET_COUNT_LOG2)) % ADDRMAN_NEW_BUCKET_COUNT;
                 nUBucketPos = (nUBucketPos + insecure_rand.randbits(ADDRMAN_BUCKET_SIZE_LOG2)) % ADDRMAN_BUCKET_SIZE;
             }
-            int nId = vvNew[nUBucket][nUBucketPos];
+            nid_type nId = vvNew[nUBucket][nUBucketPos];
             assert(mapInfo.count(nId) == 1);
             CAddrInfo& info = mapInfo[nId];
             if (RandomInt(1 << 30) < fChanceFactor * info.GetChance() * (1 << 30))
@@ -386,14 +386,14 @@ CAddrInfo CAddrMan::Select_(bool newOnly)
 #ifdef DEBUG_ADDRMAN
 int CAddrMan::Check_()
 {
-    std::set<int> setTried;
-    std::map<int, int> mapNew;
+    std::set<nid_type> setTried;
+    std::map<nid_type, int> mapNew;
 
     if (vRandom.size() != nTried + nNew)
         return -7;
 
-    for (std::map<int, CAddrInfo>::iterator it = mapInfo.begin(); it != mapInfo.end(); it++) {
-        int n = (*it).first;
+    for (std::map<nid_type, CAddrInfo>::iterator it = mapInfo.begin(); it != mapInfo.end(); it++) {
+        nid_type n = (*it).first;
         CAddrInfo& info = (*it).second;
         if (info.fInTried) {
             if (!info.nLastSuccess)

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -555,6 +555,8 @@ public:
 
     void Clear()
     {
+        mapInfo.clear();
+        mapAddr.clear();
         std::vector<nid_type>().swap(vRandom);
         nKey = GetRandHash();
         for (size_t bucket = 0; bucket < ADDRMAN_NEW_BUCKET_COUNT; bucket++) {

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -179,38 +179,47 @@ public:
 #define ADDRMAN_NEW_BUCKET_COUNT (1 << ADDRMAN_NEW_BUCKET_COUNT_LOG2)
 #define ADDRMAN_BUCKET_SIZE (1 << ADDRMAN_BUCKET_SIZE_LOG2)
 
+/**
+ * User-defined type for the internally used nIds.
+ * This used to be int, making it possible for attackers to cause an overflow.
+ * See https://bitcoincore.org/en/2024/07/31/disclose-addrman-int-overflow/.
+ */
+using nid_type = int64_t;
+
 /** 
  * Stochastical (IP) address manager 
  */
 class CAddrMan
 {
 private:
+    friend class CAddrManTest;
+
     //! critical section to protect the inner data structures
     mutable CCriticalSection cs;
 
     //! last used nId
-    int nIdCount;
+    nid_type nIdCount;
 
     //! table with information about all nIds
-    std::map<int, CAddrInfo> mapInfo;
+    std::map<nid_type, CAddrInfo> mapInfo;
 
     //! find an nId based on its network address
-    std::map<CNetAddr, int> mapAddr;
+    std::map<CNetAddr, nid_type> mapAddr;
 
     //! randomly-ordered vector of all nIds
-    std::vector<int> vRandom;
+    std::vector<nid_type> vRandom;
 
     // number of "tried" entries
     int nTried;
 
     //! list of "tried" buckets
-    int vvTried[ADDRMAN_TRIED_BUCKET_COUNT][ADDRMAN_BUCKET_SIZE];
+    nid_type vvTried[ADDRMAN_TRIED_BUCKET_COUNT][ADDRMAN_BUCKET_SIZE];
 
     //! number of (unique) "new" entries
     int nNew;
 
     //! list of "new" buckets
-    int vvNew[ADDRMAN_NEW_BUCKET_COUNT][ADDRMAN_BUCKET_SIZE];
+    nid_type vvNew[ADDRMAN_NEW_BUCKET_COUNT][ADDRMAN_BUCKET_SIZE];
 
     //! last time Good was called (memory only)
     int64_t nLastGood;
@@ -235,20 +244,20 @@ protected:
     FastRandomContext insecure_rand;
 
     //! Find an entry.
-    CAddrInfo* Find(const CNetAddr& addr, int *pnId = NULL);
+    CAddrInfo* Find(const CNetAddr& addr, nid_type* pnId = NULL);
 
     //! find an entry, creating it if necessary.
     //! nTime and nServices of the found node are updated, if necessary.
-    CAddrInfo* Create(const CAddress &addr, const CNetAddr &addrSource, int *pnId = NULL);
+    CAddrInfo* Create(const CAddress& addr, const CNetAddr& addrSource, nid_type* pnId = NULL);
 
     //! Swap two elements in vRandom.
     void SwapRandom(unsigned int nRandomPos1, unsigned int nRandomPos2);
 
     //! Move an entry from the "new" table(s) to the "tried" table
-    void MakeTried(CAddrInfo& info, int nId);
+    void MakeTried(CAddrInfo& info, nid_type nId);
 
     //! Delete an entry. It must not be in tried, and have refcount 0.
-    void Delete(int nId);
+    void Delete(nid_type nId);
 
     //! Clear a position in a "new" table. This is the only place where entries are actually deleted.
     void ClearNew(int nUBucket, int nUBucketPos);
@@ -340,9 +349,9 @@ public:
 
         int nUBuckets = ADDRMAN_NEW_BUCKET_COUNT ^ (1 << 30);
         s << nUBuckets;
-        std::map<int, int> mapUnkIds;
+        std::map<nid_type, int> mapUnkIds;
         int nIds = 0;
-        for (std::map<int, CAddrInfo>::const_iterator it = mapInfo.begin(); it != mapInfo.end(); it++) {
+        for (std::map<nid_type, CAddrInfo>::const_iterator it = mapInfo.begin(); it != mapInfo.end(); it++) {
             mapUnkIds[(*it).first] = nIds;
             const CAddrInfo &info = (*it).second;
             if (info.nRefCount) {
@@ -352,7 +361,7 @@ public:
             }
         }
         nIds = 0;
-        for (std::map<int, CAddrInfo>::const_iterator it = mapInfo.begin(); it != mapInfo.end(); it++) {
+        for (std::map<nid_type, CAddrInfo>::const_iterator it = mapInfo.begin(); it != mapInfo.end(); it++) {
             const CAddrInfo &info = (*it).second;
             if (info.fInTried) {
                 assert(nIds != nTried); // this means nTried was wrong, oh ow
@@ -528,9 +537,9 @@ public:
 
         // Prune new entries with refcount 0 (as a result of collisions).
         int nLostUnk = 0;
-        for (std::map<int, CAddrInfo>::const_iterator it = mapInfo.begin(); it != mapInfo.end(); ) {
+        for (std::map<nid_type, CAddrInfo>::const_iterator it = mapInfo.begin(); it != mapInfo.end();) {
             if (it->second.fInTried == false && it->second.nRefCount == 0) {
-                std::map<int, CAddrInfo>::const_iterator itCopy = it++;
+                std::map<nid_type, CAddrInfo>::const_iterator itCopy = it++;
                 Delete(itCopy->first);
                 nLostUnk++;
             } else {
@@ -546,7 +555,7 @@ public:
 
     void Clear()
     {
-        std::vector<int>().swap(vRandom);
+        std::vector<nid_type>().swap(vRandom);
         nKey = GetRandHash();
         for (size_t bucket = 0; bucket < ADDRMAN_NEW_BUCKET_COUNT; bucket++) {
             for (size_t entry = 0; entry < ADDRMAN_BUCKET_SIZE; entry++) {

--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -53,7 +53,9 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
     if (cmpctblock.shorttxids.size() + cmpctblock.prefilledtxn.size() > MAX_BLOCK_BASE_SIZE / MIN_TRANSACTION_BASE_SIZE)
         return READ_STATUS_INVALID;
 
-    assert(header.IsNull() && txn_available.empty());
+    if (!header.IsNull() || !txn_available.empty())
+        return READ_STATUS_INVALID;
+
     header = cmpctblock.header;
     txn_available.resize(cmpctblock.BlockTxCount());
 
@@ -170,13 +172,17 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
 }
 
 bool PartiallyDownloadedBlock::IsTxAvailable(size_t index) const {
-    assert(!header.IsNull());
+    if (header.IsNull())
+        return false;
+
     assert(index < txn_available.size());
     return txn_available[index] ? true : false;
 }
 
 ReadStatus PartiallyDownloadedBlock::FillBlock(CBlock& block, const std::vector<CTransactionRef>& vtx_missing) {
-    assert(!header.IsNull());
+    if (header.IsNull())
+        return READ_STATUS_INVALID;
+
     uint256 hash = header.GetHash();
     block = header;
     block.vtx.resize(txn_available.size());

--- a/src/evo/evodb.cpp
+++ b/src/evo/evodb.cpp
@@ -29,11 +29,10 @@ bool CEvoDB::VerifyBestBlock(const uint256& hash)
     // Make sure evodb is consistent.
     // If we already have best block hash saved, the previous block should match it.
     uint256 hashBestBlock;
-    bool fHasBestBlock = Read(EVODB_BEST_BLOCK, hashBestBlock);
-    uint256 hashBlockIndex = fHasBestBlock ? hash : uint256();
-    assert(hashBestBlock == hashBlockIndex);
-
-    return fHasBestBlock;
+    if (!Read(EVODB_BEST_BLOCK, hashBestBlock)) {
+        return false;
+    }
+    return hashBestBlock == hash;
 }
 
 void CEvoDB::WriteBestBlock(const uint256& hash)

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -45,6 +45,7 @@
 #include "llmq/quorums_signing.h"
 #include "llmq/quorums_signing_shares.h"
 
+#include <limits>
 #include <optional>
 
 #include <boost/thread.hpp>
@@ -1418,6 +1419,9 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         bool fRelay = true;
 
         vRecv >> nVersion >> nServiceInt >> nTime >> addrMe;
+        if (nTime < 0) {
+            nTime = 0;
+        }
         nSendVersion = std::min(nVersion, PROTOCOL_VERSION);
         nServices = ServiceFlags(nServiceInt);
         if (!pfrom->fInbound)
@@ -1565,7 +1569,11 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                   pfrom->nStartingHeight, addrMe.ToString(), pfrom->id,
                   remoteAddr);
 
-        int64_t nTimeOffset = nTime - GetTime();
+        const int64_t nNow = GetTime();
+        // Firo permits negative mock time, so saturate the otherwise overflowing difference.
+        const int64_t nTimeOffset = nNow < 0 && nTime > std::numeric_limits<int64_t>::max() + nNow
+            ? std::numeric_limits<int64_t>::max()
+            : nTime - nNow;
         pfrom->nTimeOffset = nTimeOffset;
         AddTimeData(pfrom->addr, nTimeOffset);
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2899,11 +2899,14 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             mapBlockSource.emplace(hash, std::make_pair(pfrom->GetId(), true));
         }
         bool fNewBlock = false;
-        const bool fProcessed = ProcessNewBlock(chainparams, pblock, forceProcessing, &fNewBlock);
-        if (fProcessed && fNewBlock) {
+        ProcessNewBlock(chainparams, pblock, forceProcessing, &fNewBlock);
+        if (fNewBlock) {
             pfrom->nLastBlockTime = GetTime();
             LOCK(cs_main);
             MarkBlockAsReceived(hash, std::nullopt);
+        } else {
+            LOCK(cs_main);
+            mapBlockSource.erase(hash);
         }
     }
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -45,6 +45,8 @@
 #include "llmq/quorums_signing.h"
 #include "llmq/quorums_signing_shares.h"
 
+#include <optional>
+
 #include <boost/thread.hpp>
 
 #if defined(NDEBUG)
@@ -327,11 +329,14 @@ void FinalizeNode(NodeId nodeid, bool& fUpdateConnectionTime) {
 }
 
 // Requires cs_main.
-// Returns a bool indicating whether we requested this block.
 // Also used if a block was /not/ received and timed out or started with another peer
-bool MarkBlockAsReceived(const uint256& hash) {
+void MarkBlockAsReceived(const uint256& hash, std::optional<NodeId> fromPeer)
+{
     std::map<uint256, std::pair<NodeId, std::list<QueuedBlock>::iterator> >::iterator itInFlight = mapBlocksInFlight.find(hash);
     if (itInFlight != mapBlocksInFlight.end()) {
+        if (fromPeer && itInFlight->second.first != *fromPeer)
+            return;
+
         CNodeState *state = State(itInFlight->second.first);
         state->nBlocksInFlightValidHeaders -= itInFlight->second.second->fValidatedHeaders;
         if (state->nBlocksInFlightValidHeaders == 0 && itInFlight->second.second->fValidatedHeaders) {
@@ -346,9 +351,7 @@ bool MarkBlockAsReceived(const uint256& hash) {
         state->nBlocksInFlight--;
         state->nStallingSince = 0;
         mapBlocksInFlight.erase(itInFlight);
-        return true;
     }
-    return false;
 }
 
 // Requires cs_main.
@@ -366,7 +369,7 @@ bool MarkBlockAsInFlight(NodeId nodeid, const uint256& hash, const Consensus::Pa
     }
 
     // Make sure it's not listed somewhere already.
-    MarkBlockAsReceived(hash);
+    MarkBlockAsReceived(hash, std::nullopt);
 
     std::list<QueuedBlock>::iterator it = state->vBlocksInFlight.insert(state->vBlocksInFlight.end(),
             {hash, pindex, pindex != NULL, std::unique_ptr<PartiallyDownloadedBlock>(pit ? new PartiallyDownloadedBlock(&mempool) : NULL)});
@@ -2554,7 +2557,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                 PartiallyDownloadedBlock& partialBlock = *(*queuedBlockIt)->partialBlock;
                 ReadStatus status = partialBlock.InitData(cmpctblock, vExtraTxnForCompact);
                 if (status == READ_STATUS_INVALID) {
-                    MarkBlockAsReceived(pindex->GetBlockHash()); // Reset in-flight state in case of whitelist
+                    MarkBlockAsReceived(pindex->GetBlockHash(), pfrom->GetId()); // Reset in-flight state in case of whitelist
                     Misbehaving(pfrom->GetId(), 100);
                     LogPrintf("Peer %d sent us invalid compact block\n", pfrom->id);
                     return true;
@@ -2642,7 +2645,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                 // process from some other peer.  We do this after calling
                 // ProcessNewBlock so that a malleated cmpctblock announcement
                 // can't be used to interfere with block relay.
-                MarkBlockAsReceived(pblock->GetHash());
+                MarkBlockAsReceived(pblock->GetHash(), std::nullopt);
             }
         }
 
@@ -2668,7 +2671,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             PartiallyDownloadedBlock& partialBlock = *it->second.second->partialBlock;
             ReadStatus status = partialBlock.FillBlock(*pblock, resp.txn);
             if (status == READ_STATUS_INVALID) {
-                MarkBlockAsReceived(resp.blockhash); // Reset in-flight state in case of whitelist
+                MarkBlockAsReceived(resp.blockhash, pfrom->GetId()); // Reset in-flight state in case of whitelist
                 Misbehaving(pfrom->GetId(), 100);
                 LogPrintf("Peer %d sent us invalid compact block/non-matching block transactions\n", pfrom->id);
                 return true;
@@ -2695,7 +2698,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                 // though the block was successfully read, and rely on the
                 // handling in ProcessNewBlock to ensure the block index is
                 // updated, reject messages go out, etc.
-                MarkBlockAsReceived(resp.blockhash); // it is now an empty pointer
+                MarkBlockAsReceived(resp.blockhash, pfrom->GetId()); // it is now an empty pointer
                 fBlockRead = true;
                 // mapBlockSource is only used for sending reject messages and DoS scores,
                 // so the race between here and cs_main in ProcessNewBlock is fine.
@@ -2889,15 +2892,19 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             LOCK(cs_main);
             // Also always process if we requested the block explicitly, as we may
             // need it even though it is not a candidate for a new best tip.
-            forceProcessing |= MarkBlockAsReceived(hash);
+            forceProcessing |= mapBlocksInFlight.count(hash) != 0;
+            MarkBlockAsReceived(hash, pfrom->GetId());
             // mapBlockSource is only used for sending reject messages and DoS scores,
             // so the race between here and cs_main in ProcessNewBlock is fine.
             mapBlockSource.emplace(hash, std::make_pair(pfrom->GetId(), true));
         }
         bool fNewBlock = false;
-        ProcessNewBlock(chainparams, pblock, forceProcessing, &fNewBlock);
-        if (fNewBlock)
+        const bool fProcessed = ProcessNewBlock(chainparams, pblock, forceProcessing, &fNewBlock);
+        if (fProcessed && fNewBlock) {
             pfrom->nLastBlockTime = GetTime();
+            LOCK(cs_main);
+            MarkBlockAsReceived(hash, std::nullopt);
+        }
     }
 
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1884,6 +1884,8 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         uint32_t nFetchFlags = GetFetchFlags(pfrom, chainActive.Tip(), chainparams.GetConsensus());
 
         std::vector<CInv> vToFetch;
+        uint256 hashBestBlock;
+        bool fRequestHeaders = false;
 
         for (unsigned int nInv = 0; nInv < vInv.size(); nInv++)
         {
@@ -1902,13 +1904,12 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             if (inv.type == MSG_BLOCK) {
                 UpdateBlockAvailability(pfrom->GetId(), inv.hash);
                 if (!fAlreadyHave && !fImporting && !fReindex && !mapBlocksInFlight.count(inv.hash)) {
-                    // We used to request the full block here, but since headers-announcements are now the
-                    // primary method of announcement on the network, and since, in the case that a node
-                    // fell back to inv we probably have a reorg which we should get the headers for first,
-                    // we now only provide a getheaders response here. When we receive the headers, we will
-                    // then ask for the blocks we need.
-                    connman.PushMessage(pfrom, msgMaker.Make(NetMsgType::GETHEADERS, chainActive.GetLocator(pindexBestHeader), inv.hash));
-                    LogPrint("net", "getheaders (%d) %s to peer=%d\n", pindexBestHeader->nHeight, inv.hash.ToString(), pfrom->id);
+                    // Headers-first is the primary method of announcement on the network. If a node fell
+                    // back to sending blocks by inv, it is probably for a reorg. The final block hash
+                    // provided should be the highest, so ask for headers once and then fetch the blocks
+                    // needed to catch up.
+                    hashBestBlock = inv.hash;
+                    fRequestHeaders = true;
                 }
             }
 
@@ -1954,6 +1955,11 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                     pfrom->AskFor(inv, doubleRequestDelay);
                 }
             }
+        }
+
+        if (fRequestHeaders) {
+            connman.PushMessage(pfrom, msgMaker.Make(NetMsgType::GETHEADERS, chainActive.GetLocator(pindexBestHeader), hashBestBlock));
+            LogPrint("net", "getheaders (%d) %s to peer=%d\n", pindexBestHeader->nHeight, hashBestBlock.ToString(), pfrom->id);
         }
 
         if (!vToFetch.empty())

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3330,6 +3330,11 @@ public:
     }
 };
 
+size_t GetInventoryBroadcastMax(size_t inventorySize)
+{
+    return std::min<size_t>(1000, INVENTORY_BROADCAST_MAX + (inventorySize / 1000) * 5);
+}
+
 bool SendMessages(CNode* pto, CConnman& connman, const std::atomic<bool>& interruptMsgProc)
 {
     const Consensus::Params& consensusParams = Params().GetConsensus();
@@ -3711,8 +3716,9 @@ bool SendMessages(CNode* pto, CConnman& connman, const std::atomic<bool>& interr
                 // No reason to drain out at many times the network's capacity,
                 // especially since we have many peers and some will draw much shorter delays.
                 unsigned int nRelayedTransactions = 0;
+                const size_t broadcastMax = GetInventoryBroadcastMax(pto->setInventoryTxToSend.size());
                 LOCK(pto->cs_filter);
-                while (!vInvTx.empty() && nRelayedTransactions < INVENTORY_BROADCAST_MAX) {
+                while (!vInvTx.empty() && nRelayedTransactions < broadcastMax) {
                     // Fetch the top element from the heap
                     std::pop_heap(vInvTx.begin(), vInvTx.end(), compareInvMempoolOrder);
                     std::set<uint256>::iterator it = vInvTx.back();

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -62,6 +62,9 @@ void Misbehaving(NodeId nodeid, int howmuch);
 
 bool IsBanned(NodeId nodeid);
 
+/** Return the maximum number of live transaction announcements for one trickle cycle. */
+size_t GetInventoryBroadcastMax(size_t inventorySize);
+
 /** Process protocol messages received from a given node */
 bool ProcessMessages(CNode* pfrom, CConnman& connman, const std::atomic<bool>& interrupt);
 /**

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -223,7 +223,7 @@ struct timeval MillisToTimeval(int64_t nTimeout)
  *
  * @note This function requires that hSocket is in non-blocking mode.
  */
-bool static InterruptibleRecv(char* data, size_t len, int timeout, SOCKET& hSocket)
+bool static InterruptibleRecv(uint8_t* data, size_t len, int timeout, SOCKET& hSocket)
 {
     int64_t curTime = GetTimeMillis();
     int64_t endTime = curTime + timeout;
@@ -231,7 +231,7 @@ bool static InterruptibleRecv(char* data, size_t len, int timeout, SOCKET& hSock
     // to break off in case of an interruption.
     const int64_t maxWait = 1000;
     while (len > 0 && curTime < endTime) {
-        ssize_t ret = recv(hSocket, data, len, 0); // Optimistically try the recv first
+        ssize_t ret = recv(hSocket, reinterpret_cast<char*>(data), len, 0); // Optimistically try the recv first
         if (ret > 0) {
             len -= ret;
             data += ret;
@@ -284,7 +284,7 @@ std::string Socks5ErrorString(int err)
 }
 
 /** Connect using SOCKS5 (as described in RFC1928) */
-static bool Socks5(const std::string& strDest, int port, const ProxyCredentials *auth, SOCKET& hSocket)
+bool Socks5(const std::string& strDest, int port, const ProxyCredentials* auth, SOCKET& hSocket)
 {
     LogPrint("net", "SOCKS5 connecting %s\n", strDest);
     if (strDest.size() > 255) {
@@ -307,7 +307,7 @@ static bool Socks5(const std::string& strDest, int port, const ProxyCredentials 
         CloseSocket(hSocket);
         return error("Error sending to proxy");
     }
-    char pchRet1[2];
+    uint8_t pchRet1[2];
     if (!InterruptibleRecv(pchRet1, 2, SOCKS5_RECV_TIMEOUT, hSocket)) {
         CloseSocket(hSocket);
         LogPrintf("Socks5() connect to %s:%d failed: InterruptibleRecv() timeout or other failure\n", strDest, port);
@@ -333,7 +333,7 @@ static bool Socks5(const std::string& strDest, int port, const ProxyCredentials 
             return error("Error sending authentication to proxy");
         }
         LogPrint("proxy", "SOCKS5 sending proxy authentication %s:%s\n", auth->username, auth->password);
-        char pchRetA[2];
+        uint8_t pchRetA[2];
         if (!InterruptibleRecv(pchRetA, 2, SOCKS5_RECV_TIMEOUT, hSocket)) {
             CloseSocket(hSocket);
             return error("Error reading proxy authentication response");
@@ -362,7 +362,7 @@ static bool Socks5(const std::string& strDest, int port, const ProxyCredentials 
         CloseSocket(hSocket);
         return error("Error sending to proxy");
     }
-    char pchRet2[4];
+    uint8_t pchRet2[4];
     if (!InterruptibleRecv(pchRet2, 4, SOCKS5_RECV_TIMEOUT, hSocket)) {
         CloseSocket(hSocket);
         return error("Error reading proxy response");
@@ -381,7 +381,7 @@ static bool Socks5(const std::string& strDest, int port, const ProxyCredentials 
         CloseSocket(hSocket);
         return error("Error: malformed proxy response");
     }
-    char pchRet3[256];
+    uint8_t pchRet3[256];
     switch (pchRet2[3])
     {
         case 0x01: ret = InterruptibleRecv(pchRet3, 4, SOCKS5_RECV_TIMEOUT, hSocket); break;
@@ -393,7 +393,7 @@ static bool Socks5(const std::string& strDest, int port, const ProxyCredentials 
                 CloseSocket(hSocket);
                 return error("Error reading from proxy");
             }
-            int nRecv = pchRet3[0];
+            const size_t nRecv = pchRet3[0];
             ret = InterruptibleRecv(pchRet3, nRecv, SOCKS5_RECV_TIMEOUT, hSocket);
             break;
         }

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -262,12 +262,6 @@ bool static InterruptibleRecv(uint8_t* data, size_t len, int timeout, SOCKET& hS
     return len == 0;
 }
 
-struct ProxyCredentials
-{
-    std::string username;
-    std::string password;
-};
-
 std::string Socks5ErrorString(int err)
 {
     switch(err) {

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -37,6 +37,13 @@ public:
     bool randomize_credentials;
 };
 
+/** Credentials for proxy authentication. */
+struct ProxyCredentials
+{
+    std::string username;
+    std::string password;
+};
+
 enum Network ParseNetwork(std::string net);
 std::string GetNetworkName(enum Network net);
 void SplitHostPort(std::string in, int &portOut, std::string &hostOut);
@@ -53,6 +60,7 @@ CService LookupNumeric(const char *pszName, int portDefault = 0);
 bool LookupSubNet(const char *pszName, CSubNet& subnet);
 bool ConnectSocket(const CService &addr, SOCKET& hSocketRet, int nTimeout, bool *outProxyConnectionFailed = 0);
 bool ConnectSocketByName(CService &addr, SOCKET& hSocketRet, const char *pszDest, int portDefault, int nTimeout, bool *outProxyConnectionFailed = 0);
+bool Socks5(const std::string& strDest, int port, const ProxyCredentials* auth, SOCKET& hSocket);
 /** Return readable error string for a network error code */
 std::string NetworkErrorString(int err);
 /** Close socket and set hSocket to INVALID_SOCKET */

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -4,10 +4,13 @@
 
 // Unit tests for denial-of-service detection/prevention code
 
+#include "arith_uint256.h"
 #include "chainparams.h"
+#include "hash.h"
 #include "keystore.h"
 #include "net.h"
 #include "net_processing.h"
+#include "netmessagemaker.h"
 #include "pow.h"
 #include "script/sign.h"
 #include "serialize.h"
@@ -213,6 +216,120 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
     BOOST_CHECK(mapOrphanTransactions.size() <= 10);
     LimitOrphanTxSize(0);
     BOOST_CHECK(mapOrphanTransactions.empty());
+}
+
+BOOST_AUTO_TEST_CASE(inv_getheaders_coalesced)
+{
+    std::atomic<bool> interruptDummy(false);
+    PeerLogicValidation peerLogic(connman);
+
+    CAddress addr(ip(0xa0b0c003), NODE_NONE);
+    CNode dummyNode(id++, NODE_NETWORK, 0, INVALID_SOCKET, addr, 0, 0, "", true);
+    dummyNode.SetSendVersion(PROTOCOL_VERSION);
+    dummyNode.SetRecvVersion(PROTOCOL_VERSION);
+    dummyNode.nVersion = PROTOCOL_VERSION;
+    dummyNode.fSuccessfullyConnected = true;
+    GetNodeSignals().InitializeNode(&dummyNode, *connman);
+
+    struct NodeStateCleanup {
+        explicit NodeStateCleanup(NodeId nodeId) : nodeId(nodeId) {}
+
+        ~NodeStateCleanup()
+        {
+            bool updateConnectionTime = false;
+            GetNodeSignals().FinalizeNode(nodeId, updateConnectionTime);
+        }
+
+        NodeId nodeId;
+    } nodeStateCleanup(dummyNode.GetId());
+
+    const uint256 firstBlock = uint256S("01");
+    const uint256 secondBlock = uint256S("02");
+    const uint256 txHash = uint256S("04");
+    const uint256 dandelionTxHash = uint256S("05");
+    std::vector<CInv> inventory{
+        CInv(MSG_BLOCK, firstBlock),
+        CInv(MSG_TX, txHash),
+        CInv(MSG_BLOCK, secondBlock),
+        CInv(MSG_DANDELION_TX, dandelionTxHash),
+    };
+    inventory.reserve(MAX_INV_SZ);
+
+    uint256 finalBlock;
+    for (uint32_t value = 100; inventory.size() < MAX_INV_SZ - 1; ++value) {
+        finalBlock = ArithToUint256(value);
+        inventory.emplace_back(MSG_BLOCK, finalBlock);
+    }
+    inventory.emplace_back(MSG_BLOCK, Params().GenesisBlock().GetHash());
+    BOOST_REQUIRE_EQUAL(inventory.size(), MAX_INV_SZ);
+
+    CDataStream payload(SER_NETWORK, PROTOCOL_VERSION);
+    payload << inventory;
+    CMessageHeader header(Params().MessageStart(), NetMsgType::INV, payload.size());
+    const uint256 payloadHash = Hash(payload.begin(), payload.end());
+    memcpy(header.pchChecksum, payloadHash.begin(), CMessageHeader::CHECKSUM_SIZE);
+
+    CDataStream serializedHeader(SER_NETWORK, PROTOCOL_VERSION);
+    serializedHeader << header;
+    {
+        LOCK(dummyNode.cs_vProcessMsg);
+        dummyNode.vProcessMsg.emplace_back(Params().MessageStart(), SER_NETWORK, PROTOCOL_VERSION);
+        CNetMessage& message = dummyNode.vProcessMsg.back();
+        BOOST_REQUIRE_EQUAL(
+            static_cast<size_t>(message.readHeader(serializedHeader.data(), serializedHeader.size())),
+            serializedHeader.size());
+        BOOST_REQUIRE_EQUAL(
+            static_cast<size_t>(message.readData(payload.data(), payload.size())),
+            payload.size());
+        message.nTime = GetTimeMicros();
+        dummyNode.nProcessQueueSize += payload.size() + CMessageHeader::HEADER_SIZE;
+    }
+
+    BOOST_CHECK(!ProcessMessages(&dummyNode, *connman, interruptDummy));
+    BOOST_CHECK(!dummyNode.fDisconnect);
+    BOOST_CHECK(dummyNode.vProcessMsg.empty());
+
+    const CSerializedNetMsg expected = CNetMsgMaker(PROTOCOL_VERSION).Make(NetMsgType::GETHEADERS, chainActive.GetLocator(pindexBestHeader), finalBlock);
+    const size_t expectedQueuedBytes = CMessageHeader::HEADER_SIZE + expected.data.size();
+    const size_t vulnerableQueuedBytes = (MAX_INV_SZ - 3) * expectedQueuedBytes;
+    BOOST_CHECK_LT(expectedQueuedBytes, DEFAULT_MAXSENDBUFFER * 1000);
+    BOOST_CHECK_GT(vulnerableQueuedBytes, DEFAULT_MAXSENDBUFFER * 1000);
+
+    CNodeStats stats;
+    dummyNode.copyStats(stats);
+    const auto getHeadersBytes = stats.mapSendBytesPerMsgCmd.find(NetMsgType::GETHEADERS);
+    BOOST_REQUIRE(getHeadersBytes != stats.mapSendBytesPerMsgCmd.end());
+    BOOST_CHECK_EQUAL(getHeadersBytes->second, expectedQueuedBytes);
+
+    {
+        LOCK(dummyNode.cs_vSend);
+        BOOST_CHECK_EQUAL(dummyNode.nSendSize, expectedQueuedBytes);
+        BOOST_CHECK_EQUAL(dummyNode.vSendMsg.size(), 2U);
+        BOOST_REQUIRE_GE(dummyNode.vSendMsg.size(), 2U);
+
+        CDataStream sentHeader(
+            dummyNode.vSendMsg[dummyNode.vSendMsg.size() - 2],
+            SER_NETWORK,
+            PROTOCOL_VERSION);
+        CMessageHeader parsedHeader(Params().MessageStart());
+        sentHeader >> parsedHeader;
+        BOOST_CHECK_EQUAL(parsedHeader.GetCommand(), NetMsgType::GETHEADERS);
+        BOOST_CHECK_EQUAL(parsedHeader.nMessageSize, expected.data.size());
+
+        CDataStream sentPayload(dummyNode.vSendMsg.back(), SER_NETWORK, PROTOCOL_VERSION);
+        CBlockLocator locator;
+        uint256 stopHash;
+        sentPayload >> locator >> stopHash;
+        BOOST_CHECK(!locator.IsNull());
+        BOOST_CHECK(stopHash == finalBlock);
+        BOOST_CHECK(sentPayload.empty());
+    }
+
+    {
+        LOCK(dummyNode.cs_inventory);
+        BOOST_CHECK(dummyNode.filterInventoryKnown.contains(txHash));
+        BOOST_CHECK(dummyNode.filterDandelionInventoryKnown.contains(dandelionTxHash));
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -5,6 +5,7 @@
 // Unit tests for denial-of-service detection/prevention code
 
 #include "arith_uint256.h"
+#include "blockencodings.h"
 #include "chainparams.h"
 #include "hash.h"
 #include "keystore.h"
@@ -45,6 +46,36 @@ CService ip(uint32_t i)
 }
 
 static NodeId id = 0;
+
+struct BlockTxnTestingSetup : public TestChain100Setup {
+    BlockTxnTestingSetup() : TestChain100Setup(1) {}
+};
+
+template <typename Payload>
+static void QueueNetMessage(CNode& node, const char* command, const Payload& value)
+{
+    CDataStream payload(SER_NETWORK, PROTOCOL_VERSION);
+    payload << value;
+
+    CMessageHeader header(Params().MessageStart(), command, payload.size());
+    const uint256 payloadHash = Hash(payload.begin(), payload.end());
+    memcpy(header.pchChecksum, payloadHash.begin(), CMessageHeader::CHECKSUM_SIZE);
+
+    CDataStream serializedHeader(SER_NETWORK, PROTOCOL_VERSION);
+    serializedHeader << header;
+
+    LOCK(node.cs_vProcessMsg);
+    node.vProcessMsg.emplace_back(Params().MessageStart(), SER_NETWORK, PROTOCOL_VERSION);
+    CNetMessage& message = node.vProcessMsg.back();
+    BOOST_REQUIRE_EQUAL(
+        static_cast<size_t>(message.readHeader(serializedHeader.data(), serializedHeader.size())),
+        serializedHeader.size());
+    BOOST_REQUIRE_EQUAL(
+        static_cast<size_t>(message.readData(payload.data(), payload.size())),
+        payload.size());
+    message.nTime = GetTimeMicros();
+    node.nProcessQueueSize += payload.size() + CMessageHeader::HEADER_SIZE;
+}
 
 BOOST_FIXTURE_TEST_SUITE(DoS_tests, TestingSetup)
 
@@ -329,6 +360,195 @@ BOOST_AUTO_TEST_CASE(inv_getheaders_coalesced)
         LOCK(dummyNode.cs_inventory);
         BOOST_CHECK(dummyNode.filterInventoryKnown.contains(txHash));
         BOOST_CHECK(dummyNode.filterDandelionInventoryKnown.contains(dandelionTxHash));
+    }
+}
+
+BOOST_FIXTURE_TEST_CASE(blocktxn_repeated_response, BlockTxnTestingSetup)
+{
+    std::atomic<bool> interruptDummy(false);
+    PeerLogicValidation peerLogic(connman);
+
+    CAddress ownerAddress(ip(0xa0b0c004), NODE_NONE);
+    CNode ownerNode(id++, NODE_NETWORK, 0, INVALID_SOCKET, ownerAddress, 0, 0, "", true);
+    ownerNode.SetSendVersion(PROTOCOL_VERSION);
+    ownerNode.SetRecvVersion(PROTOCOL_VERSION);
+    ownerNode.nVersion = PROTOCOL_VERSION;
+    ownerNode.fSuccessfullyConnected = true;
+    GetNodeSignals().InitializeNode(&ownerNode, *connman);
+
+    CAddress nonOwnerAddress(ip(0xa0b0c005), NODE_NONE);
+    CNode nonOwnerNode(id++, NODE_NETWORK, 0, INVALID_SOCKET, nonOwnerAddress, 1, 1, "", true);
+    nonOwnerNode.SetSendVersion(PROTOCOL_VERSION);
+    nonOwnerNode.SetRecvVersion(PROTOCOL_VERSION);
+    nonOwnerNode.nVersion = PROTOCOL_VERSION;
+    nonOwnerNode.fSuccessfullyConnected = true;
+    GetNodeSignals().InitializeNode(&nonOwnerNode, *connman);
+
+    struct NodeStateCleanup {
+        NodeStateCleanup(NodeId ownerId, NodeId nonOwnerId) : ownerId(ownerId), nonOwnerId(nonOwnerId) {}
+
+        ~NodeStateCleanup()
+        {
+            bool updateConnectionTime = false;
+            GetNodeSignals().FinalizeNode(nonOwnerId, updateConnectionTime);
+            GetNodeSignals().FinalizeNode(ownerId, updateConnectionTime);
+        }
+
+        NodeId ownerId;
+        NodeId nonOwnerId;
+    } nodeStateCleanup(ownerNode.GetId(), nonOwnerNode.GetId());
+
+    const auto processMessage = [&](CNode& node, bool expectDisconnect = false) {
+        // TestingSetup constructs but does not start connman, leaving its synthetic send limit at zero.
+        node.fPauseSend = false;
+        BOOST_CHECK(!ProcessMessages(&node, *connman, interruptDummy));
+        BOOST_CHECK(node.vProcessMsg.empty());
+        BOOST_CHECK(node.fDisconnect == expectDisconnect);
+    };
+
+    int initialHeight;
+    {
+        LOCK(cs_main);
+        initialHeight = chainActive.Height();
+    }
+
+    CBlock validBlock = CreateBlock({}, coinbaseKey);
+    CBlockHeaderAndShortTxIDs validCompactBlock(validBlock, false);
+    QueueNetMessage(ownerNode, NetMsgType::CMPCTBLOCK, validCompactBlock);
+    processMessage(ownerNode);
+
+    {
+        LOCK(cs_main);
+        BOOST_REQUIRE(chainActive.Tip());
+        BOOST_CHECK_EQUAL(chainActive.Height(), initialHeight + 1);
+        BOOST_CHECK(chainActive.Tip()->GetBlockHash() == validBlock.GetHash());
+    }
+
+    CNodeStateStats ownerState;
+    BOOST_REQUIRE(GetNodeStateStats(ownerNode.GetId(), ownerState));
+    BOOST_CHECK(ownerState.vHeightInFlight.empty());
+    BOOST_CHECK_EQUAL(ownerState.nMisbehavior, 0);
+
+    CMutableTransaction expectedTransaction;
+    expectedTransaction.vin.resize(1);
+    expectedTransaction.vin[0].prevout = COutPoint(GetRandHash(), 0);
+    expectedTransaction.vin[0].scriptSig << OP_1;
+    expectedTransaction.vout.resize(1);
+    expectedTransaction.vout[0].nValue = 1;
+    expectedTransaction.vout[0].scriptPubKey << OP_TRUE;
+
+    CBlock attackBlock = CreateBlock({expectedTransaction}, coinbaseKey);
+    BOOST_REQUIRE_EQUAL(attackBlock.vtx.size(), 2U);
+    CBlockHeaderAndShortTxIDs attackCompactBlock(attackBlock, false);
+    QueueNetMessage(ownerNode, NetMsgType::CMPCTBLOCK, attackCompactBlock);
+    processMessage(ownerNode);
+
+    {
+        LOCK(ownerNode.cs_vSend);
+        BOOST_REQUIRE_GE(ownerNode.vSendMsg.size(), 2U);
+
+        CDataStream sentHeader(
+            ownerNode.vSendMsg[ownerNode.vSendMsg.size() - 2],
+            SER_NETWORK,
+            PROTOCOL_VERSION);
+        CMessageHeader parsedHeader(Params().MessageStart());
+        sentHeader >> parsedHeader;
+        BOOST_CHECK_EQUAL(parsedHeader.GetCommand(), NetMsgType::GETBLOCKTXN);
+
+        CDataStream sentPayload(ownerNode.vSendMsg.back(), SER_NETWORK, PROTOCOL_VERSION);
+        BlockTransactionsRequest request;
+        sentPayload >> request;
+        BOOST_CHECK(request.blockhash == attackBlock.GetHash());
+        BOOST_REQUIRE_EQUAL(request.indexes.size(), 1U);
+        BOOST_CHECK_EQUAL(request.indexes[0], 1U);
+        BOOST_CHECK(sentPayload.empty());
+    }
+
+    ownerState = CNodeStateStats();
+    BOOST_REQUIRE(GetNodeStateStats(ownerNode.GetId(), ownerState));
+    BOOST_REQUIRE_EQUAL(ownerState.vHeightInFlight.size(), 1U);
+    BOOST_CHECK_EQUAL(ownerState.vHeightInFlight[0], initialHeight + 2);
+    BOOST_CHECK_EQUAL(ownerState.nMisbehavior, 0);
+
+    CMutableTransaction wrongTransaction(expectedTransaction);
+    ++wrongTransaction.nLockTime;
+    BlockTransactions mismatchedResponse;
+    mismatchedResponse.blockhash = attackBlock.GetHash();
+    mismatchedResponse.txn.push_back(MakeTransactionRef(wrongTransaction));
+
+    QueueNetMessage(ownerNode, NetMsgType::BLOCKTXN, mismatchedResponse);
+    processMessage(ownerNode);
+
+    {
+        LOCK(ownerNode.cs_vSend);
+        BOOST_REQUIRE_GE(ownerNode.vSendMsg.size(), 2U);
+
+        CDataStream sentHeader(
+            ownerNode.vSendMsg[ownerNode.vSendMsg.size() - 2],
+            SER_NETWORK,
+            PROTOCOL_VERSION);
+        CMessageHeader parsedHeader(Params().MessageStart());
+        sentHeader >> parsedHeader;
+        BOOST_CHECK_EQUAL(parsedHeader.GetCommand(), NetMsgType::GETDATA);
+
+        CDataStream sentPayload(ownerNode.vSendMsg.back(), SER_NETWORK, PROTOCOL_VERSION);
+        std::vector<CInv> requests;
+        sentPayload >> requests;
+        BOOST_REQUIRE_EQUAL(requests.size(), 1U);
+        BOOST_CHECK(requests[0].hash == attackBlock.GetHash());
+        BOOST_CHECK(sentPayload.empty());
+    }
+
+    ownerState = CNodeStateStats();
+    BOOST_REQUIRE(GetNodeStateStats(ownerNode.GetId(), ownerState));
+    BOOST_REQUIRE_EQUAL(ownerState.vHeightInFlight.size(), 1U);
+    BOOST_CHECK_EQUAL(ownerState.vHeightInFlight[0], initialHeight + 2);
+    BOOST_CHECK_EQUAL(ownerState.nMisbehavior, 0);
+
+    QueueNetMessage(nonOwnerNode, NetMsgType::BLOCKTXN, mismatchedResponse);
+    processMessage(nonOwnerNode);
+
+    ownerState = CNodeStateStats();
+    BOOST_REQUIRE(GetNodeStateStats(ownerNode.GetId(), ownerState));
+    BOOST_REQUIRE_EQUAL(ownerState.vHeightInFlight.size(), 1U);
+    BOOST_CHECK_EQUAL(ownerState.vHeightInFlight[0], initialHeight + 2);
+    BOOST_CHECK_EQUAL(ownerState.nMisbehavior, 0);
+
+    CNodeStateStats nonOwnerState;
+    BOOST_REQUIRE(GetNodeStateStats(nonOwnerNode.GetId(), nonOwnerState));
+    BOOST_CHECK(nonOwnerState.vHeightInFlight.empty());
+    BOOST_CHECK_EQUAL(nonOwnerState.nMisbehavior, 0);
+
+    QueueNetMessage(ownerNode, NetMsgType::BLOCKTXN, mismatchedResponse);
+    processMessage(ownerNode, true);
+
+    ownerState = CNodeStateStats();
+    BOOST_REQUIRE(GetNodeStateStats(ownerNode.GetId(), ownerState));
+    BOOST_CHECK(ownerState.vHeightInFlight.empty());
+    BOOST_CHECK_EQUAL(ownerState.nMisbehavior, 100);
+
+    nonOwnerState = CNodeStateStats();
+    BOOST_REQUIRE(GetNodeStateStats(nonOwnerNode.GetId(), nonOwnerState));
+    BOOST_CHECK(nonOwnerState.vHeightInFlight.empty());
+    BOOST_CHECK_EQUAL(nonOwnerState.nMisbehavior, 0);
+
+    QueueNetMessage(nonOwnerNode, NetMsgType::BLOCKTXN, mismatchedResponse);
+    processMessage(nonOwnerNode);
+
+    ownerState = CNodeStateStats();
+    BOOST_REQUIRE(GetNodeStateStats(ownerNode.GetId(), ownerState));
+    BOOST_CHECK(ownerState.vHeightInFlight.empty());
+    BOOST_CHECK_EQUAL(ownerState.nMisbehavior, 100);
+
+    nonOwnerState = CNodeStateStats();
+    BOOST_REQUIRE(GetNodeStateStats(nonOwnerNode.GetId(), nonOwnerState));
+    BOOST_CHECK(nonOwnerState.vHeightInFlight.empty());
+    BOOST_CHECK_EQUAL(nonOwnerState.nMisbehavior, 0);
+
+    {
+        LOCK(cs_main);
+        BOOST_REQUIRE(chainActive.Tip());
+        BOOST_CHECK(chainActive.Tip()->GetBlockHash() == validBlock.GetHash());
     }
 }
 

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -20,6 +20,7 @@
 
 #include "test/test_bitcoin.h"
 
+#include <limits>
 #include <stdint.h>
 
 #include <boost/assign/list_of.hpp> // for 'map_list_of()'
@@ -550,6 +551,190 @@ BOOST_FIXTURE_TEST_CASE(blocktxn_repeated_response, BlockTxnTestingSetup)
         BOOST_REQUIRE(chainActive.Tip());
         BOOST_CHECK(chainActive.Tip()->GetBlockHash() == validBlock.GetHash());
     }
+}
+
+BOOST_AUTO_TEST_CASE(inv_queue_adaptive_drain)
+{
+    std::atomic<bool> interruptDummy(false);
+    PeerLogicValidation peerLogic(connman);
+
+    BOOST_CHECK_EQUAL(GetInventoryBroadcastMax(0), 35U);
+    BOOST_CHECK_EQUAL(GetInventoryBroadcastMax(999), 35U);
+    BOOST_CHECK_EQUAL(GetInventoryBroadcastMax(1000), 40U);
+    BOOST_CHECK_EQUAL(GetInventoryBroadcastMax(2000), 45U);
+    BOOST_CHECK_EQUAL(GetInventoryBroadcastMax(192999), 995U);
+    BOOST_CHECK_EQUAL(GetInventoryBroadcastMax(193000), 1000U);
+    BOOST_CHECK_EQUAL(GetInventoryBroadcastMax(std::numeric_limits<size_t>::max()), 1000U);
+
+    CAddress peerAddress(ip(0xa0b0c006), NODE_NONE);
+    CNode peerNode(id++, NODE_NETWORK, 0, INVALID_SOCKET, peerAddress, 0, 0, "", true);
+    peerNode.SetSendVersion(PROTOCOL_VERSION);
+    peerNode.SetRecvVersion(PROTOCOL_VERSION);
+    peerNode.nVersion = PROTOCOL_VERSION;
+    peerNode.fWhitelisted = true;
+    peerNode.fSuccessfullyConnected = true;
+    {
+        LOCK(peerNode.cs_filter);
+        peerNode.fRelayTxes = true;
+    }
+    GetNodeSignals().InitializeNode(&peerNode, *connman);
+
+    struct NodeStateCleanup {
+        explicit NodeStateCleanup(NodeId nodeId) : nodeId(nodeId) {}
+
+        ~NodeStateCleanup()
+        {
+            bool updateConnectionTime = false;
+            GetNodeSignals().FinalizeNode(nodeId, updateConnectionTime);
+        }
+
+        NodeId nodeId;
+    } nodeStateCleanup(peerNode.GetId());
+
+    BOOST_REQUIRE_EQUAL(mempool.size(), 0U);
+
+    CMutableTransaction parent;
+    parent.vin.resize(1);
+    parent.vin[0].prevout = COutPoint(ArithToUint256(1), 0);
+    parent.vin[0].scriptSig << OP_1;
+    parent.vout.resize(1);
+    parent.vout[0].nValue = 1;
+    parent.vout[0].scriptPubKey << OP_TRUE;
+
+    TestMemPoolEntryHelper parentEntry;
+    const uint256 parentHash = parent.GetHash();
+    BOOST_REQUIRE(mempool.addUnchecked(parentHash, parentEntry.Fee(1000).FromTx(parent)));
+
+    CMutableTransaction child;
+    child.vin.resize(1);
+    child.vin[0].prevout = COutPoint(parentHash, 0);
+    child.vin[0].scriptSig << OP_1;
+    child.vout.resize(1);
+    child.vout[0].nValue = 1;
+    child.vout[0].scriptPubKey << OP_TRUE;
+
+    CTxMemPool::setEntries childAncestors;
+    const auto parentIt = mempool.mapTx.find(parentHash);
+    BOOST_REQUIRE(parentIt != mempool.mapTx.end());
+    childAncestors.insert(parentIt);
+
+    TestMemPoolEntryHelper childEntry;
+    const uint256 childHash = child.GetHash();
+    BOOST_REQUIRE(mempool.addUnchecked(
+        childHash,
+        childEntry.Fee(1000000).FromTx(child, &mempool),
+        childAncestors));
+
+    std::vector<uint256> liveHashes{parentHash, childHash};
+    for (uint32_t tag = 2; liveHashes.size() < 50; ++tag) {
+        CMutableTransaction tx;
+        tx.vin.resize(1);
+        tx.vin[0].prevout = COutPoint(ArithToUint256(1000 + tag), 0);
+        tx.vin[0].scriptSig << OP_1;
+        tx.vout.resize(1);
+        tx.vout[0].nValue = 1;
+        tx.vout[0].scriptPubKey << OP_TRUE;
+        tx.nLockTime = tag;
+
+        TestMemPoolEntryHelper entry;
+        const uint256 hash = tx.GetHash();
+        BOOST_REQUIRE(mempool.addUnchecked(hash, entry.Fee((tag + 1) * 1000).FromTx(tx)));
+        liveHashes.push_back(hash);
+    }
+    BOOST_REQUIRE_EQUAL(mempool.size(), 50U);
+
+    std::vector<uint256> missingHashes;
+    missingHashes.reserve(2000);
+    for (uint32_t value = 100000; missingHashes.size() < 2000; ++value) {
+        const uint256 hash = ArithToUint256(value);
+        if (!mempool.exists(hash))
+            missingHashes.push_back(hash);
+    }
+
+    const uint256& forcedHighFeeHash = liveHashes.back();
+    const uint256& lowFeeHash = liveHashes[2];
+    const uint256& missingHash = missingHashes.front();
+    BOOST_CHECK(mempool.CompareDepthAndScore(missingHash, forcedHighFeeHash));
+    BOOST_CHECK(!mempool.CompareDepthAndScore(forcedHighFeeHash, missingHash));
+    BOOST_CHECK(mempool.CompareDepthAndScore(forcedHighFeeHash, lowFeeHash));
+    BOOST_CHECK(!mempool.CompareDepthAndScore(lowFeeHash, forcedHighFeeHash));
+    BOOST_CHECK(mempool.CompareDepthAndScore(parentHash, childHash));
+    BOOST_CHECK(!mempool.CompareDepthAndScore(childHash, parentHash));
+
+    for (const uint256& hash : missingHashes)
+        peerNode.PushInventory(CInv(MSG_TX, hash));
+    for (size_t i = 0; i + 1 < liveHashes.size(); ++i)
+        peerNode.PushInventory(CInv(MSG_TX, liveHashes[i]));
+
+    const CInv forcedInventory(MSG_TX, forcedHighFeeHash);
+    peerNode.AddInventoryKnown(forcedInventory);
+    peerNode.PushInventory(forcedInventory, true);
+
+    {
+        LOCK(peerNode.cs_inventory);
+        BOOST_REQUIRE_EQUAL(peerNode.setInventoryTxToSend.size(), 2050U);
+        BOOST_REQUIRE_EQUAL(peerNode.setInventoryForcedToSend.size(), 1U);
+    }
+
+    BOOST_CHECK(SendMessages(&peerNode, *connman, interruptDummy));
+
+    size_t invMessageCount = 0;
+    std::vector<CInv> sentInventory;
+    {
+        LOCK(peerNode.cs_vSend);
+        size_t position = 0;
+        while (position < peerNode.vSendMsg.size()) {
+            CDataStream sentHeader(peerNode.vSendMsg[position++], SER_NETWORK, PROTOCOL_VERSION);
+            CMessageHeader parsedHeader(Params().MessageStart());
+            sentHeader >> parsedHeader;
+            BOOST_CHECK(sentHeader.empty());
+
+            if (parsedHeader.nMessageSize == 0)
+                continue;
+
+            BOOST_REQUIRE_LT(position, peerNode.vSendMsg.size());
+            CDataStream sentPayload(peerNode.vSendMsg[position++], SER_NETWORK, PROTOCOL_VERSION);
+            if (parsedHeader.GetCommand() != NetMsgType::INV)
+                continue;
+
+            std::vector<CInv> inventory;
+            sentPayload >> inventory;
+            BOOST_CHECK(sentPayload.empty());
+            sentInventory.insert(sentInventory.end(), inventory.begin(), inventory.end());
+            ++invMessageCount;
+        }
+    }
+
+    BOOST_CHECK_EQUAL(invMessageCount, 1U);
+    BOOST_CHECK_EQUAL(sentInventory.size(), 45U);
+
+    std::set<uint256> sentHashes;
+    for (const CInv& inv : sentInventory) {
+        BOOST_CHECK_EQUAL(inv.type, MSG_TX);
+        sentHashes.insert(inv.hash);
+    }
+    BOOST_CHECK_EQUAL(sentHashes.size(), sentInventory.size());
+    BOOST_CHECK(sentHashes.count(forcedHighFeeHash) == 1);
+    BOOST_CHECK(sentHashes.count(childHash) == 0);
+
+    size_t remainingMissing = 0;
+    bool allRemainingTransactionsAreLive = true;
+    {
+        LOCK(peerNode.cs_inventory);
+        BOOST_CHECK_EQUAL(peerNode.setInventoryTxToSend.size(), 5U);
+        BOOST_CHECK(peerNode.setInventoryForcedToSend.empty());
+        for (const uint256& hash : missingHashes)
+            remainingMissing += peerNode.setInventoryTxToSend.count(hash);
+        for (const uint256& hash : peerNode.setInventoryTxToSend)
+            allRemainingTransactionsAreLive &= mempool.exists(hash);
+    }
+    BOOST_CHECK_EQUAL(remainingMissing, 0U);
+    BOOST_CHECK(allRemainingTransactionsAreLive);
+
+    CNodeStateStats peerState;
+    BOOST_REQUIRE(GetNodeStateStats(peerNode.GetId(), peerState));
+    BOOST_CHECK_EQUAL(peerState.nMisbehavior, 0);
+    BOOST_CHECK(!peerNode.fDisconnect);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -161,6 +161,47 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     BOOST_CHECK(!connman->IsBanned(addr));
 }
 
+BOOST_AUTO_TEST_CASE(version_timestamp_int64_min)
+{
+    std::atomic<bool> interruptDummy(false);
+    PeerLogicValidation peerLogic(connman);
+
+    struct MockTimeReset {
+        ~MockTimeReset() { SetMockTime(0); }
+    } mockTimeReset;
+    SetMockTime(1);
+
+    CAddress peerAddress(ip(0xa0b0c007), NODE_NONE);
+    CNode peerNode(id++, NODE_NETWORK, 0, INVALID_SOCKET, peerAddress, 0, 0, "", true);
+    GetNodeSignals().InitializeNode(&peerNode, *connman);
+
+    struct NodeStateCleanup {
+        explicit NodeStateCleanup(NodeId nodeId) : nodeId(nodeId) {}
+
+        ~NodeStateCleanup()
+        {
+            bool updateConnectionTime = false;
+            GetNodeSignals().FinalizeNode(nodeId, updateConnectionTime);
+        }
+
+        NodeId nodeId;
+    } nodeStateCleanup(peerNode.GetId());
+
+    auto versionMessage = CNetMsgMaker(INIT_PROTO_VERSION).Make(
+        NetMsgType::VERSION,
+        PROTOCOL_VERSION,
+        static_cast<uint64_t>(NODE_NETWORK),
+        std::numeric_limits<int64_t>::min(),
+        CAddress());
+    QueueNetMessage(peerNode, versionMessage.command.c_str(), CFlatData(versionMessage.data));
+
+    BOOST_CHECK(!ProcessMessages(&peerNode, *connman, interruptDummy));
+    BOOST_CHECK(peerNode.vProcessMsg.empty());
+    BOOST_CHECK(!peerNode.fDisconnect);
+    BOOST_CHECK_EQUAL(peerNode.nVersion.load(), PROTOCOL_VERSION);
+    BOOST_CHECK_EQUAL(peerNode.nTimeOffset.load(), -1);
+}
+
 CTransactionRef RandomOrphan()
 {
     std::map<uint256, COrphanTx>::iterator it;

--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -134,6 +134,8 @@ BOOST_AUTO_TEST_CASE(addrman_simple)
     // Test 6: AddrMan::Clear() should empty the new table.
     addrman.Clear();
     BOOST_CHECK(addrman.size() == 0);
+    BOOST_CHECK(addrman.Find(addr1) == nullptr);
+    BOOST_CHECK(addrman.Find(addr2) == nullptr);
     CAddrInfo addr_null2 = addrman.Select();
     BOOST_CHECK(addr_null2.ToString() == "[::]:0");
 }

--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -3,7 +3,11 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #include "addrman.h"
 #include "test/test_bitcoin.h"
+#include "version.h"
+
+#include <limits>
 #include <string>
+
 #include <boost/test/unit_test.hpp>
 
 #include "hash.h"
@@ -33,19 +37,30 @@ public:
         return (unsigned int)(state % nMax);
     }
 
-    CAddrInfo* Find(const CNetAddr& addr, int* pnId = NULL)
+    CAddrInfo* Find(const CNetAddr& addr, nid_type* pnId = NULL)
     {
         return CAddrMan::Find(addr, pnId);
     }
 
-    CAddrInfo* Create(const CAddress& addr, const CNetAddr& addrSource, int* pnId = NULL)
+    CAddrInfo* Create(const CAddress& addr, const CNetAddr& addrSource, nid_type* pnId = NULL)
     {
         return CAddrMan::Create(addr, addrSource, pnId);
     }
 
-    void Delete(int nId)
+    void Delete(nid_type nId)
     {
         CAddrMan::Delete(nId);
+    }
+
+    void SetIdCount(int64_t nId)
+    {
+        nIdCount = nId;
+    }
+
+    int64_t GetId(const CNetAddr& addr) const
+    {
+        const auto it = mapAddr.find(addr);
+        return it == mapAddr.end() ? -1 : it->second;
     }
 };
 
@@ -71,6 +86,13 @@ static CService ResolveService(const char* ip, int port = 0)
 static CService ResolveService(std::string ip, int port = 0)
 {
     return ResolveService(ip.c_str(), port);
+}
+
+static std::string SerializeAddrman(const CAddrMan& addrman)
+{
+    CDataStream stream(SER_DISK, CLIENT_VERSION);
+    stream << addrman;
+    return stream.str();
 }
 
 BOOST_FIXTURE_TEST_SUITE(addrman_tests, BasicTestingSetup)
@@ -305,7 +327,7 @@ BOOST_AUTO_TEST_CASE(addrman_create)
     CAddress addr1 = CAddress(ResolveService("250.1.2.1", 8333), NODE_NONE);
     CNetAddr source1 = ResolveIP("250.1.2.1");
 
-    int nId;
+    nid_type nId;
     CAddrInfo* pinfo = addrman.Create(addr1, source1, &nId);
 
     // Test 20: The result should be the same as the input addr.
@@ -315,6 +337,49 @@ BOOST_AUTO_TEST_CASE(addrman_create)
     BOOST_CHECK(info2->ToString() == "250.1.2.1:8333");
 }
 
+BOOST_AUTO_TEST_CASE(addrman_id_overflow)
+{
+    CAddrManTest addrman;
+    const CNetAddr source = ResolveIP("252.2.2.2");
+    const CAddress addr1(ResolveService("250.1.2.1", 8333), NODE_NONE);
+    const CAddress addr2(ResolveService("250.1.2.2", 8333), NODE_NONE);
+    const int64_t max_int = std::numeric_limits<int>::max();
+
+    addrman.SetIdCount(max_int);
+    addrman.Create(addr1, source);
+    addrman.Create(addr2, source);
+
+    BOOST_CHECK_EQUAL(addrman.GetId(addr1), max_int);
+    BOOST_CHECK_EQUAL(addrman.GetId(addr2), max_int + 1);
+}
+
+BOOST_AUTO_TEST_CASE(addrman_serialization_ignores_internal_ids)
+{
+    CAddrManTest low_ids;
+    CAddrManTest high_ids;
+    low_ids.MakeDeterministic();
+    high_ids.MakeDeterministic();
+
+    const int64_t max_int = std::numeric_limits<int>::max();
+    high_ids.SetIdCount(max_int + 1);
+
+    const CNetAddr source = ResolveIP("252.5.1.1");
+    const std::vector<CAddress> addresses{
+        CAddress(ResolveService("250.7.1.1", 8333), NODE_NONE),
+        CAddress(ResolveService("250.7.2.2", 9999), NODE_NONE),
+        CAddress(ResolveService("250.7.3.3", 9999), NODE_NONE),
+    };
+
+    for (const CAddress& addr : addresses) {
+        BOOST_REQUIRE(low_ids.Add(addr, source));
+        BOOST_REQUIRE(high_ids.Add(addr, source));
+    }
+
+    BOOST_REQUIRE_EQUAL(low_ids.size(), addresses.size());
+    BOOST_REQUIRE_EQUAL(high_ids.size(), addresses.size());
+    BOOST_CHECK_GT(high_ids.GetId(addresses.front()), max_int);
+    BOOST_CHECK(SerializeAddrman(low_ids) == SerializeAddrman(high_ids));
+}
 
 BOOST_AUTO_TEST_CASE(addrman_delete)
 {
@@ -328,7 +393,7 @@ BOOST_AUTO_TEST_CASE(addrman_delete)
     CAddress addr1 = CAddress(ResolveService("250.1.2.1", 8333), NODE_NONE);
     CNetAddr source1 = ResolveIP("250.1.2.1");
 
-    int nId;
+    nid_type nId;
     addrman.Create(addr1, source1, &nId);
 
     // Test 21: Delete should actually delete the addr.

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -76,6 +76,7 @@ BOOST_AUTO_TEST_CASE(SimpleRoundTripTest)
 
         PartiallyDownloadedBlock partialBlock(&pool);
         BOOST_CHECK(partialBlock.InitData(shortIDs2, extra_txn) == READ_STATUS_OK);
+        BOOST_CHECK(partialBlock.InitData(shortIDs2, extra_txn) == READ_STATUS_INVALID);
         BOOST_CHECK( partialBlock.IsTxAvailable(0));
         BOOST_CHECK(!partialBlock.IsTxAvailable(1));
         BOOST_CHECK( partialBlock.IsTxAvailable(2));
@@ -107,6 +108,8 @@ BOOST_AUTO_TEST_CASE(SimpleRoundTripTest)
         BOOST_CHECK_EQUAL(block.GetHash().ToString(), block3.GetHash().ToString());
         BOOST_CHECK_EQUAL(block.hashMerkleRoot.ToString(), BlockMerkleRoot(block3, &mutated).ToString());
         BOOST_CHECK(!mutated);
+        BOOST_CHECK(!partialBlock.IsTxAvailable(0));
+        BOOST_CHECK(partialBlock.FillBlock(block3, {}) == READ_STATUS_INVALID);
     }
 }
 

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -3,9 +3,10 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "dbwrapper.h"
-#include "uint256.h"
+#include "evo/evodb.h"
 #include "random.h"
 #include "test/test_bitcoin.h"
+#include "uint256.h"
 
 #include <boost/assign/std/vector.hpp> // for 'operator+=()'
 #include <boost/assert.hpp>
@@ -22,7 +23,19 @@ bool is_null_key(const std::vector<unsigned char>& key) {
 }
  
 BOOST_FIXTURE_TEST_SUITE(dbwrapper_tests, BasicTestingSetup)
-                       
+
+BOOST_AUTO_TEST_CASE(evodb_verify_best_block)
+{
+    CEvoDB testEvoDb(1 << 20, true, true);
+    const uint256 storedHash = uint256S("01");
+    const uint256 mismatchedHash = uint256S("02");
+
+    BOOST_CHECK(!testEvoDb.VerifyBestBlock(storedHash));
+    testEvoDb.WriteBestBlock(storedHash);
+    BOOST_CHECK(testEvoDb.VerifyBestBlock(storedHash));
+    BOOST_CHECK(!testEvoDb.VerifyBestBlock(mismatchedHash));
+}
+
 BOOST_AUTO_TEST_CASE(dbwrapper)
 {
     // Perform tests both obfuscated and non-obfuscated.

--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -15,9 +15,6 @@
 #include <boost/assign/list_of.hpp>
 #include <boost/test/unit_test.hpp>
 
-struct ProxyCredentials;
-bool Socks5(const std::string& strDest, int port, const ProxyCredentials* auth, SOCKET& hSocket);
-
 BOOST_FIXTURE_TEST_SUITE(netbase_tests, BasicTestingSetup)
 
 #ifndef WIN32

--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -7,12 +7,113 @@
 #include "protocol.h"
 #include "utilstrencodings.h"
 
+#ifndef WIN32
+#include <future>
+#endif
 #include <string>
 
 #include <boost/assign/list_of.hpp>
 #include <boost/test/unit_test.hpp>
 
+struct ProxyCredentials;
+bool Socks5(const std::string& strDest, int port, const ProxyCredentials* auth, SOCKET& hSocket);
+
 BOOST_FIXTURE_TEST_SUITE(netbase_tests, BasicTestingSetup)
+
+#ifndef WIN32
+struct Socks5TestResult {
+    bool connected;
+    bool proxy_ok;
+};
+
+static bool RecvAll(SOCKET socket, uint8_t* data, size_t size)
+{
+    while (size > 0) {
+        const ssize_t received = recv(socket, reinterpret_cast<char*>(data), size, 0);
+        if (received <= 0) {
+            return false;
+        }
+        data += received;
+        size -= received;
+    }
+    return true;
+}
+
+static bool SendAll(SOCKET socket, const std::vector<uint8_t>& data)
+{
+    size_t sent = 0;
+    while (sent < data.size()) {
+        const ssize_t result = send(
+            socket,
+            reinterpret_cast<const char*>(data.data() + sent),
+            data.size() - sent,
+            0);
+        if (result <= 0) {
+            return false;
+        }
+        sent += result;
+    }
+    return true;
+}
+
+static Socks5TestResult TestSocks5DomainReply(uint8_t domain_length, size_t payload_size, bool include_port)
+{
+    int sockets[2];
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) != 0) {
+        return {false, false};
+    }
+
+    SOCKET client_socket = sockets[0];
+    SOCKET proxy_socket = sockets[1];
+    if (!SetSocketNonBlocking(client_socket, true)) {
+        CloseSocket(client_socket);
+        CloseSocket(proxy_socket);
+        return {false, false};
+    }
+
+    auto proxy = std::async(std::launch::async, [&] {
+        const auto finish = [&](bool result) {
+            CloseSocket(proxy_socket);
+            return result;
+        };
+
+        uint8_t greeting[3];
+        if (!RecvAll(proxy_socket, greeting, sizeof(greeting)) ||
+            greeting[0] != 0x05 || greeting[1] != 0x01 || greeting[2] != 0x00) {
+            return finish(false);
+        }
+        if (!SendAll(proxy_socket, {0x05, 0x00})) {
+            return finish(false);
+        }
+
+        uint8_t request_header[5];
+        if (!RecvAll(proxy_socket, request_header, sizeof(request_header)) ||
+            request_header[0] != 0x05 || request_header[1] != 0x01 ||
+            request_header[2] != 0x00 || request_header[3] != 0x03) {
+            return finish(false);
+        }
+        std::vector<uint8_t> request_body(request_header[4] + 2);
+        if (!RecvAll(proxy_socket, request_body.data(), request_body.size())) {
+            return finish(false);
+        }
+
+        std::vector<uint8_t> reply{0x05, 0x00, 0x00, 0x03, domain_length};
+        reply.insert(reply.end(), payload_size, 0x41);
+        if (include_port) {
+            reply.push_back(0x20);
+            reply.push_back(0x8d);
+        }
+        return finish(SendAll(proxy_socket, reply));
+    });
+
+    InterruptSocks5(false);
+    const bool connected = Socks5("example.test", 8333, nullptr, client_socket);
+    if (client_socket != INVALID_SOCKET) {
+        CloseSocket(client_socket);
+    }
+    return {connected, proxy.get()};
+}
+#endif
 
 static CNetAddr ResolveIP(const char* ip)
 {
@@ -314,6 +415,25 @@ BOOST_AUTO_TEST_CASE(netbase_getgroup)
     BOOST_CHECK(ResolveIP("2001:470:abcd:9999:9999:9999:9999:9999").GetGroup(asmap) == boost::assign::list_of((unsigned char)NET_IPV6)(32)(1)(4)(112)(175)); //he.net
     BOOST_CHECK(ResolveIP("2001:2001:9999:9999:9999:9999:9999:9999").GetGroup(asmap) == boost::assign::list_of((unsigned char)NET_IPV6)(32)(1)(32)(1)); //IPv6
 
+}
+
+BOOST_AUTO_TEST_CASE(socks5_domain_reply_length)
+{
+#ifndef WIN32
+    const Socks5TestResult below_signed_boundary = TestSocks5DomainReply(127, 127, true);
+    BOOST_REQUIRE(below_signed_boundary.proxy_ok);
+    BOOST_CHECK(below_signed_boundary.connected);
+
+    const Socks5TestResult above_signed_boundary = TestSocks5DomainReply(128, 128, true);
+    BOOST_REQUIRE(above_signed_boundary.proxy_ok);
+    BOOST_CHECK(above_signed_boundary.connected);
+
+    const Socks5TestResult truncated_maximum = TestSocks5DomainReply(255, 32, false);
+    BOOST_REQUIRE(truncated_maximum.proxy_ok);
+    BOOST_CHECK(!truncated_maximum.connected);
+#else
+    BOOST_TEST_MESSAGE("SOCKS5 socket-pair boundary coverage is unavailable on Windows");
+#endif
 }
 
 // Note: netbase_dont_resolve_strings_with_embedded_nul_characters test from Bitcoin PR #19628

--- a/src/test/timedata_tests.cpp
+++ b/src/test/timedata_tests.cpp
@@ -7,6 +7,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <limits>
+
 BOOST_FIXTURE_TEST_SUITE(timedata_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(util_MedianFilter)
@@ -32,6 +34,25 @@ BOOST_AUTO_TEST_CASE(util_MedianFilter)
 
     filter.input(0); // [0 3 7 18 30]
     BOOST_CHECK_EQUAL(filter.median(), 7);
+}
+
+BOOST_AUTO_TEST_CASE(time_offset_range)
+{
+    const int64_t nMaxAdjustment = DEFAULT_MAX_TIME_ADJUSTMENT;
+    const int64_t nSignedMax = std::numeric_limits<int64_t>::max();
+
+    BOOST_CHECK(IsTimeOffsetWithinRange(0, nMaxAdjustment));
+    BOOST_CHECK(IsTimeOffsetWithinRange(nMaxAdjustment, nMaxAdjustment));
+    BOOST_CHECK(IsTimeOffsetWithinRange(-nMaxAdjustment, nMaxAdjustment));
+    BOOST_CHECK(!IsTimeOffsetWithinRange(nMaxAdjustment + 1, nMaxAdjustment));
+    BOOST_CHECK(!IsTimeOffsetWithinRange(-nMaxAdjustment - 1, nMaxAdjustment));
+    BOOST_CHECK(!IsTimeOffsetWithinRange(std::numeric_limits<int64_t>::min(), nMaxAdjustment));
+    BOOST_CHECK(!IsTimeOffsetWithinRange(nSignedMax, nMaxAdjustment));
+
+    BOOST_CHECK(IsTimeOffsetWithinRange(nSignedMax, nSignedMax));
+    BOOST_CHECK(IsTimeOffsetWithinRange(-nSignedMax, nSignedMax));
+    BOOST_CHECK(!IsTimeOffsetWithinRange(std::numeric_limits<int64_t>::min(), nSignedMax));
+    BOOST_CHECK(!IsTimeOffsetWithinRange(0, -1));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/timedata.cpp
+++ b/src/timedata.cpp
@@ -38,9 +38,9 @@ int64_t GetAdjustedTime()
     return GetTime() + GetTimeOffset();
 }
 
-static int64_t abs64(int64_t n)
+bool IsTimeOffsetWithinRange(int64_t nTimeOffset, int64_t nMaxTimeOffset)
 {
-    return (n >= 0 ? n : -n);
+    return nMaxTimeOffset >= 0 && nTimeOffset >= -nMaxTimeOffset && nTimeOffset <= nMaxTimeOffset;
 }
 
 #define BITCOIN_TIMEDATA_MAX_SAMPLES 200
@@ -82,12 +82,10 @@ void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample)
         int64_t nMedian = vTimeOffsets.median();
         std::vector<int64_t> vSorted = vTimeOffsets.sorted();
         // Only let other nodes change our time by so much
-        if (abs64(nMedian) <= std::max<int64_t>(0, GetArg("-maxtimeadjustment", DEFAULT_MAX_TIME_ADJUSTMENT)))
-        {
+        const int64_t nMaxAdjustment = std::max<int64_t>(0, GetArg("-maxtimeadjustment", DEFAULT_MAX_TIME_ADJUSTMENT));
+        if (IsTimeOffsetWithinRange(nMedian, nMaxAdjustment)) {
             nTimeOffset = nMedian;
-        }
-        else
-        {
+        } else {
             nTimeOffset = 0;
 
             static bool fDone;
@@ -96,7 +94,7 @@ void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample)
                 // If nobody has a time different than ours but within 5 minutes of ours, give a warning
                 bool fMatch = false;
                 BOOST_FOREACH(int64_t nOffset, vSorted)
-                    if (nOffset != 0 && abs64(nOffset) < 5 * 60)
+                    if (nOffset != 0 && nOffset > -5 * 60 && nOffset < 5 * 60)
                         fMatch = true;
 
                 if (!fMatch)
@@ -108,7 +106,7 @@ void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample)
                 }
             }
         }
-        
+
         BOOST_FOREACH(int64_t n, vSorted)
             LogPrint("net", "%+d  ", n);
         LogPrint("net", "|  ");

--- a/src/timedata.h
+++ b/src/timedata.h
@@ -70,6 +70,9 @@ public:
     }
 };
 
+/** Return whether a time offset is within an inclusive, non-negative maximum. */
+bool IsTimeOffsetWithinRange(int64_t nTimeOffset, int64_t nMaxTimeOffset);
+
 /** Functions to keep track of adjusted P2P time */
 int64_t GetTimeOffset();
 int64_t GetAdjustedTime();

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1248,11 +1248,16 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
 
 bool CTxMemPool::CompareDepthAndScore(const uint256& hasha, const uint256& hashb)
 {
+    /* Return true if hasha should be considered sooner than hashb. Namely when:
+     *   a is not in the mempool, but b is
+     *   both are in the mempool and a has fewer ancestors than b
+     *   both are in the mempool and a has a higher score than b
+     */
     LOCK(cs);
-    indexed_transaction_set::const_iterator i = mapTx.find(hasha);
-    if (i == mapTx.end()) return false;
     indexed_transaction_set::const_iterator j = mapTx.find(hashb);
-    if (j == mapTx.end()) return true;
+    if (j == mapTx.end()) return false;
+    indexed_transaction_set::const_iterator i = mapTx.find(hasha);
+    if (i == mapTx.end()) return true;
     uint64_t counta = i->GetCountWithAncestors();
     uint64_t countb = j->GetCountWithAncestors();
     if (counta == countb) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4628,8 +4628,6 @@ static bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidation
         if (!fHasMoreWork) return true;     // Don't process less-work chains
         if (fTooFarAhead) return true;      // Block height is too high
     }
-    if (fNewBlock) *fNewBlock = true;
-
     if (!CheckBlock(block, state, chainparams.GetConsensus(), true, true, pindex->nHeight, false) ||
         !ContextualCheckBlock(block, state, chainparams.GetConsensus(), pindex->pprev)) {
         if (state.IsInvalid() && !state.CorruptionPossible()) {
@@ -4647,6 +4645,7 @@ static bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidation
     int nHeight = pindex->nHeight;
 
     // Write block to history file
+    if (fNewBlock) *fNewBlock = true;
     try {
         unsigned int nBlockSize = ::GetSerializeSize(block, SER_DISK, CLIENT_VERSION);
         CDiskBlockPos blockPos;


### PR DESCRIPTION
This PR backports eight security and robustness fixes from Bitcoin Core and Dash. Each issue is isolated in its own commit and includes focused regression coverage. The changes do not modify consensus rules or serialized network formats.

  ### EvoDB best-block consistency (22a09eab0)

  EvoDB now verifies that its stored best block matches the block expected by validation. A mismatch returns false, allowing the existing recovery and reindex paths to handle the inconsistency instead of silently accepting it in Release
  builds. Tests cover missing, matching, and mismatched best-block records.

  ### Peer time-offset overflow (b5e8eeacc)

  Time-offset validation now uses direct bounds instead of an overflow-prone absolute-value calculation. This handles INT64_MIN and the rest of the signed range without undefined behavior. The timedata tests cover the relevant boundary
  values. This fixes BTC-08 / CVE-2024-52912.

  ### SOCKS reply-length handling (50e1ba283)

  SOCKS protocol bytes are now kept unsigned while replies are decoded. This prevents a domain length with its high bit set from becoming a very large read into a small stack buffer. Socket-based tests cover maximum-length, truncated, and
  malformed replies. This fixes BTC-14 / CVE-2017-18350.

  ### Block inventory header requests (9a4356c85)

  A large INV message now produces at most one GETHEADERS request, using the final qualifying unknown block. Previously, one maximum-sized inventory could queue thousands of repeated locator messages. The regression test covers maximum-
  sized mixed inventories, known blocks, final-block selection, and transaction entries. This fixes BTC-06 / CVE-2024-52915.

  ### Repeated BLOCKTXN handling (4bacddb9b)

  Compact-block reconstruction state is treated as single-use without relying on reachable assertions. A repeated malicious BLOCKTXN now follows normal invalid-message handling instead of aborting the node. Tests cover consumed
  reconstruction state and the repeated-fill path. This fixes BTC-04 / CVE-2024-35202.

  ### Transaction inventory queue draining (5d49cdb40)

  Missing or stale transaction hashes are now removed before live entries, and large queues receive a bounded adaptive drain allowance. This prevents stale hashes from accumulating indefinitely while preserving existing transaction
  priority and relay filters. Tests cover queue growth, stale-entry cleanup, adaptive limits, and live transaction relay. This fixes BTC-12 / CVE-2024-52923.

  ### Block-download ownership (a9c5a7dc1)

  Pre-validation block-request cleanup is now restricted to the peer that owns the download. A block received from another peer clears remaining ownership only after successful processing, preventing mutated blocks from disrupting an
  honest compact-block download. The functional test covers same-header mutation, incorrect ownership, and successful alternate delivery. This fixes BTC-10 / CVE-2024-52921.

  ### AddrMan identifier overflow (9d2c9477e)

  AddrMan’s internal lifetime identifiers are widened from 32 to 64 bits. This prevents long-running address insertion from overflowing identifiers and corrupting AddrMan’s internal indexes, while preserving the existing on-disk
  serialization format. Tests cover identifiers above INT_MAX, internal consistency, and byte-identical serialization. This fixes BTC-15 / CVE-2024-52919.
