### PR TITLE
Spark: synchronize minted coin state

### DIFF
--- a/qa/rpc-tests/wallet-encryption.py
+++ b/qa/rpc-tests/wallet-encryption.py
@@ -64,6 +64,11 @@ class WalletEncryptionTest(BitcoinTestFramework):
         assert_raises_jsonrpc(-1, "walletpassphrasechange <oldpassphrase> <newpassphrase>\nChanges the wallet passphrase from <oldpassphrase> to <newpassphrase>.",
             self.nodes[0].walletpassphrasechange, '', 'ff')
 
+        # Check that a negative timeout is rejected without unlocking the wallet
+        assert_raises_jsonrpc(-8, "Timeout cannot be negative.", self.nodes[0].walletpassphrase, passphrase, -10)
+        otp = self.get_otp(address)
+        assert_raises_jsonrpc(-13, "Please enter the wallet passphrase with walletpassphrase first", self.nodes[0].dumpprivkey, address, otp)
+
         # Check that walletpassphrase works
         self.nodes[0].walletpassphrase(passphrase, 2)
         otp = self.get_otp(address)

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -34,7 +34,11 @@ static std::string rpcWarmupStatus("RPC server started");
 static CCriticalSection cs_rpcWarmup;
 /* Timer-creating functions */
 static RPCTimerInterface* timerInterface = NULL;
-/* Map of name to timer. */
+/* Map of name to timer, and the lock protecting it. Callers may run on any of
+ * the RPC worker threads, so every access has to be serialized. The lock is
+ * held while a timer is destroyed, which blocks until a running timer callback
+ * has returned, so no timer callback may acquire it. */
+static CCriticalSection cs_deadlineTimers;
 static std::map<std::string, std::unique_ptr<RPCTimerBase> > deadlineTimers;
 
 static struct CRPCSignals
@@ -408,7 +412,10 @@ void InterruptRPC()
 void StopRPC()
 {
     LogPrint("rpc", "Stopping RPC\n");
-    deadlineTimers.clear();
+    {
+        LOCK(cs_deadlineTimers);
+        deadlineTimers.clear();
+    }
     DeleteAuthCookie();
     g_rpcSignals.Stopped();
 }
