### PR TITLE
BLS: reject identity and non-subgroup elements

### DIFF
--- a/depends/packages/bls-dash.mk
+++ b/depends/packages/bls-dash.mk
@@ -16,7 +16,9 @@ $(package)_relic_sha256_hash=ddad83b1406985a1e4703bd03bdbab89453aa700c0c99567cf8
 
 $(package)_extra_sources=$($(package)_relic_file_name)
 
-$(package)_patches = bls-signatures.patch
+# Backport RELIC c7177c87 and 3429421e without importing the unrelated
+# arithmetic changes between the pinned revision and those commits.
+$(package)_patches = bls-signatures.patch fix-relic-ep-doubling.patch fix-relic-g1-subgroup-check.patch
 
 define $(package)_fetch_cmds
 $(call fetch_file,$(package),$($(package)_download_path),$($(package)_download_file),$($(package)_file_name),$($(package)_sha256_hash)) && \
@@ -57,6 +59,8 @@ endef
 
 define $(package)_preprocess_cmds
   patch -p1 < $($(package)_patch_dir)/bls-signatures.patch && \
+  cp $($(package)_patch_dir)/fix-relic-ep-doubling.patch . && \
+  cp $($(package)_patch_dir)/fix-relic-g1-subgroup-check.patch . && \
   sed -i.old "s|GIT_REPOSITORY https://github.com/relic-toolkit/relic.git|URL \"../../relic-toolkit-$($(package)_relic_version).tar.gz\"|" src/CMakeLists.txt && \
   sed -i.old "s|GIT_TAG        .*RELIC_GIT_TAG.*|URL_HASH SHA256=$($(package)_relic_sha256_hash)|" src/CMakeLists.txt
 endef

