### PR TITLE
bls: Guard null contribution verification vector

### DIFF
--- a/src/bls/bls_worker.cpp
+++ b/src/bls/bls_worker.cpp
@@ -755,7 +755,11 @@ std::future<bool> CBLSWorker::AsyncVerifyContributionShare(const CBLSId& forId,
                                                            const BLSVerificationVectorPtr& vvec,
                                                            const CBLSSecretKey& skContribution)
 {
-    if (!forId.IsValid() || !VerifyVerificationVector(*vvec)) {
+    // vvec may be null when the verification vector for that member was never
+    // received (e.g. a non-member observer that did not get the member's QCONTRIB).
+    // Dereferencing it here is a remote-triggerable crash; treat a missing vvec as a
+    // failed verification, mirroring the null check in VerifyVerificationVectors().
+    if (!forId.IsValid() || vvec == nullptr || !VerifyVerificationVector(*vvec)) {
         auto p = BuildFutureDoneCallback<bool>();
         p.first(false);
         return std::move(p.second);

--- a/src/test/bls_tests.cpp
+++ b/src/test/bls_tests.cpp
@@ -4,6 +4,7 @@
 
 #include "bls/bls.h"
 #include "bls/bls_batchverifier.h"
+#include "bls/bls_worker.h"
 #include "test/test_bitcoin.h"
 
 #include <boost/test/unit_test.hpp>
@@ -152,6 +153,25 @@ BOOST_AUTO_TEST_CASE(batch_verifier_tests)
     // last message invalid from one source
     AddMessage(msgs, 1, 7, 1, false);
     Verify(msgs);
+}
+
+BOOST_AUTO_TEST_CASE(bls_verify_contribution_share_null_vvec_tests)
+{
+    CBLSWorker worker;
+    worker.Start();
+
+    const CBLSId id{uint256S("1")};
+    BOOST_REQUIRE(id.IsValid());
+
+    CBLSSecretKey sk;
+    sk.MakeNewKey();
+
+    const BLSVerificationVectorPtr nullVvec;
+    BOOST_REQUIRE(nullVvec == nullptr);
+
+    BOOST_CHECK(worker.AsyncVerifyContributionShare(id, nullVvec, sk).get() == false);
+
+    worker.Stop();
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Reject DKG contribution-share verification when its verification vector is missing. This prevents a null dereference and deterministic node crash during DKG processing.