@@ -618,6 +625,7 @@ void RPCRunLater(const std::string& name, boost::function<void(void)> func, int6
 {
     if (!timerInterface)
         throw JSONRPCError(RPC_INTERNAL_ERROR, "No timer handler registered for RPC");
+    LOCK(cs_deadlineTimers);
     deadlineTimers.erase(name);
     LogPrint("rpc", "queue run of timer %s in %i seconds (using %s)\n", name, nSeconds, timerInterface->Name());
     deadlineTimers.emplace(name, std::unique_ptr<RPCTimerBase>(timerInterface->NewTimer(func, nSeconds*1000)));

--- a/src/spark/state.cpp
+++ b/src/spark/state.cpp
@@ -1103,7 +1103,10 @@ void CSparkState::Reset() {
     ShutdownWallet();
     coinGroups.clear();
     latestCoinId = 0;
-    mintedCoins.clear();
+    {
+        LOCK(cs_minted_coins);
+        mintedCoins.clear();
+    }
     usedLTags.clear();
     mobileUsedLTags.clear();
     mintMetaInfo.clear();
@@ -1111,6 +1114,7 @@ void CSparkState::Reset() {
 }
 
 std::pair<int, int> CSparkState::GetMintedCoinHeightAndId(const spark::Coin& coin) {
+    LOCK(cs_minted_coins);
     auto coinIt = mintedCoins.find(coin);
 
     if (coinIt != mintedCoins.end()) {
@@ -1120,11 +1124,13 @@ std::pair<int, int> CSparkState::GetMintedCoinHeightAndId(const spark::Coin& coi
 }
 
 bool CSparkState::HasCoin(const spark::Coin& coin) {
+    LOCK(cs_minted_coins);
     return mintedCoins.find(coin) != mintedCoins.end();
 
 }
 
 bool CSparkState::HasCoinHash(spark::Coin& coin, const uint256& coinHash) {
+    LOCK(cs_minted_coins);
     for (auto it = mintedCoins.begin(); it != mintedCoins.end(); ++it ){
         const spark::Coin& coin_ = (*it).first;
         if (primitives::GetSparkCoinHash(coin_) == coinHash) {
@@ -1175,11 +1181,13 @@ bool CSparkState::CanAddMintToMempool(const spark::Coin& coin){
 }
 
 void CSparkState::AddMint(const spark::Coin& coin, const CMintedCoinInfo& coinInfo) {
+    LOCK(cs_minted_coins);
     mintedCoins.insert(std::make_pair(coin, coinInfo));
     mintMetaInfo[coinInfo.coinGroupId] += 1;
 }
 
 void CSparkState::RemoveMint(const spark::Coin& coin) {
+    LOCK(cs_minted_coins);
     auto iter = mintedCoins.find(coin);
     if (iter != mintedCoins.end()) {
         mintMetaInfo[iter->second.coinGroupId] -= 1;
@@ -1354,14 +1362,8 @@ void CSparkState::RemoveBlock(CBlockIndex *index) {
     // roll back mints
     for (auto const&coins : index->sparkMintedCoins) {
         for (auto const& coin : coins.second) {
-            auto mintCoins = GetMints().equal_range(coin);
-            auto coinIt = find_if(
-                    mintCoins.first, mintCoins.second,
-                    [&coins](const std::unordered_map<spark::Coin, CMintedCoinInfo, spark::CoinHash>::value_type& v) {
-                        return v.second.coinGroupId == coins.first;
-                    });
-            assert(coinIt != mintCoins.second);
-            RemoveMint(coinIt->first);
+            assert(GetMintedCoinHeightAndId(coin).second == coins.first);
+            RemoveMint(coin);
         }
     }
 
@@ -1632,9 +1634,16 @@ void CSparkState::GetCoinsForRecovery(
     }
 }
 
-std::unordered_map<spark::Coin, CMintedCoinInfo, spark::CoinHash> const & CSparkState::GetMints() const {
+std::unordered_map<spark::Coin, CMintedCoinInfo, spark::CoinHash> CSparkState::GetMints() const {
+    LOCK(cs_minted_coins);
     return mintedCoins;
 }
+
+std::size_t CSparkState::GetTotalCoins() const {
+    LOCK(cs_minted_coins);
+    return mintedCoins.size();
+}
+
 std::unordered_map<GroupElement, int, spark::CLTagHash> const & CSparkState::GetSpends() const {
     return usedLTags;
 }

--- a/src/spark/state.cpp
+++ b/src/spark/state.cpp
@@ -1183,16 +1183,31 @@ bool CSparkState::CanAddMintToMempool(const spark::Coin& coin){
 void CSparkState::AddMint(const spark::Coin& coin, const CMintedCoinInfo& coinInfo) {
     LOCK(cs_minted_coins);
     mintedCoins.insert(std::make_pair(coin, coinInfo));
+    // Count indexed occurrences, including legacy duplicates that do not enter
+    // the unique mintedCoins map.
     mintMetaInfo[coinInfo.coinGroupId] += 1;
 }
 
-void CSparkState::RemoveMint(const spark::Coin& coin) {
+bool CSparkState::RemoveMint(
+        const spark::Coin& coin,
+        int expectedGroupId,
+        int expectedHeight) {
     LOCK(cs_minted_coins);
-    auto iter = mintedCoins.find(coin);
-    if (iter != mintedCoins.end()) {
-        mintMetaInfo[iter->second.coinGroupId] -= 1;
-        mintedCoins.erase(iter);
+
+    auto metaIt = mintMetaInfo.find(expectedGroupId);
+    if (metaIt != mintMetaInfo.end() && metaIt->second > 0) {
+        --metaIt->second;
     }
+
+    auto iter = mintedCoins.find(coin);
+    if (iter == mintedCoins.end() ||
+            iter->second.coinGroupId != expectedGroupId ||
+            iter->second.nHeight != expectedHeight) {
+        return false;
+    }
+
+    mintedCoins.erase(iter);
+    return true;
 }
 
 void CSparkState::AddMintsToStateAndBlockIndex(
@@ -1362,8 +1377,7 @@ void CSparkState::RemoveBlock(CBlockIndex *index) {
     // roll back mints
     for (auto const&coins : index->sparkMintedCoins) {
         for (auto const& coin : coins.second) {
-            assert(GetMintedCoinHeightAndId(coin).second == coins.first);
-            RemoveMint(coin);
+            RemoveMint(coin, coins.first, index->nHeight);
         }
     }
 

--- a/src/spark/state.h
+++ b/src/spark/state.h
@@ -10,6 +10,7 @@
 #include "../wallet/wallet.h"
 #include "../libspark/mint_transaction.h"
 #include "../libspark/spend_transaction.h"
+#include "../sync.h"
 #include "primitives.h"
 #include "sparkname.h"
 
@@ -237,7 +238,7 @@ public:
             uint256& blockHash,
             std::vector<std::pair<spark::Coin, std::pair<uint256, std::vector<unsigned char>>>>& coins);
 
-    std::unordered_map<spark::Coin, CMintedCoinInfo, spark::CoinHash> const & GetMints() const;
+    std::unordered_map<spark::Coin, CMintedCoinInfo, spark::CoinHash> GetMints() const;
     std::unordered_map<GroupElement, int, spark::CLTagHash> const & GetSpends() const;
     std::vector<std::pair<GroupElement, int>> const & GetSpendsMobile() const;
     std::unordered_map<uint256, uint256> const& GetSpendTxIds() const;
@@ -246,7 +247,7 @@ public:
 
     static CSparkState* GetState();
 
-    std::size_t GetTotalCoins() const { return mintedCoins.size(); }
+    std::size_t GetTotalCoins() const;
 
 private:
     size_t CountLastNCoins(int groupId, size_t required, CBlockIndex* &first);
@@ -263,7 +264,8 @@ private:
     std::unordered_map<int, SparkCoinGroupInfo> coinGroups;
 
     // Set of all minted coins
-    std::unordered_map<spark::Coin, CMintedCoinInfo, spark::CoinHash> mintedCoins;
+    mutable CCriticalSection cs_minted_coins;
+    std::unordered_map<spark::Coin, CMintedCoinInfo, spark::CoinHash> mintedCoins GUARDED_BY(cs_minted_coins);
     // Set of all used coin linking tags.
     std::unordered_map<GroupElement, int, spark::CLTagHash> usedLTags;
     // Set of all used linking tags, used only when -mobile=true

--- a/src/spark/state.h
+++ b/src/spark/state.h
@@ -172,7 +172,7 @@ public:
     bool CanAddMintToMempool(const spark::Coin& coin);
 
     void AddMint(const spark::Coin& coin, const CMintedCoinInfo& coinInfo);
-    void RemoveMint(const spark::Coin& coin);
+    bool RemoveMint(const spark::Coin& coin, int expectedGroupId, int expectedHeight);
     // Add mints in block, automatically assigning id to it
     void AddMintsToStateAndBlockIndex(CBlockIndex *index, const CBlock* pblock);
 

--- a/src/test/spark_state_test.cpp
+++ b/src/test/spark_state_test.cpp
@@ -325,6 +325,49 @@ BOOST_AUTO_TEST_CASE(add_remove_block)
     sparkState->Reset();
 }
 
+BOOST_AUTO_TEST_CASE(remove_block_preserves_legacy_duplicate_mint)
+{
+    GenerateBlocks(500);
+
+    std::vector<CMutableTransaction> txs;
+    const auto mint = GenerateMints({1 * COIN}, txs)[0];
+    const auto coin = pwalletMain->sparkWallet->getCoinFromMeta(mint);
+
+    const auto checkDuplicate = [&](size_t maxCoinInGroup, int duplicateGroupId) {
+        spark::CSparkState state(maxCoinInGroup, 1);
+
+        CBlock firstBlock;
+        PopulateSparkTxInfo(firstBlock, {coin}, {});
+        CBlockIndex firstIndex;
+        firstIndex.pprev = chainActive.Tip();
+        firstIndex.nHeight = chainActive.Height() + 1;
+        state.AddMintsToStateAndBlockIndex(&firstIndex, &firstBlock);
+
+        CBlock duplicateBlock;
+        PopulateSparkTxInfo(duplicateBlock, {coin}, {});
+        CBlockIndex duplicateIndex;
+        duplicateIndex.pprev = &firstIndex;
+        duplicateIndex.nHeight = firstIndex.nHeight + 1;
+        state.AddMintsToStateAndBlockIndex(&duplicateIndex, &duplicateBlock);
+
+        BOOST_REQUIRE_EQUAL(state.GetTotalCoins(), 1U);
+        BOOST_REQUIRE_EQUAL(
+            duplicateIndex.sparkMintedCoins.at(duplicateGroupId).size(), 1U);
+
+        state.RemoveBlock(&duplicateIndex);
+        BOOST_CHECK(
+            state.GetMintedCoinHeightAndId(coin) ==
+            std::make_pair(firstIndex.nHeight, 1));
+
+        state.RemoveBlock(&firstIndex);
+        BOOST_CHECK_EQUAL(state.GetTotalCoins(), 0U);
+    };
+
+    // Exercise duplicates in both the same group and a later group.
+    checkDuplicate(10, 1);
+    checkDuplicate(1, 2);
+}
+
 BOOST_AUTO_TEST_CASE(get_coin_group)
 {
     GenerateBlocks(500);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2974,9 +2974,14 @@ UniValue keypoolrefill(const JSONRPCRequest& request)
 }
 
 
-static void LockWallet(CWallet* pWallet)
+static void LockWallet(CWallet* pWallet, int64_t nRelockTime)
 {
     LOCK(pWallet->cs_wallet);
+    // Skip if this is not the most recent relock callback. walletpassphrase()
+    // may have been called again in the meantime (extending the timeout), or
+    // walletlock() may have already locked the wallet and reset nRelockTime.
+    if (pWallet->nRelockTime != nRelockTime)
+        return;
     pWallet->nRelockTime = 0;
     pWallet->Lock();
 }
@@ -3009,37 +3014,75 @@ UniValue walletpassphrase(const JSONRPCRequest& request)
         );
     }
 
-    LOCK2(cs_main, pwallet->cs_wallet);
+    // Prevent concurrent walletpassphrase calls for the same wallet. Without
+    // this, two overlapping calls can update nRelockTime and schedule the
+    // relock timer in opposite orders, so the slower call installs the last
+    // timer while the faster call owns nRelockTime. The stale callback then
+    // does nothing (see LockWallet) and no timer is left, i.e. the wallet stays
+    // unlocked past the requested timeout.
+    //
+    // This has to be a separate lock rather than cs_wallet, because it is held
+    // across RPCRunLater() below, which blocks on the relock callback, which in
+    // turn takes cs_wallet.
+    LOCK(pwallet->cs_unlock);
 
-    if (request.fHelp)
-        return true;
-    if (!pwallet->IsCrypted()) {
-        throw JSONRPCError(RPC_WALLET_WRONG_ENC_STATE, "Error: running with an unencrypted wallet, but walletpassphrase was called.");
-    }
-
-    // Note that the walletpassphrase is stored in request.params[0] which is not mlock()ed
-    SecureString strWalletPass;
-    strWalletPass.reserve(100);
-    // TODO: get rid of this .c_str() by implementing SecureString::operator=(std::string)
-    // Alternately, find a way to make request.params[0] mlock()'d to begin with.
-    strWalletPass = request.params[0].get_str().c_str();
-
-    if (strWalletPass.length() > 0)
+    int64_t nSleepTime;
+    int64_t nRelockTime;
     {
-        if (!pwallet->Unlock(strWalletPass)) {
-            throw JSONRPCError(RPC_WALLET_PASSPHRASE_INCORRECT, "Error: The wallet passphrase entered was incorrect.");
+        LOCK2(cs_main, pwallet->cs_wallet);
+
+        if (request.fHelp)
+            return true;
+        if (!pwallet->IsCrypted()) {
+            throw JSONRPCError(RPC_WALLET_WRONG_ENC_STATE, "Error: running with an unencrypted wallet, but walletpassphrase was called.");
         }
+
+        // Note that the walletpassphrase is stored in request.params[0] which is not mlock()ed
+        SecureString strWalletPass;
+        strWalletPass.reserve(100);
+        // TODO: get rid of this .c_str() by implementing SecureString::operator=(std::string)
+        // Alternately, find a way to make request.params[0] mlock()'d to begin with.
+        strWalletPass = request.params[0].get_str().c_str();
+
+        nSleepTime = request.params[1].get_int64();
+        // Timeout cannot be negative, otherwise it will relock immediately
+        if (nSleepTime < 0) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Timeout cannot be negative.");
+        }
+        // Clamp the timeout so GetTime() + nSleepTime cannot overflow
+        // nRelockTime (same bound as upstream Bitcoin Core's MAX_SLEEP_TIME)
+        constexpr int64_t MAX_SLEEP_TIME = 100000000;
+        if (nSleepTime > MAX_SLEEP_TIME) {
+            nSleepTime = MAX_SLEEP_TIME;
+        }
+
+        if (strWalletPass.length() > 0)
+        {
+            if (!pwallet->Unlock(strWalletPass)) {
+                throw JSONRPCError(RPC_WALLET_PASSPHRASE_INCORRECT, "Error: The wallet passphrase entered was incorrect.");
+            }
+        }
+        else
+            throw std::runtime_error(
+                "walletpassphrase <passphrase> <timeout>\n"
+                "Stores the wallet decryption key in memory for <timeout> seconds.");
+
+        pwallet->TopUpKeyPool();
+
+        pwallet->nRelockTime = GetTime() + nSleepTime;
+        nRelockTime = pwallet->nRelockTime;
     }
-    else
-        throw std::runtime_error(
-            "walletpassphrase <passphrase> <timeout>\n"
-            "Stores the wallet decryption key in memory for <timeout> seconds.");
 
-    pwallet->TopUpKeyPool();
-
-    int64_t nSleepTime = request.params[1].get_int64();
-    pwallet->nRelockTime = GetTime() + nSleepTime;
-    RPCRunLater(strprintf("lockwallet(%s)", pwallet->strWalletFile), boost::bind(LockWallet, pwallet), nSleepTime);
+    // Schedule the relock *after* releasing cs_wallet, but still under cs_unlock.
+    // RPCRunLater() erases any previously scheduled lockwallet timer, and
+    // destroying a libevent timer blocks until that timer's callback has finished
+    // executing. When the callback (LockWallet) happens to be running at that
+    // moment it is itself waiting for cs_wallet, so holding the lock across this
+    // call deadlocks the RPC worker against the HTTP event loop thread. Because
+    // the RPC worker also holds cs_main, every other thread that needs cs_main
+    // then piles up behind it and the whole node stops making progress.
+    AssertLockNotHeld(pwallet->cs_wallet);
+    RPCRunLater(strprintf("lockwallet(%s)", pwallet->strWalletFile), boost::bind(LockWallet, pwallet, nRelockTime), nSleepTime);
 
     return NullUniValue;
 }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -729,6 +729,17 @@ public:
      */
     mutable CCriticalSection cs_wallet;
 
+    /*
+     * Serializes the walletpassphrase RPC for this wallet, so that unlocking
+     * the wallet and scheduling the matching relock timer happen atomically
+     * with respect to other walletpassphrase calls.
+     *
+     * This must never be acquired while cs_wallet is held: it is held across
+     * RPCRunLater(), which blocks until a running relock callback has returned,
+     * and that callback acquires cs_wallet.
+     */
+    CCriticalSection cs_unlock;
+
     const std::string strWalletFile;
 
     void LoadKeyPool(int nIndex, const CKeyPool &keypool)


### PR DESCRIPTION
## Relationship and review order

This is the first of two related PRs:

1. Review, approve, and squash-merge **#1910 first**. It is the foundational Spark minted-state synchronization and rollback-safe duplicate-mint fix.
2. #1911 is now intentionally stacked on this exact branch. Its **Files changed** view contains only the follow-up hash-index/RPC delta, with the duplicated synchronization and rollback changes removed. It remains draft and must not be merged into this feature branch.
3. After #1910 lands, #1911 will be retargeted to `master`, its single follow-up commit rebased onto the squash result, and fresh CI run.
4. Review and approve #1911 only on that final master-based head.

## PR intention

Prevent asynchronous Spark wallet mint recognition from reading `CSparkState::mintedCoins` while validation concurrently inserts or erases entries during block connection and disconnection.

The unlocked `std::unordered_map` access is undefined behavior and can crash a wallet-enabled node. This uses a dedicated Spark-state mutex instead of taking `cs_main` from the wallet worker: that worker already holds `cs_spark_wallet`, while disconnect follows `cs_main -> cs_spark_wallet`, so adding the reverse edge would introduce a deadlock risk.

## Code changes brief

- Guard every direct `mintedCoins` clear, lookup, iteration, insertion, erasure, and size query with a short-lived `cs_minted_coins` lock.
- Return a locked snapshot from `GetMints()` instead of exposing a reference to mutable map storage.
- Make block disconnect match a mint's expected group and height in the same critical section as removal.
- Preserve an older stored occurrence when disconnecting a legacy duplicate, while still decrementing the disconnected occurrence's metadata.
- Leave wallet scheduling and validation lock ordering unchanged.

This does not change Spark consensus rules or wallet ownership checks.

## Validation

- The branch contains two focused commits and changes only `src/spark/state.cpp`, `src/spark/state.h`, and `src/test/spark_state_test.cpp`.
- `git diff --check` passes.
- Added a regression test covering later duplicates in both the same group and a later group.
- Audited every direct `mintedCoins` access and the resulting lock graph.
- Exact-head GitHub Actions and Jenkins checks pass.

A dedicated ThreadSanitizer stress test remains useful follow-up coverage. PR #1902 must retain the same group-and-height-aware legacy rollback semantics when rebased.