### PR TITLE
RPC: Harden Spark mint metadata lookup

### DIFF
--- a/qa/rpc-tests/spark_mint.py
+++ b/qa/rpc-tests/spark_mint.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, assert_raises_message, JSONRPCException
+from test_framework.util import assert_equal, assert_raises_jsonrpc, assert_raises_message, JSONRPCException
 
 class SparkMintTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -8,6 +8,19 @@ class SparkMintTest(BitcoinTestFramework):
         self.setup_clean_chain = True
 
     def run_test(self):
+        get_metadata = self.nodes[0].getsparkmintmetadata
+        assert_equal([], get_metadata({"coinHashes": []}))
+        assert_equal([], get_metadata({"coinHashes": [f"{i:064x}" for i in range(1000)]}))
+        assert_raises_jsonrpc(
+            -8,
+            "coinHashes must contain no more than 1000 entries",
+            get_metadata,
+            {"coinHashes": [f"{i:064x}" for i in range(1001)]})
+        assert_raises_jsonrpc(-8, "must be of length 64", get_metadata, {"coinHashes": ["0"]})
+        assert_raises_jsonrpc(-8, "must be hexadecimal", get_metadata, {"coinHashes": ["z" * 64]})
+        assert_raises_jsonrpc(-8, "must be hexadecimal", get_metadata, {"coinHashes": [1]})
+        assert_raises_jsonrpc(-8, "coinHashes is expected to be an array", get_metadata, {"coinHashes": "0" * 64})
+
         assert_raises_message(
             JSONRPCException,
             "Spark is not activated yet",
@@ -30,8 +43,15 @@ class SparkMintTest(BitcoinTestFramework):
 
         # get all mints and utxos
         mints = self.verify_listsparkmints(amounts)
-        self.verify_listunspentsparkmints(amounts)
+        unspent_mints = self.verify_listunspentsparkmints(amounts)
         assert_equal([False, False, False, False], list(map(lambda m : m["isUsed"], mints)))
+
+        expected_metadata = [{str(mint["nHeight"]): mint["nId"]} for mint in mints]
+        mint_hashes = [mint["coin"] for mint in unspent_mints]
+        assert_equal(expected_metadata, get_metadata({"coinHashes": mint_hashes}))
+        assert_equal(
+            [expected_metadata[0], expected_metadata[0]],
+            get_metadata({"coinHashes": [mint_hashes[0], mint_hashes[0]]}))
 
         # state modification test
         # mark two coins as used

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -1296,24 +1296,24 @@ UniValue getsparkanonymitysetsector(const JSONRPCRequest& request)
     return ret;
 }
 
+static constexpr size_t MAX_SPARK_MINT_METADATA_REQUEST_SIZE = 1000;
+
 UniValue getsparkmintmetadata(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 1)
         throw std::runtime_error(
-                "getmintmetadata\n"
+                "getsparkmintmetadata\n"
                 "\nReturns the anonymity set id and nHeight of mint.\n"
                 "\nArguments:\n"
-                "  \"coinHashes\"\n"
+                "  \"coinHashes\" (array, max 1000)\n"
                 "    [\n"
-                "      {\n"
-                "        \"coinHash\" (string) The hash of the spark mint\n"
-                "      }\n"
+                "      \"coinHash\" (string) The 64-character hash of the Spark mint\n"
                 "      ,...\n"
                 "    ]\n"
                 "\nResult:\n"
-                "{\n"
-                "  \"metadata\"   (Pair<string,int>) nHeight and id for each coin\n"
-                "}\n"
+                "[\n"
+                "  { \"height\": coinGroupId }, ...\n"
+                "]\n"
                 + HelpExampleCli("getsparkmintmetadata", "'{\"coinHashes\": [\"b476ed2b374bb081ea51d111f68f0136252521214e213d119b8dc67b92f5a390\",\"b476ed2b374bb081ea51d111f68f0136252521214e213d119b8dc67b92f5a390\"]}'")
                 + HelpExampleRpc("getsparkmintmetadata", "{\"coinHashes\": [\"b476ed2b374bb081ea51d111f68f0136252521214e213d119b8dc67b92f5a390\",\"b476ed2b374bb081ea51d111f68f0136252521214e213d119b8dc67b92f5a390\"]}")
 
@@ -1321,24 +1321,39 @@ UniValue getsparkmintmetadata(const JSONRPCRequest& request)
 
     UniValue coinHashes = find_value(request.params[0].get_obj(), "coinHashes");
     if (!coinHashes.isArray()) {
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "mints is expected to be an array");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "coinHashes is expected to be an array");
     }
 
