### PR TITLE
Spark: bound spend verification work and harden proof caching

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -438,6 +438,9 @@ public:
         consensus.nMaxValueLelantusMint = ZC_LELANTUS_MAX_MINT;
         consensus.nMaxValueSparkSpendPerTransaction = SPARK_VALUE_SPEND_LIMIT_PER_TRANSACTION;
         consensus.nMaxValueSparkSpendPerBlock = SPARK_VALUE_SPEND_LIMIT_PER_BLOCK;
+        // Disabled until a coordinated deployment height is selected.
+        consensus.nSparkSpendLimitStartBlock = INT_MAX;
+        consensus.nMaxSparkSpendWorkPerBlock = SPARK_SPEND_WORK_LIMIT_PER_BLOCK;
         consensus.nSparkLimitV2StartBlock = SPARK_NAME_TRANSFER_MAINNET_START_BLOCK;
         consensus.nSparkLimitV2Factor = 5;
         consensus.nMaxSparkOutLimitPerTx = SPARK_OUT_LIMIT_PER_TX;
@@ -765,6 +768,9 @@ public:
         consensus.nMaxValueLelantusMint = 1001 * COIN;
         consensus.nMaxValueSparkSpendPerTransaction = SPARK_VALUE_SPEND_LIMIT_PER_TRANSACTION;
         consensus.nMaxValueSparkSpendPerBlock = SPARK_VALUE_SPEND_LIMIT_PER_BLOCK;
+        // Disabled until a coordinated deployment height is selected.
+        consensus.nSparkSpendLimitStartBlock = INT_MAX;
+        consensus.nMaxSparkSpendWorkPerBlock = SPARK_SPEND_WORK_LIMIT_PER_BLOCK;
         consensus.nSparkLimitV2StartBlock = SPARK_NAME_TRANSFER_TESTNET_START_BLOCK;
         consensus.nSparkLimitV2Factor = 5;
         consensus.nMaxSparkOutLimitPerTx = SPARK_OUT_LIMIT_PER_TX;
@@ -1033,6 +1039,9 @@ public:
         consensus.nMaxValueLelantusMint = 1001 * COIN;
         consensus.nMaxValueSparkSpendPerTransaction = SPARK_VALUE_SPEND_LIMIT_PER_TRANSACTION;
         consensus.nMaxValueSparkSpendPerBlock = SPARK_VALUE_SPEND_LIMIT_PER_BLOCK;
+        // Disabled until a coordinated deployment height is selected.
+        consensus.nSparkSpendLimitStartBlock = INT_MAX;
+        consensus.nMaxSparkSpendWorkPerBlock = SPARK_SPEND_WORK_LIMIT_PER_BLOCK;
         consensus.nSparkLimitV2StartBlock = SPARK_NAME_TRANSFER_DEVNET_START_BLOCK;
         consensus.nSparkLimitV2Factor = 3;
         consensus.nMaxSparkOutLimitPerTx = SPARK_OUT_LIMIT_PER_TX;
@@ -1290,6 +1299,8 @@ public:
         consensus.nMaxValueLelantusMint = ZC_LELANTUS_MAX_MINT;
         consensus.nMaxValueSparkSpendPerTransaction = 1000 * COIN; // 1000 FIRO
         consensus.nMaxValueSparkSpendPerBlock = 1500 * COIN; // 1500 FIRO
+        consensus.nSparkSpendLimitStartBlock = consensus.nSparkSingleInputStartBlock;
+        consensus.nMaxSparkSpendWorkPerBlock = SPARK_SPEND_WORK_LIMIT_PER_BLOCK;
         consensus.nSparkLimitV2StartBlock = 1500;
         consensus.nSparkLimitV2Factor = 3;
         consensus.nMaxSparkOutLimitPerTx = SPARK_OUT_LIMIT_PER_TX;
@@ -1341,6 +1352,11 @@ public:
     {
         consensus.nSparkSingleInputStartBlock = height;
     }
+
+    void UpdateSparkSpendLimitHeight(int height)
+    {
+        consensus.nSparkSpendLimitStartBlock = height;
+    }
 };
 static CRegTestParams regTestParams;
 
@@ -1379,4 +1395,9 @@ void UpdateRegtestBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime,
 void UpdateRegtestSparkSingleInputHeight(int height)
 {
     regTestParams.UpdateSparkSingleInputHeight(height);
+}
+
+void UpdateRegtestSparkSpendLimitHeight(int height)
+{
+    regTestParams.UpdateSparkSpendLimitHeight(height);
 }

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -149,4 +149,7 @@ void UpdateRegtestBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime,
 /** Allows tests to exercise the single-input Spark consensus activation. */
 void UpdateRegtestSparkSingleInputHeight(int height);
 
