### PR TITLE
P2P: Limit LLMQ signing sessions per peer

### DIFF
--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -15,10 +15,23 @@
 
 #include "cxxtimer.hpp"
 
+#include <algorithm>
+
 namespace llmq
 {
 
 CSigSharesManager* quorumSigSharesManager = nullptr;
+
+namespace
+{
+constexpr size_t MAX_SESSIONS_PER_PEER_FACTOR{4};
+constexpr size_t MIN_SESSIONS_PER_PEER{100};
+
+size_t GetMaxSessionsForPeer(const Consensus::LLMQParams& params)
+{
+    return std::max<size_t>(size_t(params.size) * MAX_SESSIONS_PER_PEER_FACTOR, MIN_SESSIONS_PER_PEER);
+}
+}
 
 void CSigShare::UpdateKey()
 {
@@ -131,7 +144,34 @@ CSigSharesNodeState::Session& CSigSharesNodeState::GetOrCreateSessionFromAnn(con
     if (s.announced.inv.empty()) {
         InitSession(s, signHash, ann);
     }
+    s.receivedAnnouncement = true;
     return s;
+}
+
+bool CSigSharesNodeState::CanCreateSessionFromAnn(const CSigSesAnn& ann, size_t maxSessions) const
+{
+    const auto llmqType = (Consensus::LLMQType)ann.llmqType;
+    const auto signHash = CLLMQUtils::BuildSignHash(llmqType, ann.quorumHash, ann.id, ann.msgHash);
+    return sessions.count(signHash) != 0 || GetAnnouncementSessionCount(llmqType) < maxSessions;
+}
+
+size_t CSigSharesNodeState::GetSessionCount() const
+{
+    return sessions.size();
+}
+
+size_t CSigSharesNodeState::GetSessionCount(Consensus::LLMQType llmqType) const
+{
+    return std::count_if(sessions.begin(), sessions.end(), [llmqType](const auto& entry) {
+        return entry.second.llmqType == llmqType;
+    });
+}
+
+size_t CSigSharesNodeState::GetAnnouncementSessionCount(Consensus::LLMQType llmqType) const
+{
+    return std::count_if(sessions.begin(), sessions.end(), [llmqType](const auto& entry) {
+        return entry.second.llmqType == llmqType && entry.second.receivedAnnouncement;
+    });
 }
 
 CSigSharesNodeState::Session* CSigSharesNodeState::GetSessionBySignHash(const uint256& signHash)
@@ -311,7 +351,9 @@ void CSigSharesManager::ProcessMessage(CNode* pfrom, const std::string& strComma
 bool CSigSharesManager::ProcessMessageSigSesAnn(CNode* pfrom, const CSigSesAnn& ann, CConnman& connman)
 {
     auto llmqType = (Consensus::LLMQType)ann.llmqType;
-    if (!Params().GetConsensus().llmqs.count(llmqType)) {
+    const auto& llmqs = Params().GetConsensus().llmqs;
+    const auto paramsIt = llmqs.find(llmqType);
+    if (paramsIt == llmqs.end()) {
         return false;
     }
     if (ann.sessionId == (uint32_t)-1 || ann.quorumHash.IsNull() || ann.id.IsNull() || ann.msgHash.IsNull()) {
@@ -328,15 +370,22 @@ bool CSigSharesManager::ProcessMessageSigSesAnn(CNode* pfrom, const CSigSesAnn& 
         return true; // let's still try other announcements from the same message
     }
 
-    FIRO_UNUSED auto signHash = CLLMQUtils::BuildSignHash(llmqType, ann.quorumHash, ann.id, ann.msgHash);
-
     LOCK(cs);
     auto it = nodeStates.find(pfrom->id);
     if (it != nodeStates.end() && it->second.banned) {
         return true;
     }
     auto& nodeState = it != nodeStates.end() ? it->second : nodeStates[pfrom->id];
+    const size_t maxSessions = GetMaxSessionsForPeer(paramsIt->second);
+    if (!nodeState.CanCreateSessionFromAnn(ann, maxSessions)) {
+        LogPrint("llmq-sigs", "CSigSharesManager::%s -- too many sessions. cnt=%d, max=%d, llmqType=%d, node=%d\n", __func__,
+                 nodeState.GetAnnouncementSessionCount(llmqType), maxSessions, static_cast<int>(llmqType), pfrom->id);
+        return true;
+    }
+
+    const auto signHash = CLLMQUtils::BuildSignHash(llmqType, ann.quorumHash, ann.id, ann.msgHash);
     auto& session = nodeState.GetOrCreateSessionFromAnn(ann);
+    timeSeenForSessions.emplace(signHash, GetAdjustedTime());
     nodeState.sessionByRecvId.erase(session.recvSessionId);
     nodeState.sessionByRecvId.erase(ann.sessionId);
     session.recvSessionId = ann.sessionId;
@@ -1226,7 +1275,7 @@ void CSigSharesManager::Cleanup()
     {
         LOCK(cs);
 
-        // Remove sessions which were succesfully recovered
+        // Remove sessions which were successfully recovered
         std::unordered_set<uint256, StaticSaltedHasher> doneSessions;
         sigShares.ForEach([&](const SigShareKey& k, const CSigShare& sigShare) {
             if (doneSessions.count(sigShare.GetSignHash())) {
@@ -1236,6 +1285,11 @@ void CSigSharesManager::Cleanup()
                 doneSessions.emplace(sigShare.GetSignHash());
             }
         });
+        for (const auto& p : timeSeenForSessions) {
+            if (!doneSessions.count(p.first) && quorumSigningManager->HasRecoveredSigForSession(p.first)) {
+                doneSessions.emplace(p.first);
+            }
+        }
         for (auto& signHash : doneSessions) {
             RemoveSigSharesForSession(signHash);
         }

--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -144,7 +144,7 @@ CSigSharesNodeState::Session& CSigSharesNodeState::GetOrCreateSessionFromAnn(con
     if (s.announced.inv.empty()) {
         InitSession(s, signHash, ann);
     }
-    s.receivedAnnouncement = true;
+    s.fReceivedAnnouncement = true;
     return s;
 }
 
@@ -152,7 +152,7 @@ bool CSigSharesNodeState::CanCreateSessionFromAnn(const CSigSesAnn& ann, size_t 
 {
     const auto llmqType = (Consensus::LLMQType)ann.llmqType;
     const auto signHash = CLLMQUtils::BuildSignHash(llmqType, ann.quorumHash, ann.id, ann.msgHash);
-    return sessions.count(signHash) != 0 || GetAnnouncementSessionCount(llmqType) < maxSessions;
+    return sessions.find(signHash) != sessions.end() || GetAnnouncementSessionCount(llmqType) < maxSessions;
 }
 
 size_t CSigSharesNodeState::GetSessionCount() const
@@ -170,7 +170,7 @@ size_t CSigSharesNodeState::GetSessionCount(Consensus::LLMQType llmqType) const
 size_t CSigSharesNodeState::GetAnnouncementSessionCount(Consensus::LLMQType llmqType) const
 {
     return std::count_if(sessions.begin(), sessions.end(), [llmqType](const auto& entry) {
-        return entry.second.llmqType == llmqType && entry.second.receivedAnnouncement;
+        return entry.second.llmqType == llmqType && entry.second.fReceivedAnnouncement;
     });
 }
 

--- a/src/llmq/quorums_signing_shares.h
+++ b/src/llmq/quorums_signing_shares.h
@@ -315,7 +315,7 @@ public:
         CSigSharesInv requested;
         CSigSharesInv knows;
 
-        bool receivedAnnouncement{false};
+        bool fReceivedAnnouncement{false};
     };
     std::unordered_map<uint256, Session, StaticSaltedHasher> sessions;
 

--- a/src/llmq/quorums_signing_shares.h
+++ b/src/llmq/quorums_signing_shares.h
@@ -314,8 +314,9 @@ public:
         CSigSharesInv announced;
         CSigSharesInv requested;
         CSigSharesInv knows;
+
+        bool receivedAnnouncement{false};
     };
-    // TODO limit number of sessions per node
     std::unordered_map<uint256, Session, StaticSaltedHasher> sessions;
 
     std::unordered_map<uint32_t, Session*> sessionByRecvId;
@@ -328,6 +329,10 @@ public:
 
     Session& GetOrCreateSessionFromShare(const CSigShare& sigShare);
     Session& GetOrCreateSessionFromAnn(const CSigSesAnn& ann);
+    bool CanCreateSessionFromAnn(const CSigSesAnn& ann, size_t maxSessions) const;
+    size_t GetSessionCount() const;
+    size_t GetSessionCount(Consensus::LLMQType llmqType) const;
+    size_t GetAnnouncementSessionCount(Consensus::LLMQType llmqType) const;
     Session* GetSessionBySignHash(const uint256& signHash);
     Session* GetSessionByRecvId(uint32_t sessionId);
     bool GetSessionInfoByRecvId(uint32_t sessionId, SessionInfo& retInfo);

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -49,6 +49,7 @@ add_executable(test_firo
   ${CMAKE_CURRENT_SOURCE_DIR}/dbwrapper_tests.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/limitedmap_tests.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/logging_tests.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/llmq_signing_shares_tests.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/main_tests.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/mbstring_tests.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/mempool_tests.cpp

--- a/src/test/llmq_signing_shares_tests.cpp
+++ b/src/test/llmq_signing_shares_tests.cpp
@@ -3,6 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "llmq/quorums_signing.h"
 #include "llmq/quorums_signing_shares.h"
 #include "test/test_bitcoin.h"
 

--- a/src/test/llmq_signing_shares_tests.cpp
+++ b/src/test/llmq_signing_shares_tests.cpp
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 The Dash Core developers
+// Copyright (c) 2026 The Firo developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "llmq/quorums_signing_shares.h"
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+
+namespace llmq
+{
+namespace
+{
+uint256 TestHash(uint32_t value)
+{
+    uint256 hash;
+    hash.SetHex(strprintf("%064x", value));
+    return hash;
+}
+
+CSigSesAnn MakeAnn(Consensus::LLMQType llmqType, uint32_t uniqueValue)
+{
+    CSigSesAnn ann;
+    ann.sessionId = uniqueValue;
+    ann.llmqType = llmqType;
+    ann.quorumHash = TestHash(1);
+    ann.id = TestHash(uniqueValue + 100);
+    ann.msgHash = TestHash(uniqueValue + 200);
+    return ann;
+}
+
+CSigShare MakeShare(Consensus::LLMQType llmqType, uint32_t uniqueValue)
+{
+    CSigShare share;
+    share.llmqType = llmqType;
+    share.quorumHash = TestHash(1);
+    share.quorumMember = 0;
+    share.id = TestHash(uniqueValue + 100);
+    share.msgHash = TestHash(uniqueValue + 200);
+    share.UpdateKey();
+    return share;
+}
+}
+
+BOOST_FIXTURE_TEST_SUITE(llmq_signing_shares_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(session_announcement_limit_allows_known_session)
+{
+    constexpr size_t maxSessions{2};
+    CSigSharesNodeState nodeState;
+    auto ann1 = MakeAnn(Consensus::LLMQ_50_60, 1);
+    auto ann2 = MakeAnn(Consensus::LLMQ_50_60, 2);
+    const auto ann3 = MakeAnn(Consensus::LLMQ_50_60, 3);
+
+    BOOST_CHECK(nodeState.CanCreateSessionFromAnn(ann1, maxSessions));
+    nodeState.GetOrCreateSessionFromAnn(ann1);
+    BOOST_CHECK(nodeState.CanCreateSessionFromAnn(ann2, maxSessions));
+    nodeState.GetOrCreateSessionFromAnn(ann2);
+
+    BOOST_CHECK_EQUAL(nodeState.GetAnnouncementSessionCount(Consensus::LLMQ_50_60), maxSessions);
+    BOOST_CHECK(!nodeState.CanCreateSessionFromAnn(ann3, maxSessions));
+
+    ann1.sessionId = 4;
+    BOOST_CHECK(nodeState.CanCreateSessionFromAnn(ann1, maxSessions));
+    nodeState.GetOrCreateSessionFromAnn(ann1);
+    BOOST_CHECK_EQUAL(nodeState.GetSessionCount(), maxSessions);
+}
+
+BOOST_AUTO_TEST_CASE(send_only_sessions_do_not_count_toward_announcement_limit)
+{
+    constexpr size_t maxSessions{1};
+    CSigSharesNodeState nodeState;
+    const auto share = MakeShare(Consensus::LLMQ_50_60, 1);
+    const auto ann1 = MakeAnn(Consensus::LLMQ_50_60, 2);
+    const auto ann2 = MakeAnn(Consensus::LLMQ_50_60, 3);
+
+    nodeState.GetOrCreateSessionFromShare(share);
+    BOOST_CHECK_EQUAL(nodeState.GetSessionCount(Consensus::LLMQ_50_60), 1U);
+    BOOST_CHECK_EQUAL(nodeState.GetAnnouncementSessionCount(Consensus::LLMQ_50_60), 0U);
+
+    BOOST_CHECK(nodeState.CanCreateSessionFromAnn(ann1, maxSessions));
+    nodeState.GetOrCreateSessionFromAnn(ann1);
+    BOOST_CHECK(!nodeState.CanCreateSessionFromAnn(ann2, maxSessions));
+    BOOST_CHECK_EQUAL(nodeState.GetSessionCount(), 2U);
+}
+
+BOOST_AUTO_TEST_CASE(session_announcement_limit_is_per_llmq_type)
+{
+    constexpr size_t maxSessions{1};
+    CSigSharesNodeState nodeState;
+    const auto typeOneAnn1 = MakeAnn(Consensus::LLMQ_50_60, 1);
+    const auto typeOneAnn2 = MakeAnn(Consensus::LLMQ_50_60, 2);
+    const auto typeTwoAnn = MakeAnn(Consensus::LLMQ_400_60, 3);
+
+    nodeState.GetOrCreateSessionFromAnn(typeOneAnn1);
+    BOOST_CHECK(!nodeState.CanCreateSessionFromAnn(typeOneAnn2, maxSessions));
+    BOOST_CHECK(nodeState.CanCreateSessionFromAnn(typeTwoAnn, maxSessions));
+    nodeState.GetOrCreateSessionFromAnn(typeTwoAnn);
+
+    BOOST_CHECK_EQUAL(nodeState.GetAnnouncementSessionCount(Consensus::LLMQ_50_60), 1U);
+    BOOST_CHECK_EQUAL(nodeState.GetAnnouncementSessionCount(Consensus::LLMQ_400_60), 1U);
+    BOOST_CHECK_EQUAL(nodeState.GetSessionCount(), 2U);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}


### PR DESCRIPTION
## PR intention

Prevent unauthenticated peers from retaining an unbounded number of LLMQ signing-share sessions through QSIGSESANN announcements.

This adapts https://github.com/dashpay/dash/pull/7351 to Firo's older LLMQ implementation.

## Code changes brief

- Cap announcement-created sessions per peer and LLMQ type at `max(4 * quorum size, 100)`.
- Continue accepting re-announcements for known sessions and exclude locally created send-only sessions from the cap.
- Start session expiry on the first announcement without refreshing the timer on repeats, and clean recovered announcement-only sessions.
- Add focused unit coverage for cap enforcement, refreshes, send-only sessions, and per-type isolation.

## Validation

- `git diff --check origin/master...HEAD`
- Unit tests not run locally: no CMake/compiler or `test_firo` binary is available in this checkout.