-    spark::CSparkState* sparkState =  spark::CSparkState::GetState();
+    const auto& coinHashValues = coinHashes.getValues();
+    if (coinHashValues.size() > MAX_SPARK_MINT_METADATA_REQUEST_SIZE) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER,
+                strprintf("coinHashes must contain no more than %u entries",
+                        static_cast<unsigned int>(MAX_SPARK_MINT_METADATA_REQUEST_SIZE)));
+    }
+
+    std::vector<uint256> parsedCoinHashes;
+    parsedCoinHashes.reserve(coinHashValues.size());
+    for (size_t i = 0; i < coinHashValues.size(); ++i) {
+        parsedCoinHashes.push_back(ParseHashV(
+                coinHashValues[i], strprintf("coinHashes[%u]", static_cast<unsigned int>(i))));
+    }
+
+    spark::CSparkState* sparkState = spark::CSparkState::GetState();
+    std::vector<std::pair<int, int>> matchingMetadata;
+    matchingMetadata.reserve(parsedCoinHashes.size());
+
+    {
+        LOCK(cs_main);
+        for (const auto& coinHash : parsedCoinHashes) {
+            std::pair<int, int> coinHeightAndId;
+            if (sparkState->GetMintedCoinHeightAndId(coinHash, coinHeightAndId)) {
+                matchingMetadata.push_back(coinHeightAndId);
+            }
+        }
+    }
 
     UniValue ret(UniValue::VARR);
