### PR TITLE
Qt: improve redesign responsiveness and polish

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1769,7 +1769,6 @@ void BitcoinGUI::setNumBlocks(int count, const QDateTime& blockDate, double nVer
         if(walletFrame)
         {
             walletFrame->showOutOfSyncWarning(true);
-            modalOverlay->showHide();
         }
 #endif // ENABLE_WALLET
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1211,35 +1211,37 @@ void BitcoinGUI::updateNavigationSidebarGeometry()
 
     const bool compact = centralWidget()->height() < 600;
     const bool ultraCompact = centralWidget()->height() < 450;
-    bool densityChanged = false;
-    if (toolbar->property("compact").toBool() != compact) {
-        toolbar->setProperty("compact", compact);
-        densityChanged = true;
-    }
-    if (toolbar->property("ultraCompact").toBool() != ultraCompact) {
-        toolbar->setProperty("ultraCompact", ultraCompact);
-        densityChanged = true;
-    }
+    const bool densityChanged = !toolbar->property("compact").isValid()
+        || !toolbar->property("ultraCompact").isValid()
+        || toolbar->property("compact").toBool() != compact
+        || toolbar->property("ultraCompact").toBool() != ultraCompact;
     if (densityChanged) {
+        toolbar->setProperty("compact", compact);
+        toolbar->setProperty("ultraCompact", ultraCompact);
         toolbar->style()->unpolish(toolbar);
         toolbar->style()->polish(toolbar);
-    }
-    if (logoLabel) {
-        logoLabel->setVisible(!ultraCompact);
-        logoLabel->setFixedHeight(compact ? 54 : 88);
-    }
-    if (navigationThemeRow) {
-        navigationThemeRow->setMinimumHeight(compact ? 34 : 0);
-        navigationThemeRow->setMaximumHeight(compact ? 34 : QWIDGETSIZE_MAX);
-        if (QLayout* layout = navigationThemeRow->layout())
-            layout->setContentsMargins(12, compact ? 4 : 8, 12, compact ? 4 : 8);
-    }
-    if (navigationSyncCard) {
-        navigationSyncCard->setMinimumHeight(compact ? 58 : 76);
-        navigationSyncCard->setMaximumHeight(compact ? 58 : QWIDGETSIZE_MAX);
-        if (QLayout* layout = navigationSyncCard->layout()) {
-            layout->setContentsMargins(10, compact ? 6 : 11, 14, compact ? 6 : 11);
-            layout->setSpacing(compact ? 4 : 8);
+
+        if (logoLabel) {
+            logoLabel->setVisible(!ultraCompact);
+            logoLabel->setFixedHeight(compact ? 54 : 88);
+        }
+        if (navigationThemeRow) {
+            navigationThemeRow->setMinimumHeight(compact ? 34 : 0);
+            navigationThemeRow->setMaximumHeight(compact ? 34 : QWIDGETSIZE_MAX);
+            if (QLayout* layout = navigationThemeRow->layout())
+                layout->setContentsMargins(12, compact ? 4 : 8, 12, compact ? 4 : 8);
+        }
+        if (navigationSyncCard) {
+            navigationSyncCard->setMinimumHeight(compact ? 58 : 76);
+            navigationSyncCard->setMaximumHeight(compact ? 58 : QWIDGETSIZE_MAX);
+            if (QLayout* layout = navigationSyncCard->layout()) {
+                layout->setContentsMargins(10, compact ? 6 : 11, 14, compact ? 6 : 11);
+                layout->setSpacing(compact ? 4 : 8);
+            }
+        }
+        if (QLayout* layout = toolbar->layout()) {
+            layout->invalidate();
+            layout->activate();
         }
     }
 
@@ -1258,10 +1260,6 @@ void BitcoinGUI::updateNavigationSidebarGeometry()
         ? NAVIGATION_SIDEBAR_WIDTH - NAVIGATION_TOGGLE_WIDTH / 2
         : 8;
     navigationToggleButton->move(toggleX, 20);
-    if (QLayout* layout = toolbar->layout()) {
-        layout->invalidate();
-        layout->activate();
-    }
     updateNavigationSelectionHighlight();
     toolbar->raise();
     navigationToggleButton->raise();
@@ -2221,7 +2219,6 @@ void BitcoinGUI::checkZnodeVisibility(int numBlocks) {
     } else {
         masternodeAction->setVisible(true);
     }
-    updateToolbarTabWidths();
 }
 
 void BitcoinGUI::checkSparkNamesVisibility(int numBlocks) {
@@ -2233,7 +2230,6 @@ void BitcoinGUI::checkSparkNamesVisibility(int numBlocks) {
     const bool visible = spark::IsSparkAllowed(nextBlockHeight) &&
         nextBlockHeight >= params.nSparkNamesStartBlock;
     sparkNamesAction->setVisible(visible);
-    updateToolbarTabWidths();
 }
 
 void BitcoinGUI::toggleNetworkActive()
@@ -2319,6 +2315,5 @@ void UnitDisplayStatusBarControl::onMenuSelection(QAction* action)
 // Handles resize events for the BitcoinGUI widget by adjusting internal component sizes.
 void BitcoinGUI::resizeEvent(QResizeEvent* event) {
     QMainWindow::resizeEvent(event);
-    updateToolbarTabWidths();
     updateNavigationSidebarGeometry();
 }

--- a/src/qt/forms/modaloverlay.ui
+++ b/src/qt/forms/modaloverlay.ui
@@ -157,38 +157,6 @@
                </property>
               </widget>
              </item>
-             <item>
-              <widget class="QLabel" name="infoTextStrong">
-               <property name="font">
-                <font>
-                 <weight>75</weight>
-                 <bold>true</bold>
-                </font>
-               </property>
-               <property name="text">
-                <string>Spending firos affected by not-yet-displayed transactions won't be accepted by the network.</string>
-               </property>
-               <property name="textFormat">
-                <enum>Qt::RichText</enum>
-               </property>
-               <property name="wordWrap">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="verticalSpacerInTextSpace">
-               <property name="orientation">
-                <enum>Qt::Vertical</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>20</width>
-                 <height>24</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
             </layout>
            </item>
           </layout>

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -212,7 +212,7 @@
           </item>
           <item>
            <widget class="QLabel" name="labelPrivateSplit">
-            <property name="text"><string>Private 0.00000000 FIRO (0%)</string></property>
+            <property name="text"><string>Private (Spark): 0.00000000 FIRO (0%)</string></property>
             <property name="alignment"><set>Qt::AlignRight|Qt::AlignVCenter</set></property>
            </widget>
           </item>
@@ -273,7 +273,7 @@
         <property name="spacing"><number>8</number></property>
         <item>
          <widget class="QLabel" name="label_5">
-          <property name="text"><string>Private Balances</string></property>
+          <property name="text"><string>Private Balances (Spark)</string></property>
          </widget>
         </item>
         <item>

--- a/src/qt/forms/receivecoinsdialog.ui
+++ b/src/qt/forms/receivecoinsdialog.ui
@@ -34,10 +34,10 @@
         <item>
          <widget class="QLabel" name="addressTypeLabel">
            <property name="toolTip">
-             <string>An optional label to associate with the new receiving address.</string>
+             <string>Choose Spark or Transparent for the payment request address.</string>
            </property>
            <property name="text">
-             <string>ADDRESS</string>
+             <string>ADDRESS TYPE</string>
            </property>
          </widget>
         </item>
@@ -45,16 +45,6 @@
           <layout class="QHBoxLayout" name="addressTypeHorizontalLayout">
             <item>
               <widget class="QComboBox" name="addressTypeCombobox">
-              </widget>
-            </item>
-            <item>
-              <widget class="QLabel" name="label_5">
-                <property name="text">
-                  <string>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;. Default address is &lt;b&gt;spark&lt;/b&gt;. </string>
-                </property>
-                <property name="wordWrap">
-                  <bool>true</bool>
-                </property>
               </widget>
             </item>
             <item>

--- a/src/qt/guitheme.cpp
+++ b/src/qt/guitheme.cpp
@@ -8,11 +8,10 @@
 #include <QApplication>
 #include <QColor>
 #include <QGraphicsDropShadowEffect>
-#include <QHash>
 #include <QIcon>
 #include <QPainter>
-#include <QPair>
 #include <QPixmap>
+#include <QPixmapCache>
 #include <QSettings>
 #include <QSize>
 #include <QWidget>
@@ -202,6 +201,16 @@ QPixmap themedStatusIconPixmap(const QIcon& icon, const QSize& size)
     if (!isDarkMode() || source.isNull())
         return source;
 
+    const QString cacheKey = QStringLiteral("firo-themed-status:%1:%2x%3:%4:%5")
+                                 .arg(source.cacheKey())
+                                 .arg(source.width())
+                                 .arg(source.height())
+                                 .arg(source.devicePixelRatio())
+                                 .arg(themeColors().inkSoft);
+    QPixmap cached;
+    if (QPixmapCache::find(cacheKey, &cached))
+        return cached;
+
     QImage img = source.toImage().convertToFormat(QImage::Format_ARGB32_Premultiplied);
     const QColor tint(themeColors().inkSoft);
     for (int y = 0; y < img.height(); ++y) {
@@ -214,6 +223,7 @@ QPixmap themedStatusIconPixmap(const QIcon& icon, const QSize& size)
 
     QPixmap result = QPixmap::fromImage(img);
     result.setDevicePixelRatio(source.devicePixelRatio());
+    QPixmapCache::insert(cacheKey, result);
     return result;
 }
 

--- a/src/qt/modaloverlay.cpp
+++ b/src/qt/modaloverlay.cpp
@@ -78,12 +78,6 @@ foreverHidden(false)
     ui->warningIcon->setFocusPolicy(Qt::NoFocus);
     ui->warningIcon->setAttribute(Qt::WA_TransparentForMouseEvents);
 
-    auto* contentShadow = new QGraphicsDropShadowEffect(ui->contentWidget);
-    contentShadow->setBlurRadius(30);
-    contentShadow->setOffset(0, 10);
-    contentShadow->setColor(QColor(35, 24, 32, 70));
-    ui->contentWidget->setGraphicsEffect(contentShadow);
-
     auto* buttonShadow = new QGraphicsDropShadowEffect(ui->closeButton);
     buttonShadow->setBlurRadius(20);
     buttonShadow->setOffset(0, 6);

--- a/src/qt/modaloverlay.cpp
+++ b/src/qt/modaloverlay.cpp
@@ -136,11 +136,6 @@ void ModalOverlay::applyTheme()
     color: $INK_SOFT;
     font-size: 14px;
 }
-#contentWidget QLabel#infoTextStrong {
-    color: $INK;
-    font-weight: 700;
-    font-size: 13px;
-}
 #contentWidget QFrame#syncStatsCard {
     background: $PANEL_SOFT;
     border: 1px solid $BORDER;