+/** Allows tests to exercise the per-block Spark verification-work limit. */
+void UpdateRegtestSparkSpendLimitHeight(int height);
+
 #endif // BITCOIN_CHAINPARAMS_H

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -360,7 +360,14 @@ struct Params {
     // Value of maximum spark spend per block.
     int64_t nMaxValueSparkSpendPerBlock;
 
-    // Two values above increase after this block number
+    // Height at which the per-block Spark verification-work limit is enforced.
+    int nSparkSpendLimitStartBlock;
+    // Maximum Spark proof/cover-set work units per block after activation.
+    // Each spend is charged the maximum of its proof tags, group ids, and
+    // serialized cover-set references.
+    unsigned nMaxSparkSpendWorkPerBlock;
+
+    // The two Spark value limits increase after this block number
     int nSparkLimitV2StartBlock;
     // ... by this factor
     int nSparkLimitV2Factor;

--- a/src/firo_params.h
+++ b/src/firo_params.h
@@ -159,6 +159,10 @@ static const int64_t DUST_HARD_LIMIT = 1000;   // 0.00001 FIRO mininput
 // Value of spark spends allowed per block
 #define SPARK_VALUE_SPEND_LIMIT_PER_BLOCK  (20000 * COIN)
 
+// Provisional maximum Spark proof/cover-set verification work units per block.
+// Benchmark worst-case spends before selecting a public-network activation.
+#define SPARK_SPEND_WORK_LIMIT_PER_BLOCK  25
+
 // Maximum amount of lelantus mint
 #define ZC_LELANTUS_MAX_MINT            (5001 * COIN)
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -37,6 +37,7 @@
 #include <algorithm>
 #include <boost/thread.hpp>
 #include <boost/tuple/tuple.hpp>
+#include <climits>
 #include <queue>
 #include <unistd.h>
 
@@ -155,7 +156,7 @@ void BlockAssembler::resetBlock()
     nLelantusSpendInputs = 0;
 
     nSparkSpendAmount = 0;
-    nSparkSpendInputs = 0;
+    nSparkSpendWork = 0;
 }
 
 std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& scriptPubKeyIn, bool fMineWitnessTx)
@@ -351,6 +352,36 @@ bool BlockAssembler::TestPackage(uint64_t packageSize, int64_t packageSigOpsCost
     return true;
 }
 
+bool BlockAssembler::TestSparkSpendLimits(
+    const CTransaction& tx,
+    CAmount& spendAmount,
+    size_t& spendWork) const
+{
+    if (!tx.IsSparkSpend())
+        return true;
+
+    const auto& params = chainparams.GetConsensus();
+    const CAmount txSpendAmount = spark::GetSpendTransparentAmount(tx);
+    if (txSpendAmount > params.GetMaxValueSparkSpendPerTransaction(nHeight) ||
+        spendAmount > params.GetMaxValueSparkSpendPerBlock(nHeight) - txSpendAmount) {
+        return false;
+    }
+
+    if (params.nSparkSpendLimitStartBlock != INT_MAX &&
+        nHeight >= params.nSparkSpendLimitStartBlock) {
+        const size_t txSpendWork = spark::GetSpendWorkUnits(tx);
+        if (txSpendWork == 0 ||
+            txSpendWork > params.nMaxSparkSpendWorkPerBlock ||
+            spendWork > params.nMaxSparkSpendWorkPerBlock - txSpendWork) {
+            return false;
+        }
+        spendWork += txSpendWork;
+    }
+
+    spendAmount += txSpendAmount;
+    return true;
+}
+
 // Perform transaction-level checks before adding to block:
 // - transaction finality (locktime)
 // - premature witness (in case segwit transactions are added to mempool before
