### PR TITLE
Validation: keep precomputed transaction data alive

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2665,6 +2665,10 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 
     CBlockUndo blockundo;
 
+    // Queued script checks hold pointers into txdata, so txdata must outlive the queue controller.
+    std::vector<PrecomputedTransactionData> txdata;
+    txdata.reserve(block.vtx.size()); // Required so that pointers to individual PrecomputedTransactionData don't get invalidated
+
     CCheckQueueControl<CScriptCheck> control(fScriptChecks && nScriptCheckThreads ? &scriptcheckqueue : NULL);
 
     std::vector<int> prevheights;
@@ -2676,9 +2680,6 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     vPos.reserve(block.vtx.size());
     blockundo.vtxundo.reserve(block.vtx.size() - 1);
     CDbIndexHelper dbIndexHelper(fAddressIndex, fSpentIndex);
-
-    std::vector<PrecomputedTransactionData> txdata;
-    txdata.reserve(block.vtx.size()); // Required so that pointers to individual PrecomputedTransactionData don't get invalidated
 
     std::set<uint256> txIds;
     bool isMainNet = chainparams.GetConsensus().IsMain();


### PR DESCRIPTION
## PR intention
Queued script checks hold pointers to precomputed transaction data during parallel block validation. Construct the transaction data before the queue controller so worker threads always finish before that data is destroyed. This prevents a crafted invalid block from causing a use-after-free when validation returns early.