--- a/src/qt/modaloverlay.cpp
+++ b/src/qt/modaloverlay.cpp
@@ -359,6 +359,14 @@ void ModalOverlay::showHide(bool hide, bool userRequested)
     if (!isVisible() && !hide)
         setVisible(true);
 
+    // The initial sync state is set before the main window is shown. Place the
+    // overlay directly instead of animating inside a window that is still hidden.
+    if (!hide && !window()->isVisible()) {
+        setGeometry(0, 0, width(), height());
+        layerIsVisible = true;
+        return;
+    }
+
     setGeometry(0, hide ? 0 : height(), width(), height());
 
     QPropertyAnimation* animation = new QPropertyAnimation(this, "pos");

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -823,7 +823,7 @@ void OverviewPage::updateBalanceSplitLabels()
             .arg(BitcoinUnits::formatWithUnit(unit, privateTotal, false, BitcoinUnits::separatorAlways).toHtmlEscaped())
             .arg(privatePercent)
             .arg(tc.teal, tc.inkSoft, tc.ink)
-            .arg(tr("Private")));
+            .arg(tr("Private (Spark):")));
 }
 
 void OverviewPage::updatePrivateTransparentSplitBar()
@@ -832,7 +832,7 @@ void OverviewPage::updatePrivateTransparentSplitBar()
         return;
     privateSplitProgress->setValue(privateBarSplitPercent_);
     privateSplitProgress->setToolTip(
-        tr("Private %1%  ·  Transparent %2%")
+        tr("Private (Spark) %1%  ·  Transparent %2%")
             .arg(privateBarSplitPercent_)
             .arg(100 - privateBarSplitPercent_));
 }

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -250,7 +250,6 @@ void OverviewPage::applyOverviewRedesign()
     ui->activityCardLayout->setSpacing(8);
     addShadow(ui->balancesCard);
     addShadow(ui->detailsCard);