--- a/depends/patches/bls-dash/bls-signatures.patch
+++ b/depends/patches/bls-dash/bls-signatures.patch
@@ -27,11 +27,13 @@ diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
 index 2779a2e..1090e3f 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -16,6 +16,7 @@ FetchContent_Declare(
+@@ -16,6 +16,9 @@ FetchContent_Declare(
    relic
    GIT_REPOSITORY https://github.com/relic-toolkit/relic.git
    GIT_TAG        ${RELIC_GIT_TAG}
 +  PATCH_COMMAND  find . -type f -name "*.[ch]" -exec sed -i.old -e s/bn_init/bn_make/g {} +
++  COMMAND        patch -p1 -i ${CMAKE_CURRENT_SOURCE_DIR}/../fix-relic-ep-doubling.patch
++  COMMAND        patch -p1 -i ${CMAKE_CURRENT_SOURCE_DIR}/../fix-relic-g1-subgroup-check.patch
  )
  FetchContent_MakeAvailable(relic)
  

--- a/depends/patches/bls-dash/fix-relic-ep-doubling.patch
+++ b/depends/patches/bls-dash/fix-relic-ep-doubling.patch
@@ -1,0 +1,14 @@
+diff --git a/src/ep/relic_ep_dbl.c b/src/ep/relic_ep_dbl.c
+index 66369fdb..1a160d02 100644
+--- a/src/ep/relic_ep_dbl.c
++++ b/src/ep/relic_ep_dbl.c
+@@ -516,4 +515,0 @@ void ep_dbl_projc(ep_t r, const ep_t p) {
+-	if (fp_is_zero(p->x)) {
+-		ep_set_infty(r);
+-		return;
+-	}
+@@ -533,4 +528,0 @@ void ep_dbl_jacob(ep_t r, const ep_t p) {
+-	if (fp_is_zero(p->x)) {
+-		ep_set_infty(r);
+-		return;
+-	}

--- a/depends/patches/bls-dash/fix-relic-g1-subgroup-check.patch
+++ b/depends/patches/bls-dash/fix-relic-g1-subgroup-check.patch
@@ -1,0 +1,35 @@
+diff --git a/src/pc/relic_pc_util.c b/src/pc/relic_pc_util.c
+index af2af3fa..198f4b14 100644
+--- a/src/pc/relic_pc_util.c
++++ b/src/pc/relic_pc_util.c
+@@ -109 +109,2 @@ int g1_is_valid(g1_t a) {
+-				 * https://eprint.iacr.org/2019/814.pdf */
++				 * https://eprint.iacr.org/2019/814.pdf, together with tweaks
++				 * by Mike Scott. */
+@@ -111,6 +112 @@ int g1_is_valid(g1_t a) {
+-					/* Check [(z^2−1)](2\psi(P)-P-\psi^2(P)) == [3]\psi^2(P). */
+-					ep_psi(v, a);
+-					ep_dbl(u, v);
+-					ep_psi(v, v);
+-					ep_sub(u, u, a);
+-					ep_sub(u, u, v);
++					/* Check [(z^2−1)](\psi(P)+P) == -P. */
+@@ -119 +115,4 @@ int g1_is_valid(g1_t a) {
+-					ep_copy(t, u);
++					bn_sub_dig(n, n, 1);
++					ep_psi(t, a);
++					ep_add(t, t, a);
++					ep_copy(u, t);
+@@ -121 +120 @@ int g1_is_valid(g1_t a) {
+-						ep_dbl(t, t);
++						ep_dbl(u, u);
+@@ -123 +122 @@ int g1_is_valid(g1_t a) {
+-							ep_add(t, t, u);
++							ep_add(u, u, t);
+@@ -126,4 +125,2 @@ int g1_is_valid(g1_t a) {
+-					ep_sub(t, t, u);
+-					ep_dbl(u, v);
+-					ep_add(u, u, v);
+-					r = ep_on_curve(t) && (ep_cmp(t, u) == RLC_EQ);
++					ep_neg(v, a);
++					r = ep_on_curve(a) && (ep_cmp(v, u) == RLC_EQ);

--- a/src/bls/bls.cpp
+++ b/src/bls/bls.cpp
@@ -59,16 +59,10 @@ CBLSSecretKey CBLSSecretKey::AggregateInsecure(const std::vector<CBLSSecretKey>&
 void CBLSSecretKey::MakeNewKey()
 {
     unsigned char buf[32];
-    while (true) {
+    do {
         GetStrongRandBytes(buf, sizeof(buf));
-        try {
-            impl = bls::PrivateKey::FromBytes(bls::Bytes((const uint8_t*)buf, SerSize));
-            break;
-        } catch (...) {
-        }
-    }
-    fValid = true;
-    cachedHash.SetNull();
+        SetByteVector(std::vector<uint8_t>(buf, buf + sizeof(buf)));
+    } while (!IsValid());
 }
 #endif
 
@@ -301,17 +295,24 @@ bool CBLSSignature::VerifyInsecureAggregated(const std::vector<CBLSPublicKey>& p
 
 bool CBLSSignature::VerifySecureAggregated(const std::vector<CBLSPublicKey>& pks, const uint256& hash) const
 {
-    if (pks.empty()) {
+    if (!IsValid() || pks.empty()) {
         return false;
     }
 
     std::vector<bls::G1Element> vecPublicKeys;
     vecPublicKeys.reserve(pks.size());
     for (const auto& pk : pks) {
+        if (!pk.IsValid()) {
+            return false;
+        }
         vecPublicKeys.push_back(pk.impl);
     }
 
-    return Scheme(fLegacy)->VerifySecure(vecPublicKeys, impl, bls::Bytes(hash.begin(), hash.size()));
+    try {
+        return Scheme(fLegacy)->VerifySecure(vecPublicKeys, impl, bls::Bytes(hash.begin(), hash.size()));
+    } catch (...) {
+        return false;
+    }
 }
 
 bool CBLSSignature::Recover(const std::vector<CBLSSignature>& sigs, const std::vector<CBLSId>& ids)
@@ -392,5 +393,27 @@ bool BLSInit()
 #ifndef BUILD_BITCOIN_INTERNAL
     bls::BLS::SetSecureAllocator(secure_allocate, secure_free);
 #endif
-    return true;
+
+    // A system-provided bls-dash can otherwise silently bypass the RELIC
+    // subgroup fixes carried by depends. Fail closed if the linked library
+    // accepts either a pure torsion point or a mixed prime/torsion point.
+    try {
+        const auto orderThree = ParseHex("800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+        const auto mixedSubgroup = ParseHex("8e9277968cb92c78d15a2a2ed855d55061c3929db43d1e53d6d13bee755ff9a91b3f577bbb2f15c6ba8206a6a81c4afd");
+        const auto invalidG2 = ParseHex("0888879c99852460912fd28c7a9138926c1e87fd6609fd2d3d307764e49feb85702fd8f9b3b836bc11f7ce151b769dc70b760879d26f8c33a29e24f69297f45ef028f0794e63ddb0610db7de1a608b6d6a2129ada62b845004a408f651fd44a6");
+        if (CBLSPublicKey(orderThree).IsValid() || CBLSPublicKey(mixedSubgroup).IsValid()
+            || CBLSSignature(invalidG2).IsValid()) {
+            return false;
+        }
+
+        std::vector<uint8_t> secretKeyOne(BLS_CURVE_SECKEY_SIZE, 0);
+        secretKeyOne.back() = 1;
+        const CBLSSecretKey sk(secretKeyOne);
+        const CBLSPublicKey pk = sk.GetPublicKey();
+        const uint256 hash;
+        const CBLSSignature sig = sk.Sign(hash);
+        return sk.IsValid() && pk.IsValid() && sig.IsValid() && sig.VerifyInsecure(pk, hash);
+    } catch (...) {
+        return false;
+    }
 }

--- a/src/bls/bls.cpp
+++ b/src/bls/bls.cpp
@@ -5,6 +5,7 @@
 #include <bls/bls.h>
 
 #include <random.h>
+#include <support/cleanse.h>
 #include <tinyformat.h>
 
 #ifndef BUILD_BITCOIN_INTERNAL
@@ -58,11 +59,12 @@ CBLSSecretKey CBLSSecretKey::AggregateInsecure(const std::vector<CBLSSecretKey>&
 #ifndef BUILD_BITCOIN_INTERNAL
 void CBLSSecretKey::MakeNewKey()
 {
-    unsigned char buf[32];
+    std::vector<uint8_t> buf(BLS_CURVE_SECKEY_SIZE);
     do {
-        GetStrongRandBytes(buf, sizeof(buf));
-        SetByteVector(std::vector<uint8_t>(buf, buf + sizeof(buf)));
+        GetStrongRandBytes(buf.data(), buf.size());
+        SetByteVector(buf);
     } while (!IsValid());
+    memory_cleanse(buf.data(), buf.size());
 }
 #endif
 
@@ -253,9 +255,9 @@ void CBLSSignature::SubInsecure(const CBLSSignature& o)
     cachedHash.SetNull();
 }
 
-bool CBLSSignature::VerifyInsecure(const CBLSPublicKey& pubKey, const uint256& hash) const
+bool CBLSSignature::VerifyInsecure(const CBLSPublicKey& pubKey, const uint256& hash, bool fStrict) const
 {
-    if (!IsValid() || !pubKey.IsValid()) {
+    if (!IsValid(fStrict) || !pubKey.IsValid(fStrict)) {
         return false;
     }
 
@@ -293,16 +295,16 @@ bool CBLSSignature::VerifyInsecureAggregated(const std::vector<CBLSPublicKey>& p
     }
 }
 
-bool CBLSSignature::VerifySecureAggregated(const std::vector<CBLSPublicKey>& pks, const uint256& hash) const
+bool CBLSSignature::VerifySecureAggregated(const std::vector<CBLSPublicKey>& pks, const uint256& hash, bool fStrict) const
 {
-    if (!IsValid() || pks.empty()) {
+    if (!IsValid(fStrict) || pks.empty()) {
         return false;
     }
 
     std::vector<bls::G1Element> vecPublicKeys;
     vecPublicKeys.reserve(pks.size());
     for (const auto& pk : pks) {
-        if (!pk.IsValid()) {
+        if (!pk.IsValid(fStrict)) {
             return false;
         }
         vecPublicKeys.push_back(pk.impl);

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -29,8 +29,10 @@
 #undef BENCH
 #undef RAND
 
+#include <algorithm>
 #include <array>
 #include <mutex>
+#include <utility>
 #include <unistd.h>
 
 static const bool fLegacyDefault{true};
@@ -43,6 +45,74 @@ static const bool fLegacyDefault{true};
 
 class CBLSSignature;
 class CBLSPublicKey;
+struct CBLSIdImplicit;
+
+template <typename ImplType>
+struct CBLSImplValidation;
+
+template <typename ImplType>
+struct CBLSImplParser
+{
+    static ImplType FromBytes(const std::vector<uint8_t>& vecBytes, bool fLegacy)
+    {
+        return ImplType::FromBytes(bls::Bytes(vecBytes), fLegacy);
+    }
+};
+
+template <>
+struct CBLSImplParser<bls::PrivateKey>
+{
+    static bls::PrivateKey FromBytes(const std::vector<uint8_t>& vecBytes, bool)
+    {
+        static constexpr std::array<uint8_t, BLS_CURVE_SECKEY_SIZE> groupOrder{
+            0x73, 0xed, 0xa7, 0x53, 0x29, 0x9d, 0x7d, 0x48,
+            0x33, 0x39, 0xd8, 0x08, 0x09, 0xa1, 0xd8, 0x05,
+            0x53, 0xbd, 0xa4, 0x02, 0xff, 0xfe, 0x5b, 0xfe,
+            0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x01,
+        };
+        if (!std::lexicographical_compare(vecBytes.begin(), vecBytes.end(), groupOrder.begin(), groupOrder.end())) {
+            return bls::PrivateKey();
+        }
+        return bls::PrivateKey::FromBytes(bls::Bytes(vecBytes));
+    }
+};
+
+inline bool IsValidBLSGroupElement(const bls::G1Element& impl)
+{
+    return impl != bls::G1Element() && impl.IsValid();
+}
+
+inline bool IsValidBLSGroupElement(const bls::G2Element& impl)
+{
+    return impl != bls::G2Element() && impl.IsValid();
+}
+
+template <>
+struct CBLSImplValidation<bls::PrivateKey>
+{
+    static bool IsValid(const bls::PrivateKey& impl)
+    {
+        return !impl.IsZero();
+    }
+};
+
+template <>
+struct CBLSImplValidation<bls::G1Element>
+{
+    static bool IsValid(const bls::G1Element& impl)
+    {
+        return IsValidBLSGroupElement(impl);
+    }
+};
+
+template <>
+struct CBLSImplValidation<bls::G2Element>
+{
+    static bool IsValid(const bls::G2Element& impl)
+    {
+        return IsValidBLSGroupElement(impl);
+    }
+};
 
 template <typename ImplType, size_t _SerSize, typename C>
 class CBLSWrapper
@@ -119,8 +189,13 @@ public:
             Reset();
         } else {
             try {
-                impl = ImplType::FromBytes(bls::Bytes(vecBytes), fLegacy);
-                fValid = true;
+                ImplType parsed = CBLSImplParser<ImplType>::FromBytes(vecBytes, fLegacy);
+                if (CBLSImplValidation<ImplType>::IsValid(parsed)) {
+                    impl = std::move(parsed);
+                    fValid = true;
+                } else {
+                    Reset();
+                }
             } catch (...) {
                 Reset();
             }
@@ -218,6 +293,15 @@ struct CBLSIdImplicit : public uint256
     std::vector<uint8_t> Serialize(const bool fLegacy = false) const
     {
         return {begin(), end()};
+    }
+};
+
+template <>
+struct CBLSImplValidation<CBLSIdImplicit>
+{
+    static bool IsValid(const CBLSIdImplicit&)
+    {
+        return true;
     }
 };
 

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -32,6 +32,7 @@
 #include <algorithm>
 #include <array>
 #include <mutex>
+#include <stdexcept>
 #include <utility>
 #include <unistd.h>
 
@@ -71,7 +72,7 @@ struct CBLSImplParser<bls::PrivateKey>
             0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x01,
         };
         if (!std::lexicographical_compare(vecBytes.begin(), vecBytes.end(), groupOrder.begin(), groupOrder.end())) {
-            return bls::PrivateKey();
+            throw std::invalid_argument("BLS private key is outside the scalar field");
         }
         return bls::PrivateKey::FromBytes(bls::Bytes(vecBytes));
     }
@@ -168,9 +169,9 @@ public:
         return !((*this) == r);
     }
 
-    bool IsValid() const
+    bool IsValid(bool fStrict = true) const
     {
-        return fValid;
+        return fValid && (!fStrict || CBLSImplValidation<ImplType>::IsValid(impl));
     }
 
     void Reset()
@@ -189,13 +190,8 @@ public:
             Reset();
         } else {
             try {
-                ImplType parsed = CBLSImplParser<ImplType>::FromBytes(vecBytes, fLegacy);
-                if (CBLSImplValidation<ImplType>::IsValid(parsed)) {
-                    impl = std::move(parsed);
-                    fValid = true;
-                } else {
-                    Reset();
-                }
+                impl = CBLSImplParser<ImplType>::FromBytes(vecBytes, fLegacy);
+                fValid = true;
             } catch (...) {
                 Reset();
             }
@@ -231,7 +227,11 @@ public:
             return false;
         }
         SetByteVector(b);
-        return IsValid();
+        if (!IsValid()) {
+            Reset();
+            return false;
+        }
+        return true;
     }
 
 public:
@@ -302,6 +302,15 @@ struct CBLSImplValidation<CBLSIdImplicit>
     static bool IsValid(const CBLSIdImplicit&)
     {
         return true;
+    }
+};
+
+template <>
+struct CBLSImplParser<CBLSIdImplicit>
+{
+    static CBLSIdImplicit FromBytes(const std::vector<uint8_t>& vecBytes, bool fLegacy)
+    {
+        return CBLSIdImplicit::FromBytes(vecBytes.data(), fLegacy);
     }
 };
 
@@ -378,10 +387,10 @@ public:
 
     void SubInsecure(const CBLSSignature& o);
 
-    bool VerifyInsecure(const CBLSPublicKey& pubKey, const uint256& hash) const;
+    bool VerifyInsecure(const CBLSPublicKey& pubKey, const uint256& hash, bool fStrict = true) const;
     bool VerifyInsecureAggregated(const std::vector<CBLSPublicKey>& pubKeys, const std::vector<uint256>& hashes) const;
 
-    bool VerifySecureAggregated(const std::vector<CBLSPublicKey>& pks, const uint256& hash) const;
+    bool VerifySecureAggregated(const std::vector<CBLSPublicKey>& pks, const uint256& hash, bool fStrict = true) const;
 
     bool Recover(const std::vector<CBLSSignature>& sigs, const std::vector<CBLSId>& ids);
 };

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -421,6 +421,8 @@ public:
         consensus.nSparkStartBlock = SPARK_START_BLOCK;
         // Disabled until a deployment height is selected.
         consensus.nSparkSingleInputStartBlock = 1355970;
+        // Set alongside the next coordinated hard fork.
+        consensus.nBLSStrictValidationStartBlock = INT_MAX;
         consensus.nLelantusGracefulPeriod = LELANTUS_GRACEFUL_PERIOD;
         consensus.nSigmaEndBlock = ZC_SIGMA_END_BLOCK;
         consensus.nZerocoinV2MintMempoolGracefulPeriod = ZC_V2_MINT_GRACEFUL_MEMPOOL_PERIOD;
@@ -748,6 +750,8 @@ public:
         consensus.nLelantusFixesStartBlock = ZC_LELANTUS_TESTNET_FIXES_START_BLOCK;
         consensus.nSparkStartBlock = SPARK_TESTNET_START_BLOCK;
         consensus.nSparkSingleInputStartBlock = INT_MAX;
+        // Set alongside the next coordinated hard fork.
+        consensus.nBLSStrictValidationStartBlock = INT_MAX;
         consensus.nLelantusGracefulPeriod = LELANTUS_TESTNET_GRACEFUL_PERIOD;
         consensus.nSigmaEndBlock = ZC_SIGMA_TESTNET_END_BLOCK;
         consensus.nZerocoinV2MintMempoolGracefulPeriod = ZC_V2_MINT_TESTNET_GRACEFUL_MEMPOOL_PERIOD;
@@ -1020,6 +1024,8 @@ public:
 
         consensus.nSparkStartBlock = 1500;
         consensus.nSparkSingleInputStartBlock = INT_MAX;
+        // Set alongside the next coordinated hard fork.
+        consensus.nBLSStrictValidationStartBlock = INT_MAX;
         consensus.nLelantusGracefulPeriod = 6000;
         consensus.nSigmaEndBlock = 3600;
         consensus.nMaxSigmaInputPerBlock = ZC_SIGMA_INPUT_LIMIT_PER_BLOCK;
@@ -1272,6 +1278,7 @@ public:
         consensus.nLelantusFixesStartBlock = 1;
         consensus.nSparkStartBlock = 100;
         consensus.nSparkSingleInputStartBlock = 500;
+        consensus.nBLSStrictValidationStartBlock = 2700;
         consensus.nExchangeAddressStartBlock = 1000;
         consensus.nLelantusGracefulPeriod = 600;
         consensus.nSigmaEndBlock = 1;
@@ -1341,6 +1348,11 @@ public:
     {
         consensus.nSparkSingleInputStartBlock = height;
     }
+
+    void UpdateBLSStrictValidationHeight(int height)
+    {
+        consensus.nBLSStrictValidationStartBlock = height;
+    }
 };
 static CRegTestParams regTestParams;
 
@@ -1379,4 +1391,9 @@ void UpdateRegtestBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime,
 void UpdateRegtestSparkSingleInputHeight(int height)
 {
     regTestParams.UpdateSparkSingleInputHeight(height);
+}
+
+void UpdateRegtestBLSStrictValidationHeight(int height)
+{
+    regTestParams.UpdateBLSStrictValidationHeight(height);
 }

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -149,4 +149,7 @@ void UpdateRegtestBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime,
 /** Allows tests to exercise the single-input Spark consensus activation. */
 void UpdateRegtestSparkSingleInputHeight(int height);
 
+/** Allows tests to exercise strict BLS consensus activation. */
+void UpdateRegtestBLSStrictValidationHeight(int height);
+
 #endif // BITCOIN_CHAINPARAMS_H

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -279,6 +279,9 @@ struct Params {
     // Activation height for the single-input Spark spend rule.
     int nSparkSingleInputStartBlock;
 
+    // Activation height for strict BLS identity and subgroup validation.
+    int nBLSStrictValidationStartBlock;
+
     int nSparkNamesStartBlock;
     int nSparkNamesV2StartBlock;        // v2 enables spark name transfer
     int nSparkNamesV21StartBlock;       // v2.1 tweaks rules for renewals and transfers

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -448,7 +448,7 @@ void CDeterministicMNList::AddMN(const CDeterministicMNCPtr& dmn)
         AddUniqueProperty(dmn, dmn->pdmnState->addr);
     }
     AddUniqueProperty(dmn, dmn->pdmnState->keyIDOwner);
-    if (dmn->pdmnState->pubKeyOperator.Get().IsValid()) {
+    if (dmn->pdmnState->pubKeyOperator.Get().IsValid(false)) {
         AddUniqueProperty(dmn, dmn->pdmnState->pubKeyOperator);
     }
 }
@@ -491,7 +491,7 @@ void CDeterministicMNList::RemoveMN(const uint256& proTxHash)
         DeleteUniqueProperty(dmn, dmn->pdmnState->addr);
     }
     DeleteUniqueProperty(dmn, dmn->pdmnState->keyIDOwner);
-    if (dmn->pdmnState->pubKeyOperator.Get().IsValid()) {
+    if (dmn->pdmnState->pubKeyOperator.Get().IsValid(false)) {
         DeleteUniqueProperty(dmn, dmn->pdmnState->pubKeyOperator);
     }
     mnMap = mnMap.erase(proTxHash);
@@ -658,6 +658,24 @@ bool CDeterministicMNManager::BuildNewListFromBlock(const CBlock& block, const C
 
     DecreasePoSePenalties(newList);
 
+    if (nHeight == Params().GetConsensus().nBLSStrictValidationStartBlock) {
+        std::vector<uint256> invalidOperatorMNs;
+        newList.ForEachMN(false, [&](const CDeterministicMNCPtr& dmn) {
+            const auto& operatorKey = dmn->pdmnState->pubKeyOperator.Get();
+            if (operatorKey.IsValid(false) && !operatorKey.IsValid()) {
+                invalidOperatorMNs.emplace_back(dmn->proTxHash);
+            }
+        });
+
+        for (const auto& proTxHash : invalidOperatorMNs) {
+            const auto dmn = newList.GetMN(proTxHash);
+            auto newState = std::make_shared<CDeterministicMNState>(*dmn->pdmnState);
+            newState->ResetOperatorFields();
+            newState->BanIfNotBanned(nHeight);
+            newList.UpdateMN(dmn, newState);
+        }
+    }
+
     // we skip the coinbase
     for (int i = 1; i < (int)block.vtx.size(); i++) {
         const CTransaction& tx = *block.vtx[i];
@@ -756,7 +774,8 @@ bool CDeterministicMNManager::BuildNewListFromBlock(const CBlock& block, const C
 
             if (newState->nPoSeBanHeight != -1) {
                 // only revive when all keys are set
-                if (newState->pubKeyOperator.Get().IsValid() && !newState->keyIDVoting.IsNull() && !newState->keyIDOwner.IsNull()) {
+                const bool fBLSStrict = nHeight >= Params().GetConsensus().nBLSStrictValidationStartBlock;
+                if (newState->pubKeyOperator.Get().IsValid(fBLSStrict) && !newState->keyIDVoting.IsNull() && !newState->keyIDOwner.IsNull()) {
                     newState->nPoSePenalty = 0;
                     newState->nPoSeBanHeight = -1;
                     newState->nPoSeRevivedHeight = nHeight;

--- a/src/evo/providertx.cpp
+++ b/src/evo/providertx.cpp
@@ -17,6 +17,11 @@
 #include "univalue.h"
 #include "validation.h"
 
+static bool IsBLSStrictValidationEnabled(const CBlockIndex* pindexPrev)
+{
+    return !pindexPrev || pindexPrev->nHeight + 1 >= Params().GetConsensus().nBLSStrictValidationStartBlock;
+}
+
 template <typename ProTx>
 static bool CheckService(const uint256& proTxHash, const ProTx& proTx, CValidationState& state)
 {
@@ -64,9 +69,9 @@ static bool CheckStringSig(const ProTx& proTx, const CKeyID& keyID, CValidationS
 }
 
 template <typename ProTx>
-static bool CheckHashSig(const ProTx& proTx, const CBLSPublicKey& pubKey, CValidationState& state)
+static bool CheckHashSig(const ProTx& proTx, const CBLSPublicKey& pubKey, CValidationState& state, bool fBLSStrict)
 {
-    if (!proTx.sig.VerifyInsecure(pubKey, ::SerializeHash(proTx))) {
+    if (!proTx.sig.VerifyInsecure(pubKey, ::SerializeHash(proTx), fBLSStrict)) {
         return state.DoS(100, false, REJECT_INVALID, "bad-protx-sig", false);
     }
     return true;
@@ -104,7 +109,7 @@ bool CheckProRegTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValid
         return state.DoS(100, false, REJECT_INVALID, "bad-protx-mode");
     }
 
-    if (ptx.keyIDOwner.IsNull() || !ptx.pubKeyOperator.IsValid() || ptx.keyIDVoting.IsNull()) {
+    if (ptx.keyIDOwner.IsNull() || !ptx.pubKeyOperator.IsValid(IsBLSStrictValidationEnabled(pindexPrev)) || ptx.keyIDVoting.IsNull()) {
         return state.DoS(10, false, REJECT_INVALID, "bad-protx-key-null");
     }
     if (!ptx.scriptPayout.IsPayToPublicKeyHash() && !ptx.scriptPayout.IsPayToScriptHash()) {
@@ -257,7 +262,7 @@ bool CheckProUpServTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CVa
         if (!CheckInputsHash(tx, ptx, state)) {
             return false;
         }
-        if (!CheckHashSig(ptx, mn->pdmnState->pubKeyOperator.Get(), state)) {
+        if (!CheckHashSig(ptx, mn->pdmnState->pubKeyOperator.Get(), state, IsBLSStrictValidationEnabled(pindexPrev))) {
             return false;
         }
     }
@@ -283,7 +288,7 @@ bool CheckProUpRegTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CVal
         return state.DoS(100, false, REJECT_INVALID, "bad-protx-mode");
     }
 
-    if (!ptx.pubKeyOperator.IsValid() || ptx.keyIDVoting.IsNull()) {
+    if (!ptx.pubKeyOperator.IsValid(IsBLSStrictValidationEnabled(pindexPrev)) || ptx.keyIDVoting.IsNull()) {
         return state.DoS(10, false, REJECT_INVALID, "bad-protx-key-null");
     }
     if (!ptx.scriptPayout.IsPayToPublicKeyHash() && !ptx.scriptPayout.IsPayToScriptHash()) {
@@ -376,7 +381,7 @@ bool CheckProUpRevTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CVal
 
         if (!CheckInputsHash(tx, ptx, state))
             return false;
-        if (!CheckHashSig(ptx, dmn->pdmnState->pubKeyOperator.Get(), state))
+        if (!CheckHashSig(ptx, dmn->pdmnState->pubKeyOperator.Get(), state, IsBLSStrictValidationEnabled(pindexPrev)))
             return false;
     }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -42,6 +42,7 @@
 #include "validation.h"
 #include "mtpstate.h"
 #include "batchproof_container.h"
+#include "bls/bls.h"
 #include <crypto/progpow/include/ethash/progpow.hpp>
 #include "leveldb/env.h"
 
@@ -847,6 +848,10 @@ bool InitSanityCheck(void)
 {
     if(!ECC_InitSanityCheck()) {
         InitError("Elliptic curve cryptography sanity check failure. Aborting.");
+        return false;
+    }
+    if (!BLSInit()) {
+        InitError("BLS cryptographic sanity check failure. Aborting.");
         return false;
     }
     if (!glibc_sanity_test() || !glibcxx_sanity_test())

--- a/src/llmq/quorums_blockprocessor.cpp
+++ b/src/llmq/quorums_blockprocessor.cpp
@@ -101,7 +101,8 @@ void CQuorumBlockProcessor::ProcessMessage(CNode* pfrom, const std::string& strC
 
         auto members = CLLMQUtils::GetAllQuorumMembers(type, pquorumIndex);
 
-        if (!qc.Verify(members, true)) {
+        // Unmined P2P commitments always use the node's strict runtime policy.
+        if (!qc.Verify(members, true, true)) {
             LOCK(cs_main);
             LogPrintf("CQuorumBlockProcessor::%s -- commitment for quorum %s:%d is not valid, peer=%d\n", __func__,
                       qc.quorumHash.ToString(), qc.llmqType, pfrom->id);

--- a/src/llmq/quorums_blockprocessor.cpp
+++ b/src/llmq/quorums_blockprocessor.cpp
@@ -207,7 +207,8 @@ bool CQuorumBlockProcessor::ProcessCommitment(int nHeight, const uint256& blockH
     auto quorumIndex = mapBlockIndex.at(qc.quorumHash);
     auto members = CLLMQUtils::GetAllQuorumMembers(params.type, quorumIndex);
 
-    if (!qc.Verify(members, true)) {
+    const bool fBLSStrict = nHeight >= Params().GetConsensus().nBLSStrictValidationStartBlock;
+    if (!qc.Verify(members, true, fBLSStrict)) {
         return state.DoS(100, false, REJECT_INVALID, "bad-qc-invalid");
     }
 

--- a/src/llmq/quorums_commitment.cpp
+++ b/src/llmq/quorums_commitment.cpp
@@ -27,7 +27,7 @@ CFinalCommitment::CFinalCommitment(const Consensus::LLMQParams& params, const ui
     LogPrintStr(strprintf("CFinalCommitment::%s -- %s", __func__, tinyformat::format(__VA_ARGS__))); \
 } while(0)
 
-bool CFinalCommitment::Verify(const std::vector<CDeterministicMNCPtr>& members, bool checkSigs) const
+bool CFinalCommitment::Verify(const std::vector<CDeterministicMNCPtr>& members, bool checkSigs, bool fBLSStrict) const
 {
     if (nVersion == 0 || nVersion > CURRENT_VERSION) {
         return false;
@@ -42,6 +42,10 @@ bool CFinalCommitment::Verify(const std::vector<CDeterministicMNCPtr>& members, 
     if (!VerifySizes(params)) {
         return false;
     }
+    if (cmp::greater(members.size(), params.size)) {
+        LogPrintfFinalCommitment("invalid members size. membersSize=%d\n", members.size());
+        return false;
+    }
 
     if (CountValidMembers() < params.minSize) {
         LogPrintfFinalCommitment("invalid validMembers count. validMembersCount=%d\n", CountValidMembers());
@@ -51,7 +55,7 @@ bool CFinalCommitment::Verify(const std::vector<CDeterministicMNCPtr>& members, 
         LogPrintfFinalCommitment("invalid signers count. signersCount=%d\n", CountSigners());
         return false;
     }
-    if (!quorumPublicKey.IsValid()) {
+    if (!quorumPublicKey.IsValid(fBLSStrict)) {
         LogPrintfFinalCommitment("invalid quorumPublicKey\n");
         return false;
     }
@@ -59,11 +63,11 @@ bool CFinalCommitment::Verify(const std::vector<CDeterministicMNCPtr>& members, 
         LogPrintfFinalCommitment("invalid quorumVvecHash\n");
         return false;
     }
-    if (!membersSig.IsValid()) {
+    if (!membersSig.IsValid(fBLSStrict)) {
         LogPrintfFinalCommitment("invalid membersSig\n");
         return false;
     }
-    if (!quorumSig.IsValid()) {
+    if (!quorumSig.IsValid(fBLSStrict)) {
         LogPrintfFinalCommitment("invalid vvecSig\n");
         return false;
     }
@@ -79,6 +83,15 @@ bool CFinalCommitment::Verify(const std::vector<CDeterministicMNCPtr>& members, 
         }
     }
 
+    if (fBLSStrict) {
+        for (size_t i = 0; i < members.size(); ++i) {
+            if ((signers[i] || validMembers[i]) && !members[i]->pdmnState->pubKeyOperator.Get().IsValid()) {
+                LogPrintfFinalCommitment("invalid member public key at index=%d\n", i);
+                return false;
+            }
+        }
+    }
+
     // sigs are only checked when the block is processed
     if (checkSigs) {
         uint256 commitmentHash = CLLMQUtils::BuildCommitmentHash((uint8_t)params.type, quorumHash, validMembers, quorumPublicKey, quorumVvecHash);
@@ -91,12 +104,12 @@ bool CFinalCommitment::Verify(const std::vector<CDeterministicMNCPtr>& members, 
             memberPubKeys.emplace_back(members[i]->pdmnState->pubKeyOperator.Get());
         }
 
-        if (!membersSig.VerifySecureAggregated(memberPubKeys, commitmentHash)) {
+        if (!membersSig.VerifySecureAggregated(memberPubKeys, commitmentHash, fBLSStrict)) {
             LogPrintfFinalCommitment("invalid aggregated members signature\n");
             return false;
         }
 
-        if (!quorumSig.VerifyInsecure(quorumPublicKey, commitmentHash)) {
+        if (!quorumSig.VerifyInsecure(quorumPublicKey, commitmentHash, fBLSStrict)) {
             LogPrintfFinalCommitment("invalid quorum signature\n");
             return false;
         }
@@ -194,7 +207,8 @@ bool CheckLLMQCommitment(const CTransaction& tx, const CBlockIndex* pindexPrev, 
     }
 
     auto members = CLLMQUtils::GetAllQuorumMembers(params.type, pindexQuorum);
-    if (!qcTx.commitment.Verify(members, false)) {
+    const bool fBLSStrict = cmp::greater_equal(qcTx.nHeight, Params().GetConsensus().nBLSStrictValidationStartBlock);
+    if (!qcTx.commitment.Verify(members, false, fBLSStrict)) {
         return state.DoS(100, false, REJECT_INVALID, "bad-qc-invalid");
     }
 

--- a/src/llmq/quorums_commitment.h
+++ b/src/llmq/quorums_commitment.h
@@ -48,7 +48,7 @@ public:
         return (int)std::count(validMembers.begin(), validMembers.end(), true);
     }
 
-    bool Verify(const std::vector<CDeterministicMNCPtr>& members, bool checkSigs, bool fBLSStrict = true) const;
+    bool Verify(const std::vector<CDeterministicMNCPtr>& members, bool checkSigs, bool fBLSStrict) const;
     bool VerifyNull() const;
     bool VerifySizes(const Consensus::LLMQParams& params) const;
 

--- a/src/llmq/quorums_commitment.h
+++ b/src/llmq/quorums_commitment.h
@@ -48,7 +48,7 @@ public:
         return (int)std::count(validMembers.begin(), validMembers.end(), true);
     }
 
-    bool Verify(const std::vector<CDeterministicMNCPtr>& members, bool checkSigs) const;
+    bool Verify(const std::vector<CDeterministicMNCPtr>& members, bool checkSigs, bool fBLSStrict = true) const;
     bool VerifyNull() const;
     bool VerifySizes(const Consensus::LLMQParams& params) const;
 
@@ -78,10 +78,10 @@ public:
             std::count(validMembers.begin(), validMembers.end(), true)) {
             return false;
         }
-        if (quorumPublicKey.IsValid() ||
+        if (quorumPublicKey.IsValid(false) ||
             !quorumVvecHash.IsNull() ||
-            membersSig.IsValid() ||
-            quorumSig.IsValid()) {
+            membersSig.IsValid(false) ||
+            quorumSig.IsValid(false)) {
             return false;
         }
         return true;

--- a/src/llmq/quorums_commitment.h
+++ b/src/llmq/quorums_commitment.h
@@ -48,6 +48,22 @@ public:
         return (int)std::count(validMembers.begin(), validMembers.end(), true);
     }
 
+    /**
+     * Validate this final commitment against its quorum members.
+     *
+     * @param members Ordered deterministic quorum members for this commitment's
+     *        llmqType and quorumHash.
+     * @param checkSigs Perform cryptographic verification of the aggregate
+     *        member signature and recovered quorum signature when true.
+     * @param fBLSStrict When true, require the commitment's BLS public key and
+     *        signatures, and participating members' operator public keys, to be
+     *        non-identity elements in the prime-order subgroup. When false,
+     *        apply the legacy parse-valid policy.
+     * @return true if all structural and field checks pass and, when requested,
+     *         both signatures verify; false otherwise.
+     * @pre members contains non-null entries in quorum-member order and does
+     *      not exceed the configured quorum size.
+     */
     bool Verify(const std::vector<CDeterministicMNCPtr>& members, bool checkSigs, bool fBLSStrict) const;
     bool VerifyNull() const;
     bool VerifySizes(const Consensus::LLMQParams& params) const;

--- a/src/llmq/quorums_dkgsessionhandler.cpp
+++ b/src/llmq/quorums_dkgsessionhandler.cpp
@@ -17,6 +17,21 @@
 namespace llmq
 {
 
+static size_t GetMaxDKGMessageSize(const Consensus::LLMQParams& params, const std::string& command)
+{
+    // Leave ample room for fixed fields and CompactSize prefixes while
+    // bounding vectors before their BLS elements are deserialized.
+    constexpr size_t overhead = 1024;
+    if (command == NetMsgType::QCONTRIB) {
+        return overhead + static_cast<size_t>(params.threshold) * BLS_CURVE_PUBKEY_SIZE
+               + static_cast<size_t>(params.size) * (BLS_CURVE_SECKEY_SIZE + 1);
+    }
+    if (command == NetMsgType::QJUSTIFICATION) {
+        return overhead + static_cast<size_t>(params.size) * (sizeof(uint32_t) + BLS_CURVE_SECKEY_SIZE);
+    }
+    return overhead;
+}
+
 CDKGPendingMessages::CDKGPendingMessages(size_t _maxMessagesPerNode) :
     maxMessagesPerNode(_maxMessagesPerNode)
 {
@@ -127,6 +142,16 @@ void CDKGSessionHandler::UpdatedBlockTip(const CBlockIndex* pindexNew)
 
 void CDKGSessionHandler::ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman)
 {
+    const size_t maxSize = GetMaxDKGMessageSize(params, strCommand);
+    if (vRecv.size() > maxSize) {
+        LogPrintf("CDKGSessionHandler::%s -- oversized %s message, size=%u, max=%u, peer=%d\n",
+                  __func__, strCommand, static_cast<unsigned int>(vRecv.size()),
+                  static_cast<unsigned int>(maxSize), pfrom->id);
+        LOCK(cs_main);
+        Misbehaving(pfrom->id, 100);
+        return;
+    }
+
     // We don't handle messages in the calling thread as deserialization/processing of these would block everything
     if (strCommand == NetMsgType::QCONTRIB) {
         pendingContributions.PushPendingMessage(pfrom->id, vRecv);

--- a/src/test/bls_tests.cpp
+++ b/src/test/bls_tests.cpp
@@ -4,6 +4,8 @@
 
 #include "bls/bls.h"
 #include "bls/bls_batchverifier.h"
+#include "chainparams.h"
+#include "llmq/quorums_commitment.h"
 #include "test/test_bitcoin.h"
 
 #include <boost/test/unit_test.hpp>
@@ -41,15 +43,50 @@ BOOST_AUTO_TEST_CASE(bls_reject_invalid_elements_tests)
     const std::vector<uint8_t> secretKeyGroupOrder = ParseHex("73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001");
     const std::vector<uint8_t> secretKeyGroupOrderPlusOne = ParseHex("73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000002");
 
-    BOOST_CHECK(!CBLSPublicKey(g1Identity).IsValid());
-    BOOST_CHECK(!CBLSSignature(g2Identity).IsValid());
-    BOOST_CHECK(!CBLSPublicKey(g1OrderThree).IsValid());
-    BOOST_CHECK(!CBLSPublicKey(mixedG1).IsValid());
-    BOOST_CHECK(!CBLSPublicKey(invalidG1).IsValid());
-    BOOST_CHECK(!CBLSSignature(invalidG2).IsValid());
+    const CBLSPublicKey identityPublicKey(g1Identity);
+    const CBLSSignature identitySignature(g2Identity);
+    const CBLSPublicKey orderThreePublicKey(g1OrderThree);
+    const CBLSPublicKey mixedPublicKey(mixedG1);
+    const CBLSPublicKey invalidPublicKey(invalidG1);
+    const CBLSSignature invalidSignature(invalidG2);
+
+    BOOST_CHECK(identityPublicKey.IsValid(false));
+    BOOST_CHECK(identitySignature.IsValid(false));
+    BOOST_CHECK(orderThreePublicKey.IsValid(false));
+    BOOST_CHECK(mixedPublicKey.IsValid(false));
+    BOOST_CHECK(invalidPublicKey.IsValid(false));
+    BOOST_CHECK(invalidSignature.IsValid(false));
+
+    BOOST_CHECK(!identityPublicKey.IsValid());
+    BOOST_CHECK(!identitySignature.IsValid());
+    BOOST_CHECK(!orderThreePublicKey.IsValid());
+    BOOST_CHECK(!mixedPublicKey.IsValid());
+    BOOST_CHECK(!invalidPublicKey.IsValid());
+    BOOST_CHECK(!invalidSignature.IsValid());
+
+    CBLSPublicKey hexPublicKey;
+    BOOST_CHECK(!hexPublicKey.SetHexStr(HexStr(g1Identity)));
+    BOOST_CHECK(!hexPublicKey.IsValid(false));
+
+    BOOST_CHECK(identityPublicKey.ToByteVector() == g1Identity);
+    BOOST_CHECK(identitySignature.ToByteVector() == g2Identity);
+    BOOST_CHECK(orderThreePublicKey.ToByteVector() == g1OrderThree);
+    BOOST_CHECK(mixedPublicKey.ToByteVector() == mixedG1);
+    BOOST_CHECK(invalidPublicKey.ToByteVector() == invalidG1);
+    BOOST_CHECK(invalidSignature.ToByteVector() == invalidG2);
+
+    const uint256 identityMessageHash = uint256S("0000000000000000000000000000000000000000000000000000000000000001");
+    BOOST_CHECK(identitySignature.VerifyInsecure(identityPublicKey, identityMessageHash, false));
+    BOOST_CHECK(!identitySignature.VerifyInsecure(identityPublicKey, identityMessageHash));
     BOOST_CHECK(!CBLSSecretKey(secretKeyGroupOrder).IsValid());
     BOOST_CHECK(!CBLSSecretKey(secretKeyGroupOrder, false).IsValid());
     BOOST_CHECK(!CBLSSecretKey(secretKeyGroupOrderPlusOne).IsValid());
+
+    const uint256 idValue = uint256S("0000000000000000000000000000000000000000000000000000000000000002");
+    const CBLSId id(idValue);
+    const CBLSId parsedId(id.ToByteVector());
+    BOOST_CHECK(parsedId.IsValid());
+    BOOST_CHECK(parsedId.ToByteVector() == id.ToByteVector());
 
     CBLSSecretKey sk;
     sk.MakeNewKey();
@@ -59,6 +96,64 @@ BOOST_AUTO_TEST_CASE(bls_reject_invalid_elements_tests)
     BOOST_CHECK(pubKey.IsValid());
     BOOST_CHECK(sig.IsValid());
     BOOST_CHECK(sig.VerifyInsecure(pubKey, msgHash));
+
+    CBLSSignature cancelledSig = sig;
+    cancelledSig.SubInsecure(sig);
+    BOOST_CHECK(cancelledSig.IsValid(false));
+    BOOST_CHECK(!cancelledSig.IsValid());
+}
+
+BOOST_AUTO_TEST_CASE(bls_final_commitment_strict_validation_tests)
+{
+    const auto& params = Params().GetConsensus().llmqs.at(Consensus::LLMQ_50_60);
+    const uint256 quorumHash = uint256S("01");
+    llmq::CFinalCommitment commitment(params, quorumHash);
+    for (int i = 0; i < params.minSize; ++i) {
+        commitment.signers[i] = true;
+        commitment.validMembers[i] = true;
+    }
+    commitment.quorumVvecHash = uint256S("02");
+
+    std::vector<CDeterministicMNCPtr> members;
+    members.reserve(params.minSize);
+    for (int i = 0; i < params.minSize; ++i) {
+        CBLSSecretKey memberKey;
+        memberKey.MakeNewKey();
+        auto state = std::make_shared<CDeterministicMNState>();
+        state->pubKeyOperator.Set(memberKey.GetPublicKey());
+        auto dmn = std::make_shared<CDeterministicMN>();
+        dmn->pdmnState = state;
+        members.emplace_back(std::move(dmn));
+    }
+
+    std::vector<uint8_t> g1Identity(BLS_CURVE_PUBKEY_SIZE, 0);
+    std::vector<uint8_t> g2Identity(BLS_CURVE_SIG_SIZE, 0);
+    g1Identity[0] = 0xc0;
+    g2Identity[0] = 0xc0;
+    commitment.quorumPublicKey = CBLSPublicKey(g1Identity);
+    commitment.quorumSig = CBLSSignature(g2Identity);
+    commitment.membersSig = CBLSSignature(g2Identity);
+    BOOST_CHECK(!commitment.IsNull());
+    BOOST_CHECK(commitment.Verify(members, false, false));
+    BOOST_CHECK(!commitment.Verify(members, false, true));
+
+    CBLSSecretKey validKey;
+    validKey.MakeNewKey();
+    const uint256 hash;
+    commitment.quorumPublicKey = validKey.GetPublicKey();
+    commitment.quorumSig = validKey.Sign(hash);
+    commitment.membersSig = validKey.Sign(hash);
+    auto oversizedMembers = members;
+    oversizedMembers.resize(params.size + 1, members.front());
+    BOOST_CHECK(!commitment.Verify(oversizedMembers, false, false));
+
+    auto invalidMemberState = std::make_shared<CDeterministicMNState>(*members[0]->pdmnState);
+    invalidMemberState->pubKeyOperator.Set(CBLSPublicKey(g1Identity));
+    auto invalidMember = std::make_shared<CDeterministicMN>(*members[0]);
+    invalidMember->pdmnState = invalidMemberState;
+    members[0] = invalidMember;
+    BOOST_CHECK(commitment.Verify(members, false, false));
+    BOOST_CHECK(!commitment.Verify(members, false, true));
 }
 
 BOOST_AUTO_TEST_CASE(bls_sig_tests)

--- a/src/test/bls_tests.cpp
+++ b/src/test/bls_tests.cpp
@@ -28,6 +28,39 @@ BOOST_AUTO_TEST_CASE(bls_sethexstr_tests)
     BOOST_CHECK(!sk.IsValid());
 }
 
+BOOST_AUTO_TEST_CASE(bls_reject_invalid_elements_tests)
+{
+    std::vector<uint8_t> g1Identity(BLS_CURVE_PUBKEY_SIZE, 0);
+    std::vector<uint8_t> g2Identity(BLS_CURVE_SIG_SIZE, 0);
+    g1Identity[0] = 0xc0;
+    g2Identity[0] = 0xc0;
+    const std::vector<uint8_t> g1OrderThree = ParseHex("800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+    const std::vector<uint8_t> mixedG1 = ParseHex("8e9277968cb92c78d15a2a2ed855d55061c3929db43d1e53d6d13bee755ff9a91b3f577bbb2f15c6ba8206a6a81c4afd");
+    const std::vector<uint8_t> invalidG1 = ParseHex("11df3a748b713460f9b21083315c0dca1742b7962ca98685be4094d302e84b0884a04c1a55beb0ed921dae1dd66c0a11");
+    const std::vector<uint8_t> invalidG2 = ParseHex("0888879c99852460912fd28c7a9138926c1e87fd6609fd2d3d307764e49feb85702fd8f9b3b836bc11f7ce151b769dc70b760879d26f8c33a29e24f69297f45ef028f0794e63ddb0610db7de1a608b6d6a2129ada62b845004a408f651fd44a6");
+    const std::vector<uint8_t> secretKeyGroupOrder = ParseHex("73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001");
+    const std::vector<uint8_t> secretKeyGroupOrderPlusOne = ParseHex("73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000002");
+
+    BOOST_CHECK(!CBLSPublicKey(g1Identity).IsValid());
+    BOOST_CHECK(!CBLSSignature(g2Identity).IsValid());
+    BOOST_CHECK(!CBLSPublicKey(g1OrderThree).IsValid());
+    BOOST_CHECK(!CBLSPublicKey(mixedG1).IsValid());
+    BOOST_CHECK(!CBLSPublicKey(invalidG1).IsValid());
+    BOOST_CHECK(!CBLSSignature(invalidG2).IsValid());
+    BOOST_CHECK(!CBLSSecretKey(secretKeyGroupOrder).IsValid());
+    BOOST_CHECK(!CBLSSecretKey(secretKeyGroupOrder, false).IsValid());
+    BOOST_CHECK(!CBLSSecretKey(secretKeyGroupOrderPlusOne).IsValid());
+
+    CBLSSecretKey sk;
+    sk.MakeNewKey();
+    const uint256 msgHash = uint256S("0000000000000000000000000000000000000000000000000000000000000001");
+    const CBLSPublicKey pubKey(sk.GetPublicKey().ToByteVector());
+    const CBLSSignature sig(sk.Sign(msgHash).ToByteVector());
+    BOOST_CHECK(pubKey.IsValid());
+    BOOST_CHECK(sig.IsValid());
+    BOOST_CHECK(sig.VerifyInsecure(pubKey, msgHash));
+}
+
 BOOST_AUTO_TEST_CASE(bls_sig_tests)
 {
     CBLSSecretKey sk1, sk2;

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -425,14 +425,14 @@ BOOST_FIXTURE_TEST_CASE(bls_strict_validation_activation, TestChainDIP3Setup)
     BOOST_CHECK(!dmn->pdmnState->pubKeyOperator.Get().IsValid());
     BOOST_CHECK_EQUAL(dmn->pdmnState->nPoSeBanHeight, -1);
 
+    CValidationState reconnectState;
     {
-        CValidationState reconnectState;
         LOCK(cs_main);
         const auto it = mapBlockIndex.find(activationBlockHash);
         BOOST_REQUIRE(it != mapBlockIndex.end());
         BOOST_REQUIRE(ResetBlockFailureFlags(it->second));
-        BOOST_REQUIRE(ActivateBestChain(reconnectState, Params()));
     }
+    BOOST_REQUIRE(ActivateBestChain(reconnectState, Params()));
     deterministicMNManager->UpdatedBlockTip(chainActive.Tip());
     BOOST_REQUIRE_EQUAL(chainActive.Height(), activationHeight);
     dmn = deterministicMNManager->GetListAtChainTip().GetMN(proTxHash);

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -9,6 +9,7 @@
 #include "script/sign.h"
 #include "validation.h"
 #include "base58.h"
+#include "chainparams.h"
 #include "netbase.h"
 #include "messagesigner.h"
 #include "keystore.h"
@@ -366,6 +367,78 @@ BOOST_FIXTURE_TEST_CASE(dip3_activation, TestChainDIP3BeforeActivationSetup)
     BOOST_ASSERT(chainActive.Height() == nHeight + 2);
     BOOST_ASSERT(block->GetHash() == chainActive.Tip()->GetBlockHash());
     BOOST_ASSERT(deterministicMNManager->GetListAtChainTip().HasMN(tx.GetHash()));
+}
+
+BOOST_FIXTURE_TEST_CASE(bls_strict_validation_activation, TestChainDIP3Setup)
+{
+    struct ResetActivationHeight {
+        int height;
+        ~ResetActivationHeight()
+        {
+            UpdateRegtestBLSStrictValidationHeight(height);
+        }
+    } resetActivationHeight{Params().GetConsensus().nBLSStrictValidationStartBlock};
+
+    auto utxos = BuildSimpleUtxoMap(coinbaseTxns);
+    CKey ownerKey;
+    CBLSSecretKey operatorKey;
+    CMutableTransaction tx = CreateProRegTx(utxos, 1, GenerateRandomAddress(), coinbaseKey, ownerKey, operatorKey);
+
+    CProRegTx proTx;
+    BOOST_REQUIRE(GetTxPayload(CTransaction(tx), proTx));
+    std::vector<uint8_t> identity(BLS_CURVE_PUBKEY_SIZE, 0);
+    identity[0] = 0xc0;
+    proTx.pubKeyOperator = CBLSPublicKey(identity);
+    BOOST_REQUIRE(proTx.pubKeyOperator.IsValid(false));
+    BOOST_REQUIRE(!proTx.pubKeyOperator.IsValid());
+    SetTxPayload(tx, proTx);
+    SignTransaction(tx, coinbaseKey);
+
+    const int activationHeight = chainActive.Height() + 2;
+    UpdateRegtestBLSStrictValidationHeight(activationHeight);
+
+    CValidationState historicalState;
+    BOOST_CHECK(CheckProRegTx(CTransaction(tx), chainActive.Tip(), historicalState));
+
+    const uint256 proTxHash = tx.GetHash();
+    ProcessBlockAndUpdateMNManager(*this, {tx}, coinbaseKey);
+    BOOST_REQUIRE_EQUAL(chainActive.Height(), activationHeight - 1);
+    BOOST_REQUIRE(deterministicMNManager->GetListAtChainTip().HasMN(proTxHash));
+
+    CValidationState activeState;
+    BOOST_CHECK(!CheckProRegTx(CTransaction(tx), chainActive.Tip(), activeState));
+    BOOST_CHECK_EQUAL(activeState.GetRejectReason(), "bad-protx-key-null");
+
+    ProcessBlockAndUpdateMNManager(*this, {}, coinbaseKey);
+    BOOST_REQUIRE_EQUAL(chainActive.Height(), activationHeight);
+    const uint256 activationBlockHash = chainActive.Tip()->GetBlockHash();
+    auto dmn = deterministicMNManager->GetListAtChainTip().GetMN(proTxHash);
+    BOOST_REQUIRE(dmn);
+    BOOST_CHECK(!dmn->pdmnState->pubKeyOperator.Get().IsValid(false));
+    BOOST_CHECK_EQUAL(dmn->pdmnState->nPoSeBanHeight, activationHeight);
+
+    InvalidateBlockAndUpdateMNManager(activationBlockHash);
+    BOOST_REQUIRE_EQUAL(chainActive.Height(), activationHeight - 1);
+    dmn = deterministicMNManager->GetListAtChainTip().GetMN(proTxHash);
+    BOOST_REQUIRE(dmn);
+    BOOST_CHECK(dmn->pdmnState->pubKeyOperator.Get().IsValid(false));
+    BOOST_CHECK(!dmn->pdmnState->pubKeyOperator.Get().IsValid());
+    BOOST_CHECK_EQUAL(dmn->pdmnState->nPoSeBanHeight, -1);
+
+    {
+        CValidationState reconnectState;
+        LOCK(cs_main);
+        const auto it = mapBlockIndex.find(activationBlockHash);
+        BOOST_REQUIRE(it != mapBlockIndex.end());
+        BOOST_REQUIRE(ResetBlockFailureFlags(it->second));
+        BOOST_REQUIRE(ActivateBestChain(reconnectState, Params()));
+    }
+    deterministicMNManager->UpdatedBlockTip(chainActive.Tip());
+    BOOST_REQUIRE_EQUAL(chainActive.Height(), activationHeight);
+    dmn = deterministicMNManager->GetListAtChainTip().GetMN(proTxHash);
+    BOOST_REQUIRE(dmn);
+    BOOST_CHECK(!dmn->pdmnState->pubKeyOperator.Get().IsValid(false));
+    BOOST_CHECK_EQUAL(dmn->pdmnState->nPoSeBanHeight, activationHeight);
 }
 
 BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChainDIP3Setup)


### PR DESCRIPTION
## Summary

- Reject BLS identity and non-prime-order public keys/signatures after a height-gated consensus activation.
- Preserve permissive historical deserialization so pre-activation blocks and EvoDB state remain replayable.
- At activation, clear malformed operator keys and PoSe-ban the affected masternodes; normal diff/undo handling makes the migration reorg-safe.
- Enforce canonical secret scalars (`0 < sk < r`), backport the two required RELIC fixes, fail startup if an external BLS library lacks the required behavior, and reject oversized DKG messages before expensive decoding.

## Activation

`nBLSStrictValidationStartBlock` gates provider operator keys/signatures and non-null final commitments. The public-network values are intentionally `INT_MAX` until the coordinated hard-fork heights are selected; setting them later is a chain-parameter-only change. Regtest activates at height 2700 and exposes a setter for boundary tests.

Before activation, malformed canonical encodings are retained and legacy validation semantics are used. At and after activation, ProReg/ProUpReg keys, ProUpServ/ProUpRev signatures, quorum keys/signatures, and participating member keys must be non-identity prime-subgroup elements. Runtime-only BLS paths (MNAUTH, DKG, recovered signatures, ChainLocks, and InstantSend) remain strict immediately.

## Cryptographic fix

Legacy BLS deserialization skips subgroup validation. The wrapper now separates parse validity from strict cryptographic validity, allowing height-aware historical replay while making strict validation the default everywhere else.

The RELIC revision is deliberately not bumped: moving from the pinned revision to `3429421e` imports 235 commits across 241 files. Instead, this backports upstream `c7177c87` (the required x=0 doubling correction) followed by `3429421e` (the corrected BLS12 G1 subgroup predicate). Applying the latter alone falsely accepts the canonical order-3 point on the pinned revision.

## Validation

- Added vectors for G1/G2 identity, order-3 torsion, mixed prime/torsion G1, on-curve non-subgroup G2, invalid points, scalar `r`, and `r+1`.
- Added permissive-vs-strict verification, hex-setter reset, arithmetic-created identity, final-commitment, oversized-member, activation H-1/H, migration, disconnect, and reconnect tests.
- Fresh depends-style BLS 1.1.0 build: **902 assertions in 15 upstream test cases passed**.
- Focused wrapper, identity-verification, arithmetic-cancellation, and hex-setter harnesses passed; direct `src/bls/bls.cpp` syntax compilation and `git diff --check` passed.
- Canonical-chain scan from DIP3 activation (height 278,300) through height 1,362,314 / `859274ff48807773f745c277afab186a3b16f30203ae12cfa921ee42c4c8ba1e`: 1,084,015 blocks, 2,765,433 transactions, and 277,890 non-null on-chain BLS fields checked with the final subgroup predicate; **0 identity, noncanonical, decode, or subgroup failures**.
- Current snapshot: all 6,416 eligible operator keys and 24 active quorum keys were strict-valid.
