### PR TITLE
CI: retain symbols in release builds

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build_type: [Release, Debug]
+        build_type: [RelWithDebInfo, Debug]
         include:
           - platform: linux
             runs_on: ubuntu-22.04


### PR DESCRIPTION
## PR intention
Use RelWithDebInfo for all CI release builds so crashes include symbolized stack traces without disabling optimization.