-    addShadow(ui->activityCard);
 
     ui->detailsCard->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
     ui->activityCard->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);

--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -309,8 +309,6 @@ void ReceiveCoinsDialog::applyTheme()
     for (QLabel* caption : {ui->addressTypeLabel, ui->label_2, ui->label, ui->label_3}) {
         caption->setStyleSheet(captionStyle);
     }
-    ui->label_5->setStyleSheet(GUIUtil::themed(QStringLiteral(
-        "QLabel { background: transparent; color: $INK_SOFT; font-size: 12px; }")));
     ui->label_6->setStyleSheet(GUIUtil::themed(QStringLiteral(
         "QLabel { background: transparent; color: $INK; font-size: 18px; font-weight: 700; }")));
 
@@ -830,7 +828,6 @@ void ReceiveCoinsDialog::adjustTextSize(int width,int height){
     ui->reuseAddress->setFont(font);
     ui->label_3->setFont(font);
     ui->addressTypeLabel->setFont(font);
-    ui->label_5->setFont(font);
     ui->label_2->setFont(font);
     ui->label->setFont(font);
     ui->label_6->setFont(font);

--- a/src/qt/res/css/firo.css
+++ b/src/qt/res/css/firo.css
@@ -1185,7 +1185,6 @@ QWidget#contentWidget {
     border-color: #878787;
 }
 
