### PR TITLE
Spark: avoid caching failed spend proofs

### DIFF
--- a/src/spark/state.cpp
+++ b/src/spark/state.cpp
@@ -22,7 +22,7 @@ struct ProofCheckState {
 };
 
 // Bound the mempool-acceptance proof cache. Without a cap, peers can relay many
-// distinct spends that parse and fail verification, each leaving a permanent
+// distinct spends that parse and pass verification, each leaving a permanent
 // uint256 entry. DisconnectTipSpark clears on reorg; successful entries are also
 // removed when the mempool drops the transaction.
 static constexpr size_t MAX_CHECKED_SPARK_SPEND_TRANSACTIONS = 10000;
@@ -820,11 +820,13 @@ bool CheckSparkSpendTransaction(
                     ? spark::SpendTransaction::verify(*spend, cover_sets)
                     : spark::SpendTransaction::verifyHistorical(
                         *spend, cover_sets);
-                ProofCheckState newState;
-                newState.fChecked = true;
-                newState.fResult = passVerify;
-                LOCK(cs_checkedSparkSpendTransactions);
-                gCheckedSparkSpendTransactions.insert(hashTx, newState);
+                if (passVerify) {
+                    ProofCheckState newState;
+                    newState.fChecked = true;
+                    newState.fResult = true;
+                    LOCK(cs_checkedSparkSpendTransactions);
+                    gCheckedSparkSpendTransactions.insert(hashTx, newState);
+                }
             }
             else {
                 // we need the answer now, so verify and execute

--- a/src/spark/state.cpp
+++ b/src/spark/state.cpp
@@ -728,8 +728,15 @@ bool CheckSparkSpendTransaction(
 
     for (const auto& idAndHash : idAndBlockHashes) {
         CSparkState::SparkCoinGroupInfo coinGroup;
-        if (!sparkState.GetCoinGroupInfo(idAndHash.first, coinGroup))
-            return state.DoS(100, false, NO_MINT_ZEROCOIN, "CheckSparkSpendTransaction: Error: no coins were minted with such parameters");
+        if (!sparkState.GetCoinGroupInfo(idAndHash.first, coinGroup)) {
+            // A peer may be ahead of us, so avoid an immediate mempool ban
+            // while keeping block validation strict.
+            return state.DoS(
+                isMempoolAcceptance ? 5 : 100,
+                false,
+                isMempoolAcceptance ? REJECT_NONSTANDARD : NO_MINT_ZEROCOIN,
+                "CheckSparkSpendTransaction: Error: no coins were minted with such parameters");
+        }
 
         CBlockIndex *index = coinGroup.lastBlock;
         // find index for block with hash of accumulatorBlockHash or set index to the coinGroup.firstBlock if not found

--- a/src/test/spark_tests.cpp
+++ b/src/test/spark_tests.cpp
@@ -1054,6 +1054,63 @@ BOOST_AUTO_TEST_CASE(spark_proof_cache_is_invalidated_on_cover_set_reorg)
     sparkState->Reset();
 }
 
+BOOST_AUTO_TEST_CASE(spark_failed_proof_is_not_cached)
+{
+    GenerateBlocks(500);
+
+    std::vector<CMutableTransaction> mintTransactions;
+    GenerateMints({5 * COIN, 5 * COIN}, mintTransactions);
+    mempool.clear();
+    BOOST_REQUIRE(GenerateBlock(mintTransactions));
+    GenerateBlocks(10);
+
+    const CTransaction spend = GenerateSparkSpend({4 * COIN}, {}, nullptr);
+    mempool.clear();
+
+    // Change the public output without updating the proof transcript. The
+    // transaction remains well formed, but its proof must return false.
+    CMutableTransaction invalidSpend(spend);
+    bool changedOutput = false;
+    for (CTxOut& output : invalidSpend.vout) {
+        if (!output.scriptPubKey.IsSparkSMint()) {
+            ++output.nValue;
+            changedOutput = true;
+            break;
+        }
+    }
+    BOOST_REQUIRE(changedOutput);
+    const CTransaction invalidTx(invalidSpend);
+
+    CValidationState firstState;
+    BOOST_CHECK(!CheckSparkTransaction(
+        invalidTx,
+        firstState,
+        invalidTx.GetHash(),
+        false,
+        INT_MAX,
+        false,
+        true,
+        nullptr));
+    BOOST_CHECK(firstState.IsValid());
+
+    // A negative cache entry used to turn this second proof failure into a
+    // punitive "previously checked and failed" rejection.
+    CValidationState secondState;
+    BOOST_CHECK(!CheckSparkTransaction(
+        invalidTx,
+        secondState,
+        invalidTx.GetHash(),
+        false,
+        INT_MAX,
+        false,
+        true,
+        nullptr));
+    BOOST_CHECK(secondState.IsValid());
+
+    mempool.clear();
+    sparkState->Reset();
+}
+
 BOOST_AUTO_TEST_CASE(coingroup)
 {
     GenerateBlocks(500);

--- a/src/test/spark_tests.cpp
+++ b/src/test/spark_tests.cpp
@@ -1111,6 +1111,60 @@ BOOST_AUTO_TEST_CASE(spark_failed_proof_is_not_cached)
     sparkState->Reset();
 }
 
+BOOST_AUTO_TEST_CASE(spark_unknown_group_uses_mempool_penalty)
+{
+    GenerateBlocks(500);
+
+    std::vector<CMutableTransaction> mintTransactions;
+    GenerateMints({5 * COIN, 5 * COIN}, mintTransactions);
+    mempool.clear();
+    CBlockIndex* mintIndex = GenerateBlock(mintTransactions);
+    BOOST_REQUIRE(mintIndex);
+    GenerateBlocks(10);
+
+    const CTransaction spend = GenerateSparkSpend({4 * COIN}, {}, nullptr);
+    mempool.clear();
+
+    const int disconnectCount = chainActive.Height() - mintIndex->nHeight + 1;
+    BOOST_REQUIRE_GT(disconnectCount, 0);
+    BOOST_REQUIRE(DisconnectBlocks(disconnectCount));
+    BOOST_REQUIRE(chainActive.Height() < mintIndex->nHeight);
+
+    CValidationState mempoolState;
+    BOOST_CHECK(!CheckSparkTransaction(
+        spend,
+        mempoolState,
+        spend.GetHash(),
+        false,
+        INT_MAX,
+        false,
+        true,
+        nullptr));
+    int mempoolDoS = -1;
+    BOOST_REQUIRE(mempoolState.IsInvalid(mempoolDoS));
+    BOOST_CHECK_EQUAL(mempoolDoS, 5);
+    BOOST_CHECK_EQUAL(mempoolState.GetRejectCode(), REJECT_NONSTANDARD);
+
+    CValidationState blockState;
+    CSparkTxInfo blockInfo;
+    BOOST_CHECK(!CheckSparkTransaction(
+        spend,
+        blockState,
+        spend.GetHash(),
+        false,
+        chainActive.Height() + 1,
+        false,
+        true,
+        &blockInfo));
+    int blockDoS = -1;
+    BOOST_REQUIRE(blockState.IsInvalid(blockDoS));
+    BOOST_CHECK_EQUAL(blockDoS, 100);
+    BOOST_CHECK_EQUAL(blockState.GetRejectCode(), NO_MINT_ZEROCOIN);
+
+    mempool.clear();
+    sparkState->Reset();
+}
+
 BOOST_AUTO_TEST_CASE(coingroup)
 {
     GenerateBlocks(500);


### PR DESCRIPTION
## PR intention
Spark proof verification results are cached to avoid repeating expensive checks. This change caches only successful results, preventing a temporary failure on a lagging node from being reused later when connecting a valid block. A regression test confirms that failed proofs are checked again instead of becoming punitive cached failures.