-    for(UniValue const & element : coinHashes.getValues()) {
-        uint256 coinHash;
-        coinHash.SetHex(element.get_str());
-        spark::Coin coin(spark::Params::get_default());
-        if(!sparkState->HasCoinHash(coin, coinHash))
-            continue;
-
-        std::pair<int, int> coinHeightAndId;
-        {
-            LOCK(cs_main);
-            coinHeightAndId = sparkState->GetMintedCoinHeightAndId(coin);
-        }
+    for (const auto& coinHeightAndId : matchingMetadata) {
         UniValue metaData(UniValue::VOBJ);
         metaData.pushKV(std::to_string(coinHeightAndId.first), coinHeightAndId.second);
         ret.push_back(metaData);

--- a/src/spark/state.cpp
+++ b/src/spark/state.cpp
@@ -1105,11 +1105,12 @@ void CSparkState::Reset() {
     latestCoinId = 0;
     {
         LOCK(cs_minted_coins);
+        mintedCoinsByHash.clear();
         mintedCoins.clear();
+        mintMetaInfo.clear();
     }
     usedLTags.clear();
     mobileUsedLTags.clear();
-    mintMetaInfo.clear();
     spendMetaInfo.clear();
 }
 
@@ -1123,6 +1124,17 @@ std::pair<int, int> CSparkState::GetMintedCoinHeightAndId(const spark::Coin& coi
     return std::make_pair(-1, -1);
 }
 
+bool CSparkState::GetMintedCoinHeightAndId(const uint256& coinHash, std::pair<int, int>& result) const {
+    LOCK(cs_minted_coins);
+    auto coinIt = mintedCoinsByHash.find(coinHash);
+    if (coinIt == mintedCoinsByHash.end()) {
+        return false;
+    }
+
+    result = std::make_pair(coinIt->second->second.nHeight, coinIt->second->second.coinGroupId);
+    return true;
+}
+
 bool CSparkState::HasCoin(const spark::Coin& coin) {
     LOCK(cs_minted_coins);
     return mintedCoins.find(coin) != mintedCoins.end();
@@ -1131,14 +1143,13 @@ bool CSparkState::HasCoin(const spark::Coin& coin) {
 
 bool CSparkState::HasCoinHash(spark::Coin& coin, const uint256& coinHash) {
     LOCK(cs_minted_coins);
-    for (auto it = mintedCoins.begin(); it != mintedCoins.end(); ++it ){
-        const spark::Coin& coin_ = (*it).first;
-        if (primitives::GetSparkCoinHash(coin_) == coinHash) {
-            coin = coin_;
-            return true;
-        }
+    auto coinIt = mintedCoinsByHash.find(coinHash);
+    if (coinIt == mintedCoinsByHash.end()) {
+        return false;
     }
-    return false;
+
+    coin = coinIt->second->first;
+    return true;
 }
 
 bool CSparkState::GetCoinGroupInfo(
@@ -1182,7 +1193,10 @@ bool CSparkState::CanAddMintToMempool(const spark::Coin& coin){
 
 void CSparkState::AddMint(const spark::Coin& coin, const CMintedCoinInfo& coinInfo) {
     LOCK(cs_minted_coins);
-    mintedCoins.insert(std::make_pair(coin, coinInfo));
+    auto result = mintedCoins.insert(std::make_pair(coin, coinInfo));
+    if (result.second) {
+        mintedCoinsByHash.emplace(primitives::GetSparkCoinHash(result.first->first), &*result.first);
+    }
     // Count indexed occurrences, including legacy duplicates that do not enter
     // the unique mintedCoins map.
     mintMetaInfo[coinInfo.coinGroupId] += 1;
@@ -1206,6 +1220,7 @@ bool CSparkState::RemoveMint(
         return false;
     }
 
+    mintedCoinsByHash.erase(primitives::GetSparkCoinHash(iter->first));
     mintedCoins.erase(iter);
     return true;
 }

--- a/src/spark/state.h
+++ b/src/spark/state.h
@@ -144,6 +144,11 @@ public:
             size_t maxCoinInGroup = ZC_SPARK_MAX_MINT_NUM,
             size_t startGroupSize = ZC_SPARK_SET_START_SIZE);
 
+    CSparkState(const CSparkState&) = delete;
+    CSparkState& operator=(const CSparkState&) = delete;
+    CSparkState(CSparkState&&) = delete;
+    CSparkState& operator=(CSparkState&&) = delete;
+
     // Reset to initial values
     void Reset();
 
@@ -154,6 +159,9 @@ public:
 
     // Return height of mint transaction and id of minted coin
     std::pair<int, int> GetMintedCoinHeightAndId(const spark::Coin& coin);
+
+    // Return height and id for the mint matching the given coin hash
+    bool GetMintedCoinHeightAndId(const uint256& coinHash, std::pair<int, int>& result) const;
 
     // Query if there is a coin with given pubCoin value
     bool HasCoin(const spark::Coin& coin);
@@ -263,9 +271,13 @@ private:
     // Collection of coin groups. Map from id to LelantusCoinGroupInfo structure
     std::unordered_map<int, SparkCoinGroupInfo> coinGroups;
 
+    using MintedCoins = std::unordered_map<spark::Coin, CMintedCoinInfo, spark::CoinHash>;
+
     // Set of all minted coins
     mutable CCriticalSection cs_minted_coins;
-    std::unordered_map<spark::Coin, CMintedCoinInfo, spark::CoinHash> mintedCoins GUARDED_BY(cs_minted_coins);
+    MintedCoins mintedCoins GUARDED_BY(cs_minted_coins);
+    // Entries point to stable unordered_map nodes and are erased before their nodes.
+    std::unordered_map<uint256, const MintedCoins::value_type*> mintedCoinsByHash GUARDED_BY(cs_minted_coins);
     // Set of all used coin linking tags.
     std::unordered_map<GroupElement, int, spark::CLTagHash> usedLTags;
     // Set of all used linking tags, used only when -mobile=true

--- a/src/test/spark_state_test.cpp
+++ b/src/test/spark_state_test.cpp
@@ -106,12 +106,22 @@ BOOST_AUTO_TEST_CASE(add_mints_to_state)
     BOOST_CHECK(!sparkState->HasCoin(pwalletMain->sparkWallet->getCoinFromMeta(mints[2])));
 
     // test has coin hash
-    auto cn0 = pwalletMain->sparkWallet->getCoinFromMeta(mints[0]);
-    BOOST_CHECK(sparkState->HasCoinHash(cn0, cn0.getHash()));
-    auto cn1 = pwalletMain->sparkWallet->getCoinFromMeta(mints[1]);
-    BOOST_CHECK(sparkState->HasCoinHash(cn1, cn1.getHash()));
-    auto cn2 = pwalletMain->sparkWallet->getCoinFromMeta(mints[2]);
-    BOOST_CHECK(!sparkState->HasCoinHash(cn2, cn2.getHash()));
+    const auto expectedCn0 = pwalletMain->sparkWallet->getCoinFromMeta(mints[0]);
+    const auto expectedCn1 = pwalletMain->sparkWallet->getCoinFromMeta(mints[1]);
+    const auto expectedCn2 = pwalletMain->sparkWallet->getCoinFromMeta(mints[2]);
+    spark::Coin cn0(spark::Params::get_default());
+    BOOST_CHECK(sparkState->HasCoinHash(cn0, expectedCn0.getHash()));
+    BOOST_CHECK(cn0 == expectedCn0);
+    spark::Coin cn1(spark::Params::get_default());
+    BOOST_CHECK(sparkState->HasCoinHash(cn1, expectedCn1.getHash()));
+    BOOST_CHECK(cn1 == expectedCn1);
+    spark::Coin cn2(spark::Params::get_default());
+    BOOST_CHECK(!sparkState->HasCoinHash(cn2, expectedCn2.getHash()));
+
+    std::pair<int, int> coinHeightAndId;
+    BOOST_CHECK(sparkState->GetMintedCoinHeightAndId(expectedCn0.getHash(), coinHeightAndId));
+    BOOST_CHECK_EQUAL(std::make_pair(chainActive.Height() - 1, 1), coinHeightAndId);
+    BOOST_CHECK(!sparkState->GetMintedCoinHeightAndId(expectedCn2.getHash(), coinHeightAndId));
 
     BOOST_CHECK_EQUAL(2, sparkState->GetTotalCoins());
 
@@ -128,7 +138,20 @@ BOOST_AUTO_TEST_CASE(add_mints_to_state)
 
     BOOST_CHECK_EQUAL(1, sparkState->GetLatestCoinID());
 
+    // The hash index stores pointers to mintedCoins nodes. Verify that the first
+    // entry remains valid after enough insertions to force map rehashing.
+    for (size_t i = 0; i < 256; ++i) {
+        auto rehashCoin = expectedCn0;
+        rehashCoin.S.randomize();
+        sparkState->AddMint(rehashCoin, spark::CMintedCoinInfo::make(1, chainActive.Height()));
+    }
+    spark::Coin coinAfterRehash(spark::Params::get_default());
+    BOOST_CHECK(sparkState->HasCoinHash(coinAfterRehash, expectedCn0.getHash()));
+    BOOST_CHECK(coinAfterRehash == expectedCn0);
+
     sparkState->Reset();
+    BOOST_CHECK(!sparkState->HasCoinHash(cn0, expectedCn0.getHash()));
+    BOOST_CHECK(!sparkState->GetMintedCoinHeightAndId(expectedCn0.getHash(), coinHeightAndId));
     mempool.clear();
 }
 
@@ -318,11 +341,23 @@ BOOST_AUTO_TEST_CASE(add_remove_block)
     BOOST_CHECK(sparkState->HasCoin(pwalletMain->sparkWallet->getCoinFromMeta(mint2)));
     BOOST_CHECK(!sparkState->HasCoin(pwalletMain->sparkWallet->getCoinFromMeta(mint3)));
 
+    spark::Coin foundCoin(spark::Params::get_default());
+    const auto coin1 = pwalletMain->sparkWallet->getCoinFromMeta(mint1);
+    const auto coin3 = pwalletMain->sparkWallet->getCoinFromMeta(mint3);
+    BOOST_CHECK(sparkState->HasCoinHash(foundCoin, coin1.getHash()));
+    BOOST_CHECK(foundCoin == coin1);
+    BOOST_CHECK(!sparkState->HasCoinHash(foundCoin, coin3.getHash()));
+
+    std::pair<int, int> coinHeightAndId;
+    BOOST_CHECK(sparkState->GetMintedCoinHeightAndId(coin1.getHash(), coinHeightAndId));
+    BOOST_CHECK(!sparkState->GetMintedCoinHeightAndId(coin3.getHash(), coinHeightAndId));
+
     BOOST_CHECK(sparkState->IsUsedLTag(lTag1));
     BOOST_CHECK(sparkState->IsUsedLTag(lTag2));
     BOOST_CHECK(!sparkState->IsUsedLTag(lTag3));
 
     sparkState->Reset();
+    BOOST_CHECK(!sparkState->HasCoinHash(foundCoin, coin1.getHash()));
 }
 
 BOOST_AUTO_TEST_CASE(remove_block_preserves_legacy_duplicate_mint)
@@ -358,9 +393,13 @@ BOOST_AUTO_TEST_CASE(remove_block_preserves_legacy_duplicate_mint)
         BOOST_CHECK(
             state.GetMintedCoinHeightAndId(coin) ==
             std::make_pair(firstIndex.nHeight, 1));
+        std::pair<int, int> hashHeightAndId;
+        BOOST_REQUIRE(state.GetMintedCoinHeightAndId(coin.getHash(), hashHeightAndId));
+        BOOST_CHECK(hashHeightAndId == std::make_pair(firstIndex.nHeight, 1));
 
         state.RemoveBlock(&firstIndex);
         BOOST_CHECK_EQUAL(state.GetTotalCoins(), 0U);
+        BOOST_CHECK(!state.GetMintedCoinHeightAndId(coin.getHash(), hashHeightAndId));
     };
 
     // Exercise duplicates in both the same group and a later group.


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked draft on #1910. The Files changed view is follow-up-only; do not merge this PR into the feature base.**

## Relationship and review order

This PR is intentionally based on `fix/spark-minted-coins-race`, the head branch of #1910. The synchronization and rollback changes owned by #1910 have been removed from this diff.

Required order:

1. Review, approve, and squash-merge #1910.
2. Retarget #1911 to the resulting `master`.
3. Rebase its single follow-up commit onto the #1910 squash result.
4. Run fresh master-based CI, then review and approve #1911 on that final head.

The intended scope of this PR is only the follow-up hash-index and RPC mint-metadata hardening. It will remain draft until #1910 lands and the final rebase and validation are complete.

## PR intention

Prevent `getsparkmintmetadata` from performing unbounded O(K x N) work. Arrays of missing hashes could otherwise keep RPC workers busy.

## Code changes brief

- Maintain a synchronized coin-hash index so metadata lookups are O(1).
- Keep the index synchronized across add, exact-match rollback, reset, startup replay, and reorg paths; make `CSparkState` non-copyable because the index uses stable node pointers.
- Preserve #1910's group-and-height-aware legacy duplicate rollback behavior.
- Limit requests to 1,000 entries and require each hash to be exactly 64 hexadecimal characters.
- Hold `cs_main` for one bounded metadata snapshot while preserving input ordering and duplicate behavior.
- Add state lifecycle, duplicate rollback/index interaction, and RPC validation coverage.

## Validation

- `git diff --check fix/spark-minted-coins-race..HEAD`
- `PYTHONPYCACHEPREFIX=/private/tmp/firo-mintmetadata-pr-pycache python3 -m py_compile qa/rpc-tests/spark_mint.py`
- Audited all state API call sites, hash-index lifetime rules, and the absence of #1910-owned `RemoveBlock`, `GetMints`, `GetTotalCoins`, and mutex-introduction hunks.
- A local C++ build could not reach the changed objects because the host lacks Berkeley DB's `db_cxx.h`; fresh master-based CI is required before approval.