-QWidget#contentWidget QLabel#infoTextStrong,
 QWidget#contentWidget QLabel#labelNumberOfBlocksLeft,
 QWidget#contentWidget QLabel#labelLastBlockTime,
 QWidget#contentWidget QLabel#labelSyncDone,

--- a/src/qt/sparknamespage.cpp
+++ b/src/qt/sparknamespage.cpp
@@ -12,7 +12,6 @@
 
 #include <QDateTime>
 #include <QEvent>
-#include <QGraphicsDropShadowEffect>
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QLocale>
@@ -212,15 +211,6 @@ SparkNamesPage::SparkNamesPage(const PlatformStyle *_platformStyle, QWidget *par
     emptyLayout->addStretch();
     namesScroll->viewport()->installEventFilter(this);
 
-    const auto addCardShadow = [](QWidget* card) {
-        auto* shadow = new QGraphicsDropShadowEffect(card);
-        shadow->setBlurRadius(20);
-        shadow->setOffset(0, 5);
-        shadow->setColor(QColor(65, 37, 52, 24));
-        card->setGraphicsEffect(shadow);
-    };
-    addCardShadow(ui->sparkNamesContentCard);
-
     ui->createSparkNameButton->setStyleSheet(GUIUtil::primaryButtonStyle());
     GUIUtil::applyPrimaryButtonShadow(ui->createSparkNameButton);
 
@@ -377,12 +367,6 @@ QFrame *SparkNamesPage::createSparkNameCard(const QString &name, const QString &
     frame->setAttribute(Qt::WA_StyledBackground, true);
     frame->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
     frame->setMinimumHeight(126);
-
-    auto* shadow = new QGraphicsDropShadowEffect(frame);
-    shadow->setBlurRadius(16);
-    shadow->setOffset(0, 3);
-    shadow->setColor(QColor(65, 37, 52, 18));
-    frame->setGraphicsEffect(shadow);
 
     auto* root = new QVBoxLayout(frame);
     root->setContentsMargins(16, 14, 16, 14);

--- a/src/qt/sparknamespage.cpp
+++ b/src/qt/sparknamespage.cpp
@@ -21,6 +21,7 @@
 #include <QScrollArea>
 #include <QTimer>
 #include <QToolButton>
+#include <QVariant>
 #include <QVBoxLayout>
 
 #include <algorithm>
@@ -253,12 +254,12 @@ void SparkNamesPage::setClientModel(ClientModel *_clientModel)
     clientModel = _clientModel;
     if (clientModel) {
         connect(clientModel, &ClientModel::numBlocksChanged,
-                this, [this](int, const QDateTime&, double, bool header) {
+                this, [this](int count, const QDateTime&, double, bool header) {
                     if (!header && clientModel && !clientModel->inInitialBlockDownload())
-                        scheduleRefreshList();
+                        updateCardStatuses(count);
                 });
     }
-    refreshList();
+    updateCardStatuses(clientModel ? clientModel->getNumBlocks() : 0);
 }
 
 void SparkNamesPage::scheduleRefreshList()
@@ -333,40 +334,24 @@ void SparkNamesPage::refreshList()
 
     const int currentHeight = clientModel ? clientModel->getNumBlocks() : 0;
 
-    constexpr int nBlocksPerHour = 24;
-    constexpr int nBlocksPerMonth = nBlocksPerHour * 24 * 30;
-
     for (const auto &entry : sparkNames) {
-        const qint64 remainingBlocks = static_cast<qint64>(entry.validityHeight) - currentHeight;
-        QString expiry;
-        int statusKind;
-        if (remainingBlocks <= 0) {
-            expiry = tr("Expired");
-            statusKind = 2;
-        } else {
-            const QDateTime expiryDate = QDateTime::currentDateTime().addSecs(
-                (qint64)remainingBlocks * 3600 / nBlocksPerHour);
-            expiry = QLocale::system().toString(expiryDate.date(), QLocale::LongFormat);
-            statusKind = remainingBlocks < nBlocksPerMonth ? 1 : 0;
-        }
-
         QFrame *card = createSparkNameCard(
-            entry.name, entry.address, expiry, statusKind, entry.additionalInfo);
+            entry.name, entry.address, entry.validityHeight, entry.additionalInfo, currentHeight);
         namesCardsLayout->addWidget(card);
     }
 
     updateEmptyState();
 }
 
