### PR TITLE
Tests: initialize mnemonic-backed HD wallet

### DIFF
--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -109,9 +109,9 @@ TestingSetup::TestingSetup(const std::string& chainName, std::string suf) : Basi
         // Init HD mint
 
         // Create new keyUser and set as default key
-        // generate a new master key
-        CPubKey masterPubKey = pwalletMain->GenerateNewHDMasterKey();
-        pwalletMain->SetHDMasterKey(masterPubKey);
+        // generate a new mnemonic-backed HD chain
+        pwalletMain->GenerateNewMnemonic();
+        pwalletMain->SetMinVersion(FEATURE_HD);
         CPubKey newDefaultKey;
         if (pwalletMain->GetKeyFromPool(newDefaultKey)) {
             pwalletMain->SetDefaultKey(newDefaultKey);


### PR DESCRIPTION
## PR intention
The test fixture marked its wallet as mnemonic-backed HD without creating a mnemonic seed, causing an out-of-bounds access during key generation. Initialize the fixture through the normal mnemonic wallet path so Spark tests receive a valid HD seed.