@@ -359,6 +390,8 @@ bool BlockAssembler::TestPackage(uint64_t packageSize, int64_t packageSigOpsCost
 bool BlockAssembler::TestPackageTransactions(const CTxMemPool::setEntries& package)
 {
     uint64_t nPotentialBlockSize = nBlockSize; // only used with fNeedSizeAccounting
+    CAmount nPotentialSparkSpendAmount = nSparkSpendAmount;
+    size_t nPotentialSparkSpendWork = nSparkSpendWork;
     BOOST_FOREACH (const CTxMemPool::txiter it, package) {
         if (!IsFinalTx(it->GetTx(), nHeight, nLockTimeCutoff))
             return false;
@@ -373,6 +406,12 @@ bool BlockAssembler::TestPackageTransactions(const CTxMemPool::setEntries& packa
                 return false;
             }
             nPotentialBlockSize += nTxSize;
+        }
+        if (!TestSparkSpendLimits(
+                it->GetTx(),
+                nPotentialSparkSpendAmount,
+                nPotentialSparkSpendWork)) {
+            return false;
         }
     }
     return true;
@@ -429,16 +468,13 @@ bool BlockAssembler::TestForBlock(CTxMemPool::txiter iter)
 
     const CTransaction &tx = iter->GetTx();
 
-    // Check transaction against spark limits
-    if(tx.IsSparkSpend()) {
-        CAmount spendAmount = spark::GetSpendTransparentAmount(tx);
-        const auto &params = chainparams.GetConsensus();
-
-        if (spendAmount > params.GetMaxValueSparkSpendPerTransaction(nHeight))
-            return false;
-
-        if (spendAmount + nSparkSpendAmount > params.GetMaxValueSparkSpendPerBlock(nHeight))
-            return false;
+    CAmount nPotentialSparkSpendAmount = nSparkSpendAmount;
+    size_t nPotentialSparkSpendWork = nSparkSpendWork;
+    if (!TestSparkSpendLimits(
+            tx,
+            nPotentialSparkSpendAmount,
+            nPotentialSparkSpendWork)) {
+        return false;
     }
 
     return true;
@@ -448,16 +484,8 @@ void BlockAssembler::AddToBlock(CTxMemPool::txiter iter)
 {
     const CTransaction &tx = iter->GetTx();
 
-    if(tx.IsSparkSpend()) {
-        CAmount spendAmount = spark::GetSpendTransparentAmount(tx);
-        const auto &params = chainparams.GetConsensus();
-
-        if (spendAmount > params.GetMaxValueSparkSpendPerTransaction(nHeight))
-            return;
-
-        if ((nSparkSpendAmount += spendAmount) > params.GetMaxValueSparkSpendPerBlock(nHeight))
-            return;
-    }
+    if (!TestSparkSpendLimits(tx, nSparkSpendAmount, nSparkSpendWork))
+        return;
 
     pblock->vtx.emplace_back(iter->GetSharedTx());
     pblocktemplate->vTxFees.push_back(iter->GetFee());

--- a/src/miner.h
+++ b/src/miner.h
@@ -174,9 +174,9 @@ private:
     CAmount nLelantusSpendAmount;
     size_t nLelantusSpendInputs;
 
-    // lelantus spend limits
+    // Spark spend limits
     CAmount nSparkSpendAmount;
-    size_t nSparkSpendInputs;
+    size_t nSparkSpendWork;
 
     // transactions we cannot include in this block
     CTxMemPool::setEntries txBlackList;
@@ -192,6 +192,8 @@ private:
     void resetBlock();
     /** Add a tx to the block */
     void AddToBlock(CTxMemPool::txiter iter);
+    /** Test and update tentative Spark spend totals. */
+    bool TestSparkSpendLimits(const CTransaction& tx, CAmount& spendAmount, size_t& spendWork) const;
 
     // Methods for how to add transactions to a block.
     /** Add transactions based on tx "priority" */

--- a/src/spark/state.cpp
+++ b/src/spark/state.cpp
@@ -8,6 +8,7 @@
 #include "../sync.h"
 #include "../unordered_lru_cache.h"
 
+#include <algorithm>
 #include <memory>
 #include <set>
 
@@ -19,6 +20,9 @@ struct ProofCheckState {
 
     // result of the check (if fChecked is true)
     bool fResult = false;
+
+    // The historical and single-input verifiers are distinct consensus modes.
+    bool fSingleInputVerifier = false;
 };
 
 // Bound the mempool-acceptance proof cache. Without a cap, peers can relay many
@@ -34,6 +38,12 @@ void EraseCheckedSparkSpendTransaction(const uint256& hashTx)
 {
     LOCK(cs_checkedSparkSpendTransactions);
     gCheckedSparkSpendTransactions.erase(hashTx);
+}
+
+static void ClearCheckedSparkSpendTransactions()
+{
+    LOCK(cs_checkedSparkSpendTransactions);
+    gCheckedSparkSpendTransactions.clear();
 }
 
 static CSparkState sparkState;
@@ -251,6 +261,27 @@ std::vector<spark::Coin> GetSparkMintCoins(const CTransaction &tx)
 size_t GetSpendInputs(const CTransaction &tx) {
     return tx.IsSparkSpend() ?
            GetSparkUsedTags(tx).size() : 0;
+}
+
+static size_t GetSpendWorkUnits(SpendTransaction& spend)
+{
+    return std::max({
+        spend.getUsedLTags().size(),
+        spend.getCoinGroupIds().size(),
+        spend.getBlockHashes().size()});
+}
+
+size_t GetSpendWorkUnits(const CTransaction& tx)
+{
+    if (!tx.IsSparkSpend())
+        return 0;
+
+    try {
+        SpendTransaction spend = ParseSparkSpend(tx);
+        return GetSpendWorkUnits(spend);
+    } catch (const std::exception&) {
+        return 0;
+    }
 }
 
 CAmount GetSpendTransparentAmount(const CTransaction& tx) {
@@ -484,10 +515,7 @@ void DisconnectTipSpark(CBlock& block, CBlockIndex *pindexDelete) {
 
     // Spark verification depends on active-chain cover-set data. Refresh all
     // cached results after a disconnect so they use the current chain context.
-    {
-        LOCK(cs_checkedSparkSpendTransactions);
-        gCheckedSparkSpendTransactions.clear();
-    }
+    ClearCheckedSparkSpendTransactions();
 
     // Also remove from mempool spends that reference given block hash.
     RemoveSpendReferencingBlock(mempool, pindexDelete);
@@ -498,6 +526,10 @@ bool CheckSparkBlock(CValidationState &state, const CBlock& block, int nBlockHei
     auto& consensus = ::Params().GetConsensus();
 
     CAmount blockSpendsValue = 0;
+    std::size_t blockSpendWork = 0;
+    const bool enforceSpendWorkLimit =
+        consensus.nSparkSpendLimitStartBlock != INT_MAX &&
+        nBlockHeight >= consensus.nSparkSpendLimitStartBlock;
 
     for (const auto& tx : block.vtx) {
         auto txSpendsValue =  GetSpendTransparentAmount(*tx);
@@ -507,6 +539,17 @@ bool CheckSparkBlock(CValidationState &state, const CBlock& block, int nBlockHei
                              "bad-txns-spark-spend-invalid");
         }
         blockSpendsValue += txSpendsValue;
+
+        if (enforceSpendWorkLimit && tx->IsSparkSpend()) {
+            const std::size_t txSpendWork = GetSpendWorkUnits(*tx);
+            if (txSpendWork == 0 ||
+                txSpendWork > consensus.nMaxSparkSpendWorkPerBlock ||
+                blockSpendWork > consensus.nMaxSparkSpendWorkPerBlock - txSpendWork) {
+                return state.DoS(100, false, REJECT_INVALID,
+                                 "bad-blk-spark-spend-work");
+            }
+            blockSpendWork += txSpendWork;
+        }
     }
 
     if (cmp::greater(blockSpendsValue, consensus.GetMaxValueSparkSpendPerBlock(nBlockHeight))) {
@@ -685,6 +728,9 @@ bool CheckSparkSpendTransaction(
     bool isMempoolAcceptance = (!sparkTxInfo);
     const bool enforceSingleInput = isMempoolAcceptance ? (height >= (params.nSparkSingleInputStartBlock - 10))
         : height >= params.nSparkSingleInputStartBlock;
+    const bool enforceSpendWorkLimit =
+        params.nSparkSpendLimitStartBlock != INT_MAX &&
+        height >= params.nSparkSpendLimitStartBlock;
 
     if (enforceSingleInput &&
         spend->getUsedLTags().size() != 1) {
@@ -692,6 +738,14 @@ bool CheckSparkSpendTransaction(
                          false,
                          isMempoolAcceptance ? REJECT_NONSTANDARD : REJECT_INVALID,
                          "CheckSparkSpendTransaction: multi-input Spark spends are disabled");
+    }
+    const std::size_t spendWork = GetSpendWorkUnits(*spend);
+    if (enforceSpendWorkLimit &&
+        (spendWork == 0 || spendWork > params.nMaxSparkSpendWorkPerBlock)) {
+        return state.DoS(isMempoolAcceptance ? 0 : 100,
+                         false,
+                         isMempoolAcceptance ? REJECT_NONSTANDARD : REJECT_INVALID,
+                         "CheckSparkSpendTransaction: Spark spend work limit exceeded");
     }
     bool passVerify = false;
 
@@ -719,123 +773,132 @@ bool CheckSparkSpendTransaction(
     if (!CheckSparkSMintTransaction(tx.vout, state, hashTx, fStatefulSigmaCheck, out_coins, sparkTxInfo))
         return false;
     spend->setOutCoins(out_coins);
-    std::unordered_map<uint64_t, std::vector<Coin>> cover_sets;
-    std::unordered_map<uint64_t, CoverSetData> cover_set_data;
-    const auto idAndBlockHashes = spend->getBlockHashes();
-
-    BatchProofContainer* batchProofContainer = BatchProofContainer::get_instance();
-    bool useBatching = batchProofContainer->fCollectProofs && !isVerifyDB && !isCheckWallet && sparkTxInfo && !sparkTxInfo->fInfoIsComplete;
-
-    for (const auto& idAndHash : idAndBlockHashes) {
-        CSparkState::SparkCoinGroupInfo coinGroup;
-        if (!sparkState.GetCoinGroupInfo(idAndHash.first, coinGroup))
-            return state.DoS(100, false, NO_MINT_ZEROCOIN, "CheckSparkSpendTransaction: Error: no coins were minted with such parameters");
-
-        CBlockIndex *index = coinGroup.lastBlock;
-        // find index for block with hash of accumulatorBlockHash or set index to the coinGroup.firstBlock if not found
-        while (index != coinGroup.firstBlock && index->GetBlockHash() != idAndHash.second)
-            index = index->pprev;
-
-        // take the hash from last block of anonymity set
-        std::vector<unsigned char> set_hash = GetAnonymitySetHash(index, idAndHash.first);
-
-        std::vector<Coin> cover_set;
-        cover_set.reserve(coinGroup.nCoins);
-        std::size_t set_size = 0;
-        // Build a vector with all the public coins with given id before
-        // the block on which the spend occurred.
-        // This list of public coins is required by function "Verify" of spend.
-        while (true) {
-            int id = 0;
-            if (CountCoinInBlock(index, idAndHash.first)) {
-                id = idAndHash.first;
-            } else if (CountCoinInBlock(index, idAndHash.first - 1)) {
-                id = idAndHash.first - 1;
-            }
-            if (id) {
-                if (index->sparkMintedCoins.count(id) > 0) {
-                    BOOST_FOREACH(
-                    const auto& coin,
-                    index->sparkMintedCoins[id]) {
-                        set_size++;
-                        if (!useBatching)
-                            cover_set.push_back(coin);
-                    }
-                }
-            }
-
-            if (index == coinGroup.firstBlock)
-                break;
-            index = index->pprev;
-        }
-
-        CoverSetData setData;
-        setData.cover_set_size = set_size;
-        if (!set_hash.empty())
-            setData.cover_set_representation = set_hash;
-        setData.cover_set_representation.insert(setData.cover_set_representation.end(), txHashForMetadata.begin(), txHashForMetadata.end());
-
-        cover_sets[idAndHash.first] = std::move(cover_set);
-        cover_set_data [idAndHash.first] = setData;
-    }
-    spend->setCoverSets(cover_set_data);
-    spend->setVout(Vout);
-
     const std::vector<uint64_t>& ids = spend->getCoinGroupIds();
-    for (const auto& id : ids) {
-        if (!cover_sets.count(id) || !cover_set_data.count(id))
-            return state.DoS(100,
-                             error("CheckSparkSpendTransaction: No cover set found."));
+    ProofCheckState checkState;
+    bool haveCachedResult = false;
+    {
+        LOCK(cs_checkedSparkSpendTransactions);
+        haveCachedResult =
+            gCheckedSparkSpendTransactions.get(hashTx, checkState) &&
+            checkState.fChecked &&
+            checkState.fSingleInputVerifier == enforceSingleInput;
     }
-    
-    // if we are collecting proofs, skip verification and collect proofs
-    // add proofs into container
-    if (useBatching) {
-        passVerify = true;
-        if (enforceSingleInput) {
-            batchProofContainer->add(*spend);
-        } else {
-            batchProofContainer->addHistorical(*spend);
-        }
-    } else {
-        try {
-            ProofCheckState checkState;
-            bool haveCachedResult = false;
-            {
-                LOCK(cs_checkedSparkSpendTransactions);
-                haveCachedResult = gCheckedSparkSpendTransactions.get(hashTx, checkState);
+
+    if (haveCachedResult) {
+        if (!checkState.fResult) {
+            // Negative cache entries are a mempool DoS shortcut. Never let a
+            // policy cache entry decide block consensus.
+            if (isMempoolAcceptance) {
+                return state.DoS(0, false, REJECT_NONSTANDARD,
+                                 "CheckSparkSpendTransaction: previously checked and failed");
             }
-            if (haveCachedResult) {
-                if (checkState.fChecked) {
-                    if (!checkState.fResult)
-                        return state.DoS(100, false, REJECT_INVALID, "CheckSparkSpendTransaction: previously checked and failed");
-                    else {
-                        LogPrintf("CheckSparkSpendTransaction: already checked tx %s\n", hashTx.ToString());
-                        passVerify = true;
+        } else {
+            LogPrintf("CheckSparkSpendTransaction: already checked tx %s\n", hashTx.ToString());
+            passVerify = true;
+        }
+    }
+
+    if (!passVerify) {
+        std::unordered_map<uint64_t, std::vector<Coin>> cover_sets;
+        std::unordered_map<uint64_t, CoverSetData> cover_set_data;
+        const auto idAndBlockHashes = spend->getBlockHashes();
+        bool cacheResultForCurrentChain = true;
+
+        BatchProofContainer* batchProofContainer = BatchProofContainer::get_instance();
+        const bool useBatching = batchProofContainer->fCollectProofs &&
+            !isVerifyDB && !isCheckWallet && sparkTxInfo &&
+            !sparkTxInfo->fInfoIsComplete;
+
+        for (const auto& idAndHash : idAndBlockHashes) {
+            CSparkState::SparkCoinGroupInfo coinGroup;
+            if (!sparkState.GetCoinGroupInfo(idAndHash.first, coinGroup))
+                return state.DoS(100, false, NO_MINT_ZEROCOIN, "CheckSparkSpendTransaction: Error: no coins were minted with such parameters");
+
+            CBlockIndex *index = coinGroup.lastBlock;
+            // Find the referenced cover-set block, or use the group's first block if it is not found.
+            while (index != coinGroup.firstBlock && index->GetBlockHash() != idAndHash.second)
+                index = index->pprev;
+            // The historical fallback remains consensus-compatible, but its
+            // result can change if the claimed block arrives later. Do not
+            // cache a proof unless every claimed cutoff resolved exactly.
+            if (index->GetBlockHash() != idAndHash.second)
+                cacheResultForCurrentChain = false;
+
+            // Take the hash from the last block of the anonymity set.
+            std::vector<unsigned char> set_hash = GetAnonymitySetHash(index, idAndHash.first);
+
+            std::vector<Coin> cover_set;
+            cover_set.reserve(coinGroup.nCoins);
+            std::size_t set_size = 0;
+            // Build the public coin vector only when immediate verification needs it.
+            while (true) {
+                int id = 0;
+                if (CountCoinInBlock(index, idAndHash.first)) {
+                    id = idAndHash.first;
+                } else if (CountCoinInBlock(index, idAndHash.first - 1)) {
+                    id = idAndHash.first - 1;
+                }
+                if (id) {
+                    const auto mintedCoins = index->sparkMintedCoins.find(id);
+                    if (mintedCoins != index->sparkMintedCoins.end()) {
+                        set_size += mintedCoins->second.size();
+                        if (!useBatching) {
+                            cover_set.insert(
+                                cover_set.end(),
+                                mintedCoins->second.begin(),
+                                mintedCoins->second.end());
+                        }
                     }
                 }
+
+                if (index == coinGroup.firstBlock)
+                    break;
+                index = index->pprev;
             }
-            else if (isMempoolAcceptance) {
-                passVerify = enforceSingleInput
-                    ? spark::SpendTransaction::verify(*spend, cover_sets)
-                    : spark::SpendTransaction::verifyHistorical(
-                        *spend, cover_sets);
-                ProofCheckState newState;
-                newState.fChecked = true;
-                newState.fResult = passVerify;
-                LOCK(cs_checkedSparkSpendTransactions);
-                gCheckedSparkSpendTransactions.insert(hashTx, newState);
-            }
-            else {
-                // we need the answer now, so verify and execute
-                passVerify = enforceSingleInput
-                    ? spark::SpendTransaction::verify(*spend, cover_sets)
-                    : spark::SpendTransaction::verifyHistorical(
-                        *spend, cover_sets);
-            }
+
+            CoverSetData setData;
+            setData.cover_set_size = set_size;
+            if (!set_hash.empty())
+                setData.cover_set_representation = set_hash;
+            setData.cover_set_representation.insert(setData.cover_set_representation.end(), txHashForMetadata.begin(), txHashForMetadata.end());
+
+            cover_sets.emplace(idAndHash.first, std::move(cover_set));
+            cover_set_data[idAndHash.first] = std::move(setData);
         }
-        catch (const std::exception &) {
-            passVerify = false;
+        spend->setCoverSets(cover_set_data);
+        spend->setVout(Vout);
+
+        for (const auto& id : ids) {
+            if (!cover_sets.count(id) || !cover_set_data.count(id))
+                return state.DoS(100,
+                                 error("CheckSparkSpendTransaction: No cover set found."));
+        }
+
+        // If we are collecting proofs, defer verification to the batch container.
+        if (useBatching) {
+            passVerify = true;
+            if (enforceSingleInput) {
+                batchProofContainer->add(*spend);
+            } else {
+                batchProofContainer->addHistorical(*spend);
+            }
+        } else {
+            try {
+                passVerify = enforceSingleInput
+                    ? spark::SpendTransaction::verify(*spend, cover_sets)
+                    : spark::SpendTransaction::verifyHistorical(
+                        *spend, cover_sets);
+                if (isMempoolAcceptance && cacheResultForCurrentChain) {
+                    ProofCheckState newState;
+                    newState.fChecked = true;
+                    newState.fResult = passVerify;
+                    newState.fSingleInputVerifier = enforceSingleInput;
+                    LOCK(cs_checkedSparkSpendTransactions);
+                    gCheckedSparkSpendTransactions.insert(hashTx, newState);
+                }
+            } catch (const std::exception &) {
+                passVerify = false;
+            }
         }
     }
 
@@ -1101,6 +1164,7 @@ CSparkState::CSparkState(
 
 void CSparkState::Reset() {
     ShutdownWallet();
+    ClearCheckedSparkSpendTransactions();
     coinGroups.clear();
     latestCoinId = 0;
     mintedCoins.clear();

--- a/src/spark/state.h
+++ b/src/spark/state.h
@@ -57,6 +57,7 @@ std::vector<GroupElement>  GetSparkUsedTags(const CTransaction &tx);
 std::vector<spark::Coin>  GetSparkMintCoins(const CTransaction &tx);
 
 size_t GetSpendInputs(const CTransaction &tx);
+size_t GetSpendWorkUnits(const CTransaction& tx);
 CAmount GetSpendTransparentAmount(const CTransaction& tx);
 
 bool CheckSparkBlock(CValidationState &state, const CBlock& block, int nBlockHeight);

--- a/src/test/spark_tests.cpp
+++ b/src/test/spark_tests.cpp
@@ -1,5 +1,8 @@
 #include "../chainparams.h"
 #include "../batchproof_container.h"
+#include "../llmq/quorums_chainlocks.h"
+#include "../miner.h"
+#include "../policy/policy.h"
 #include "../script/standard.h"
 #include "../validation.h"
 #include "../wallet/coincontrol.h"
@@ -206,6 +209,288 @@ BOOST_AUTO_TEST_CASE(is_spark_allowed)
     BOOST_CHECK(!IsSparkAllowed(start - 1));
     BOOST_CHECK(IsSparkAllowed(start));
     BOOST_CHECK(IsSparkAllowed(start + 1));
+}
+
+BOOST_AUTO_TEST_CASE(spark_spend_work_limit_and_cache_safety)
+{
+    auto& mutableParams =
+        const_cast<Consensus::Params&>(::Params().GetConsensus());
+    const int originalActivation =
+        mutableParams.nSparkSpendLimitStartBlock;
+    const unsigned originalMaxWork =
+        mutableParams.nMaxSparkSpendWorkPerBlock;
+    struct ResetSpendWorkLimit {
+        int height;
+        unsigned maxWork;
+        ~ResetSpendWorkLimit()
+        {
+            UpdateRegtestSparkSpendLimitHeight(height);
+            auto& params =
+                const_cast<Consensus::Params&>(::Params().GetConsensus());
+            params.nMaxSparkSpendWorkPerBlock = maxWork;
+            mempool.clear();
+        }
+    } resetLimit{originalActivation, originalMaxWork};
+
+    BOOST_REQUIRE_EQUAL(
+        originalMaxWork,
+        static_cast<unsigned>(SPARK_SPEND_WORK_LIMIT_PER_BLOCK));
+
+    GenerateBlocks(500);
+    std::vector<CMutableTransaction> mintTransactions;
+    GenerateMints({5 * COIN, 5 * COIN}, mintTransactions);
+    mempool.clear();
+    BOOST_REQUIRE(GenerateBlock(mintTransactions));
+    GenerateBlocks(1);
+
+    const CTransaction spend = GenerateSparkSpend({1 * COIN}, {}, nullptr);
+    BOOST_REQUIRE_EQUAL(GetSpendInputs(spend), 1U);
+    BOOST_REQUIRE(mempool.exists(spend.GetHash()));
+
+    // Check only the verification-work rule, independently of the separate
+    // transparent-value limit.
+    CMutableTransaction workMarkerMutable(spend);
+    for (auto& output : workMarkerMutable.vout) {
+        output.nValue = 0;
+    }
+    const CTransaction workMarker(workMarkerMutable);
+    BOOST_REQUIRE_EQUAL(GetSpendWorkUnits(workMarker), 1U);
+
+    const auto makeBlock = [&workMarker](std::size_t spendCount) {
+        CBlock block;
+        block.vtx.reserve(spendCount + 1);
+        block.vtx.emplace_back(MakeTransactionRef(CMutableTransaction()));
+        for (std::size_t i = 0; i < spendCount; ++i) {
+            block.vtx.emplace_back(MakeTransactionRef(workMarker));
+        }
+        return block;
+    };
+
+    const auto& params = ::Params().GetConsensus();
+    const int activationHeight = chainActive.Height() + 1;
+    UpdateRegtestSparkSpendLimitHeight(activationHeight);
+
+    const CBlock overLimitBlock =
+        makeBlock(params.nMaxSparkSpendWorkPerBlock + 1);
+    CValidationState preActivationState;
+    BOOST_CHECK(CheckSparkBlock(
+        preActivationState, overLimitBlock, activationHeight - 1));
+
+    CValidationState atLimitState;
+    BOOST_CHECK(CheckSparkBlock(
+        atLimitState,
+        makeBlock(params.nMaxSparkSpendWorkPerBlock),
+        activationHeight));
+
+    CValidationState overLimitState;
+    BOOST_CHECK(!CheckSparkBlock(
+        overLimitState, overLimitBlock, activationHeight));
+    int dosScore = 0;
+    BOOST_REQUIRE(overLimitState.IsInvalid(dosScore));
+    BOOST_CHECK_EQUAL(dosScore, 100);
+    BOOST_CHECK_EQUAL(
+        overLimitState.GetRejectReason(),
+        "bad-blk-spark-spend-work");
+
+    // A single-input spend can serialize additional cover-set references.
+    // Charge those references as work so they cannot bypass the proof count.
+    SpendTransaction extraReferences = ParseSparkSpend(workMarker);
+    std::map<uint64_t, uint256> blockHashes = extraReferences.getBlockHashes();
+    BOOST_REQUIRE(!blockHashes.empty());
+    uint64_t nextGroupId = blockHashes.rbegin()->first + 1;
+    while (blockHashes.size() <= params.nMaxSparkSpendWorkPerBlock) {
+        blockHashes.emplace(nextGroupId++, blockHashes.begin()->second);
+    }
+    extraReferences.setBlockHashes(blockHashes);
+
+    CDataStream payload(SER_NETWORK, PROTOCOL_VERSION);
+    payload << extraReferences;
+    CMutableTransaction extraReferenceMutable(workMarker);
+    extraReferenceMutable.vExtraPayload.assign(payload.begin(), payload.end());
+    const CTransaction extraReferenceSpend(extraReferenceMutable);
+    BOOST_REQUIRE_EQUAL(GetSpendInputs(extraReferenceSpend), 1U);
+    BOOST_REQUIRE_EQUAL(
+        GetSpendWorkUnits(extraReferenceSpend),
+        params.nMaxSparkSpendWorkPerBlock + 1U);
+
+    CBlock extraReferenceBlock;
+    extraReferenceBlock.vtx.emplace_back(MakeTransactionRef(extraReferenceSpend));
+    CValidationState extraReferenceState;
+    BOOST_CHECK(!CheckSparkBlock(
+        extraReferenceState, extraReferenceBlock, activationHeight));
+    BOOST_CHECK_EQUAL(
+        extraReferenceState.GetRejectReason(),
+        "bad-blk-spark-spend-work");
+
+    CValidationState extraReferenceMempoolState;
+    BOOST_CHECK(!CheckSparkTransaction(
+        extraReferenceSpend,
+        extraReferenceMempoolState,
+        extraReferenceSpend.GetHash(),
+        false,
+        activationHeight,
+        false,
+        true,
+        nullptr));
+    BOOST_CHECK_EQUAL(
+        extraReferenceMempoolState.GetRejectReason(),
+        "CheckSparkSpendTransaction: Spark spend work limit exceeded");
+
+    // Negative proof results may accelerate repeated mempool rejection, but
+    // they must never decide consensus validation for a block.
+    const std::string cachedFailureReason =
+        "CheckSparkSpendTransaction: previously checked and failed";
+    CValidationState firstInvalidProofState;
+    BOOST_CHECK(!CheckSparkTransaction(
+        workMarker,
+        firstInvalidProofState,
+        workMarker.GetHash(),
+        false,
+        activationHeight,
+        false,
+        true,
+        nullptr));
+    BOOST_CHECK(firstInvalidProofState.GetRejectReason() != cachedFailureReason);
+
+    CValidationState cachedInvalidProofState;
+    BOOST_CHECK(!CheckSparkTransaction(
+        workMarker,
+        cachedInvalidProofState,
+        workMarker.GetHash(),
+        false,
+        activationHeight,
+        false,
+        true,
+        nullptr));
+    BOOST_CHECK_EQUAL(
+        cachedInvalidProofState.GetRejectReason(), cachedFailureReason);
+
+    CValidationState blockInvalidProofState;
+    CSparkTxInfo blockInvalidProofInfo;
+    BOOST_CHECK(!CheckSparkTransaction(
+        workMarker,
+        blockInvalidProofState,
+        workMarker.GetHash(),
+        false,
+        activationHeight,
+        false,
+        true,
+        &blockInvalidProofInfo));
+    BOOST_CHECK(blockInvalidProofState.GetRejectReason() != cachedFailureReason);
+
+    // An unresolved claimed cutoff uses the historical fallback, whose result
+    // can change as the chain grows. Such results must not enter the cache.
+    SpendTransaction unresolvedCutoff = ParseSparkSpend(workMarker);
+    std::map<uint64_t, uint256> unresolvedHashes =
+        unresolvedCutoff.getBlockHashes();
+    BOOST_REQUIRE_EQUAL(unresolvedHashes.size(), 1U);
+    unresolvedHashes.begin()->second = uint256S("01");
+    unresolvedCutoff.setBlockHashes(unresolvedHashes);
+    CDataStream unresolvedPayload(SER_NETWORK, PROTOCOL_VERSION);
+    unresolvedPayload << unresolvedCutoff;
+    CMutableTransaction unresolvedMutable(workMarker);
+    unresolvedMutable.vExtraPayload.assign(
+        unresolvedPayload.begin(), unresolvedPayload.end());
+    const CTransaction unresolvedSpend(unresolvedMutable);
+
+    for (int attempt = 0; attempt < 2; ++attempt) {
+        CValidationState unresolvedState;
+        BOOST_CHECK(!CheckSparkTransaction(
+            unresolvedSpend,
+            unresolvedState,
+            unresolvedSpend.GetHash(),
+            false,
+            activationHeight,
+            false,
+            true,
+            nullptr));
+        BOOST_CHECK(unresolvedState.GetRejectReason() != cachedFailureReason);
+    }
+
+    CMutableTransaction malformedSpend;
+    malformedSpend.nVersion = 3;
+    malformedSpend.nType = TRANSACTION_SPARK;
+    CBlock malformedBlock;
+    malformedBlock.vtx.emplace_back(MakeTransactionRef(malformedSpend));
+    CValidationState malformedState;
+    BOOST_CHECK(!CheckSparkBlock(
+        malformedState, malformedBlock, activationHeight));
+    BOOST_CHECK_EQUAL(
+        malformedState.GetRejectReason(),
+        "bad-blk-spark-spend-work");
+
+    // Exercise the real template path with a one-unit test limit. The clone
+    // is deliberately proof-invalid, but has a slightly lower fee so the valid
+    // original is selected first and the work limit excludes it.
+    mutableParams.nMaxSparkSpendWorkPerBlock = 1;
+    CAmount originalFee = 0;
+    {
+        LOCK(mempool.cs);
+        const auto original = mempool.mapTx.find(spend.GetHash());
+        BOOST_REQUIRE(original != mempool.mapTx.end());
+        originalFee = original->GetFee();
+    }
+    BOOST_REQUIRE_GT(originalFee, 1);
+
+    CMutableTransaction cloneMutable(spend);
+    cloneMutable.nLockTime = spend.nLockTime == 0 ? 1 : 0;
+    const CTransaction clone(cloneMutable);
+    BOOST_REQUIRE(spend.GetHash() != clone.GetHash());
+    BOOST_REQUIRE_EQUAL(spend.GetTotalSize(), clone.GetTotalSize());
+    BOOST_REQUIRE_EQUAL(GetSpendWorkUnits(clone), 1U);
+    BOOST_REQUIRE(
+        CFeeRate(originalFee - 1, clone.GetTotalSize()).GetFeePerK() >=
+        static_cast<CAmount>(DEFAULT_BLOCK_MIN_TX_FEE));
+
+    TestMemPoolEntryHelper entry;
+    BOOST_REQUIRE(mempool.addUnchecked(
+        clone.GetHash(),
+        entry.Fee(originalFee - 1)
+            .Time(1)
+            .Height(chainActive.Height())
+            .FromTx(clone),
+        false));
+    {
+        LOCK(cs_main);
+        BOOST_REQUIRE(llmq::chainLocksHandler->IsTxSafeForMining(
+            spend.GetHash()));
+        BOOST_REQUIRE(llmq::chainLocksHandler->IsTxSafeForMining(
+            clone.GetHash()));
+    }
+
+    std::unique_ptr<CBlockTemplate> blockTemplate =
+        BlockAssembler(::Params()).CreateNewBlock(script);
+    BOOST_REQUIRE(blockTemplate);
+    std::size_t sparkSpendCount = 0;
+    bool hasOriginal = false;
+    bool hasClone = false;
+    for (const auto& tx : blockTemplate->block.vtx) {
+        if (tx->IsSparkSpend()) {
+            ++sparkSpendCount;
+        }
+        hasOriginal |= tx->GetHash() == spend.GetHash();
+        hasClone |= tx->GetHash() == clone.GetHash();
+    }
+    BOOST_CHECK_EQUAL(sparkSpendCount, 1U);
+    BOOST_CHECK(hasOriginal);
+    BOOST_CHECK(!hasClone);
+
+    // A direct active-state reset must invalidate positive proof-cache entries.
+    sparkState->Reset();
+    CValidationState resetState;
+    CSparkTxInfo resetInfo;
+    BOOST_CHECK(!CheckSparkTransaction(
+        spend,
+        resetState,
+        spend.GetHash(),
+        false,
+        activationHeight,
+        false,
+        true,
+        &resetInfo));
+    BOOST_CHECK_EQUAL(
+        resetState.GetRejectReason(),
+        "CheckSparkSpendTransaction: Error: no coins were minted with such parameters");
 }
 
 BOOST_AUTO_TEST_CASE(parse_spark_mintscript)


### PR DESCRIPTION
## Summary

- Define Spark spend verification work as the maximum of used linking tags, coin-group IDs, and serialized cover-set block references.
- Add an activation-gated 25-work-unit limit to block and transaction validation, and apply the same accounting in priority, package, and add-to-block miner paths.
- Move proof-cache lookup ahead of cover-set reconstruction while keeping cache reuse chain-context safe: cache only exactly resolved cutoffs, separate historical and single-input verifier modes, never let cached failures decide block consensus, and clear the cache on disconnect/reset.
- Avoid materializing full cover-set vectors when proof verification is already being deferred to the batch verifier.
- Add regression coverage for activation boundaries, excess serialized references, mempool/block enforcement, miner templates, negative-cache isolation, unresolved cutoffs, and reset invalidation.

## Security rationale

Spark verification cost scales with both proofs and referenced cover sets. Existing block-size and transparent-value limits do not directly bound that work, allowing a valid cache-cold block to amplify cover-set reconstruction and proof verification. The new accounting gives consensus and miners the same deterministic upper bound; the cache changes remove avoidable reconstruction for previously verified transactions without making chain-dependent or policy-only cache results consensus-authoritative.

## Draft / activation blocker

**This is not yet an active public-network mitigation.** Mainnet, testnet, and devnet intentionally set `nSparkSpendLimitStartBlock = INT_MAX`. Regtest activates the rule at its Spark single-input height.

Before this can merge as a production consensus fix:

1. Benchmark maximum-shaped spends against current/worst-case cover sets on representative hardware.
2. Confirm or revise the provisional 25-unit limit.
3. Select fixed future activation heights through a coordinated node/miner upgrade; do not reuse a past height.
4. Exercise devnet/testnet before activating mainnet.

## Validation

Passed locally:

- `git diff --check`
- C++20 syntax compilation of `src/miner.cpp`, `src/spark/state.cpp`, `src/chainparams.cpp`, and `src/test/spark_tests.cpp`

Not run locally:

- the linked Boost unit-test binary; the repository's configured `depends` artifacts were unavailable in this workspace

CI in the supported dependency environment should run the Spark unit tests and benchmark the provisional limit before this leaves draft.