-QFrame *SparkNamesPage::createSparkNameCard(const QString &name, const QString &address, const QString &expiry,
-                                             int statusKind, const QString &additionalInfo)
+QFrame *SparkNamesPage::createSparkNameCard(const QString &name, const QString &address, uint64_t validityHeight,
+                                             const QString &additionalInfo, int currentHeight)
 {
-    const GUIUtil::ThemeColors& tc = GUIUtil::themeColors();
     auto* frame = new QFrame(namesCardsHost);
     frame->setObjectName(QStringLiteral("sparkNameCard"));
     frame->setAttribute(Qt::WA_StyledBackground, true);
     frame->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
     frame->setMinimumHeight(126);
+    frame->setProperty("validityHeight", QVariant::fromValue<qulonglong>(validityHeight));
 
     auto* root = new QVBoxLayout(frame);
     root->setContentsMargins(16, 14, 16, 14);
@@ -397,23 +382,10 @@ QFrame *SparkNamesPage::createSparkNameCard(const QString &name, const QString &
     titleCol->addWidget(addressLab);
     header->addLayout(titleCol, 1);
 
-    QString badgeBg = tc.tealTint;
-    QString statusText = tr("Active");
-    if (statusKind == 1) {
-        badgeBg = tc.goldTint;
-        statusText = tr("Expiring Soon");
-    } else if (statusKind == 2) {
-        badgeBg = tc.wineTint;
-        statusText = tr("Expired");
-    }
-    auto* statusLab = new QLabel(statusText, frame);
+    auto* statusLab = new QLabel(frame);
     statusLab->setObjectName(QStringLiteral("cardStatusBadge"));
     statusLab->setAlignment(Qt::AlignCenter);
     statusLab->setMinimumHeight(22);
-    statusLab->setStyleSheet(QStringLiteral(
-        "QLabel { background: %1; color: %2; border: none; border-radius: 11px;"
-        " padding: 2px 10px; font-size: 12px; font-weight: 700; }")
-                                 .arg(badgeBg, tc.ink));
     header->addWidget(statusLab, 0, Qt::AlignVCenter);
 
     root->addLayout(header);
@@ -429,7 +401,9 @@ QFrame *SparkNamesPage::createSparkNameCard(const QString &name, const QString &
     auto* grid = new QHBoxLayout();
     grid->setContentsMargins(0, 0, 0, 0);
     grid->setSpacing(4);
-    grid->addWidget(metricColumn(tr("EXPIRES"), expiry, frame), 1);
+    auto* expiryMetric = metricColumn(tr("EXPIRES"), QString(), frame);
+    expiryMetric->setObjectName(QStringLiteral("cardExpiryMetric"));
+    grid->addWidget(expiryMetric, 1);
     if (!additionalInfo.isEmpty())
         grid->addWidget(metricColumn(tr("ADDITIONAL INFO"), additionalInfo, frame), 2);
     grid->addStretch(additionalInfo.isEmpty() ? 2 : 0);
@@ -459,7 +433,74 @@ QFrame *SparkNamesPage::createSparkNameCard(const QString &name, const QString &
 
     root->addLayout(actionsRow);
 
+    updateCardStatus(frame, currentHeight);
     return frame;
+}
+
+void SparkNamesPage::updateCardStatuses(int currentHeight)
+{
+    if (!namesCardsLayout)
+        return;
+
+    for (int i = 0; i < namesCardsLayout->count(); ++i) {
+        if (QFrame* card = qobject_cast<QFrame*>(namesCardsLayout->itemAt(i)->widget()))
+            updateCardStatus(card, currentHeight);
+    }
+}
+
+void SparkNamesPage::updateCardStatus(QFrame* card, int currentHeight)
+{
+    const QVariant validity = card->property("validityHeight");
+    auto* statusLabel = card->findChild<QLabel*>(QStringLiteral("cardStatusBadge"));
+    auto* expiryMetric = card->findChild<QWidget*>(QStringLiteral("cardExpiryMetric"));
+    auto* expiryLabel = expiryMetric
+        ? expiryMetric->findChild<QLabel*>(QStringLiteral("cardMetricValue"))
+        : nullptr;
+    if (!validity.isValid() || !statusLabel || !expiryLabel)
+        return;
+
+    constexpr int blocksPerHour = 24;
+    constexpr int blocksPerMonth = blocksPerHour * 24 * 30;
+    const qint64 remainingBlocks = static_cast<qint64>(validity.toULongLong()) - currentHeight;
+
+    QString expiry;
+    QString statusText;
+    int statusKind;
+    const GUIUtil::ThemeColors& tc = GUIUtil::themeColors();
+    QString badgeBackground;
+    if (remainingBlocks <= 0) {
+        expiry = tr("Expired");
+        statusText = tr("Expired");
+        statusKind = 2;
+        badgeBackground = tc.wineTint;
+    } else {
+        const QDateTime expiryDate = QDateTime::currentDateTime().addSecs(
+            remainingBlocks * 3600 / blocksPerHour);
+        expiry = QLocale::system().toString(expiryDate.date(), QLocale::LongFormat);
+        if (remainingBlocks < blocksPerMonth) {
+            statusText = tr("Expiring Soon");
+            statusKind = 1;
+            badgeBackground = tc.goldTint;
+        } else {
+            statusText = tr("Active");
+            statusKind = 0;
+            badgeBackground = tc.tealTint;
+        }
+    }
+
+    if (expiryLabel->text() != expiry)
+        expiryLabel->setText(expiry);
+
+    const QVariant displayedStatusKind = statusLabel->property("statusKind");
+    if (!displayedStatusKind.isValid() || displayedStatusKind.toInt() != statusKind
+        || statusLabel->text() != statusText) {
+        statusLabel->setText(statusText);
+        statusLabel->setStyleSheet(QStringLiteral(
+            "QLabel { background: %1; color: %2; border: none; border-radius: 11px;"
+            " padding: 2px 10px; font-size: 12px; font-weight: 700; }")
+                                       .arg(badgeBackground, tc.ink));
+        statusLabel->setProperty("statusKind", statusKind);
+    }
 }
 
 void SparkNamesPage::extendSparkName(const QString &name, const QString &address)

--- a/src/qt/sparknamespage.h
+++ b/src/qt/sparknamespage.h
@@ -1,6 +1,8 @@
 #ifndef BITCOIN_QT_SPARKNAMESPAGE_H
 #define BITCOIN_QT_SPARKNAMESPAGE_H
 
+#include <cstdint>
+
 #include <QWidget>
 
 namespace Ui {
@@ -49,11 +51,13 @@ private:
 
     void refreshList();
     void scheduleRefreshList();
+    void updateCardStatuses(int currentHeight);
+    void updateCardStatus(QFrame *card, int currentHeight);
     void updateEmptyState();
     bool eventFilter(QObject *object, QEvent *event) override;
     void applyTheme();
-    QFrame *createSparkNameCard(const QString &name, const QString &address, const QString &expiry,
-                                 int statusKind, const QString &additionalInfo);
+    QFrame *createSparkNameCard(const QString &name, const QString &address, uint64_t validityHeight,
+                                 const QString &additionalInfo, int currentHeight);
     void extendSparkName(const QString &name, const QString &address);
 
 private Q_SLOTS:


### PR DESCRIPTION
## PR intention

Follow up #1914 with focused UI polish and responsiveness fixes found during final review. This targets `ui-redesign`, so merging it updates #1914 directly.

## Code changes brief

- Clarify Spark private-balance labels and simplify the Receive request form.
- Remove obsolete sync copy, avoid the startup-only overlay slide, and reduce live sync repaint work.
- Update Spark Name expiry/status cards in place instead of rebuilding the page every block.
- Avoid redundant sidebar layout work and cache dark-mode status icons.
- Remove blur effects from dynamic Spark Names and recent-activity content.

Design choices: keeps existing Qt widget/model patterns, retains user-triggered sync animation, and avoids changing transaction-model invalidation without runtime profiling.

Validation: `git diff --check`, per-commit diff checks, Qt UI XML parsing, removed-widget/reference checks, and remote-head verification.

Not run: native CMake/Qt build, interactive GUI testing, HiDPI/long-translation visual checks, or runtime profiling because the required local Qt toolchain is unavailable.

Related: #1914 and #1922.