### PR TITLE
Qt: Refresh GUI translation source catalog

### DIFF
--- a/share/qt/extract_strings_qt.py
+++ b/share/qt/extract_strings_qt.py
@@ -77,13 +77,13 @@ f.write("""
 #endif
 """)
 f.write('static const char UNUSED *bitcoin_strings[] = {\n')
-f.write('QT_TRANSLATE_NOOP("bitcoin-core", "%s"),\n' % (os.getenv('PACKAGE_NAME'),))
-f.write('QT_TRANSLATE_NOOP("bitcoin-core", "%s"),\n' % (os.getenv('COPYRIGHT_HOLDERS'),))
+f.write('QT_TRANSLATE_NOOP("firo-core", "%s"),\n' % (os.getenv('PACKAGE_NAME'),))
+f.write('QT_TRANSLATE_NOOP("firo-core", "%s"),\n' % (os.getenv('COPYRIGHT_HOLDERS'),))
 if os.getenv('COPYRIGHT_HOLDERS_SUBSTITUTION') != os.getenv('PACKAGE_NAME'):
-    f.write('QT_TRANSLATE_NOOP("bitcoin-core", "%s"),\n' % (os.getenv('COPYRIGHT_HOLDERS_SUBSTITUTION'),))
+    f.write('QT_TRANSLATE_NOOP("firo-core", "%s"),\n' % (os.getenv('COPYRIGHT_HOLDERS_SUBSTITUTION'),))
 messages.sort(key=operator.itemgetter(0))
 for (msgid, msgstr) in messages:
     if msgid != EMPTY:
-        f.write('QT_TRANSLATE_NOOP("bitcoin-core", %s),\n' % ('\n'.join(msgid)))
+        f.write('QT_TRANSLATE_NOOP("firo-core", %s),\n' % ('\n'.join(msgid)))
 f.write('};\n')
 f.close()

--- a/share/qt/extract_strings_qt.py
+++ b/share/qt/extract_strings_qt.py
@@ -7,7 +7,7 @@ Extract _("...") strings for translation and convert to Qt stringdefs so that
 they can be picked up by Qt linguist.
 '''
 from __future__ import division,print_function,unicode_literals
-from subprocess import Popen, PIPE
+from subprocess import run, PIPE
 import operator
 import os
 import sys
@@ -59,8 +59,7 @@ if not XGETTEXT:
     print('Cannot extract strings: xgettext utility is not installed or not configured.',file=sys.stderr)
     print('Please install package "gettext" and re-run \'./configure\'.',file=sys.stderr)
     exit(1)
-child = Popen([XGETTEXT,'--output=-','-n','--keyword=_'] + files, stdout=PIPE)
-(out, err) = child.communicate()
+out = run([XGETTEXT,'--output=-','-n','--keyword=_'] + files, stdout=PIPE, check=True).stdout
 
 messages = parse_po(out.decode('utf-8'))
 

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -448,7 +448,7 @@ else()
   get_translatable_sources(qt_translatable_sources src/qt)
   file(GLOB ui_files ${CMAKE_CURRENT_SOURCE_DIR}/forms/*.ui)
   add_custom_target(translate
-    COMMAND ${CMAKE_COMMAND} -E env XGETTEXT=${XGETTEXT_EXECUTABLE} COPYRIGHT_HOLDERS=${COPYRIGHT_HOLDERS} $<TARGET_FILE:Python3::Interpreter> ${PROJECT_SOURCE_DIR}/share/qt/extract_strings_qt.py ${translatable_sources}
+    COMMAND ${CMAKE_COMMAND} -E env XGETTEXT=${XGETTEXT_EXECUTABLE} "PACKAGE_NAME=${CLIENT_NAME}" "COPYRIGHT_HOLDERS=${COPYRIGHT_HOLDERS}" "COPYRIGHT_HOLDERS_SUBSTITUTION=${CLIENT_NAME}" $<TARGET_FILE:Python3::Interpreter> ${PROJECT_SOURCE_DIR}/share/qt/extract_strings_qt.py ${translatable_sources}
     COMMAND Qt6::lupdate -no-obsolete -I ${PROJECT_SOURCE_DIR}/src -locations relative ${CMAKE_CURRENT_SOURCE_DIR}/bitcoinstrings.cpp ${ui_files} ${qt_translatable_sources} -ts ${CMAKE_CURRENT_SOURCE_DIR}/locale/bitcoin_en.ts
     COMMAND Qt6::lconvert -drop-translations -o ${CMAKE_CURRENT_SOURCE_DIR}/locale/bitcoin_en.xlf -i ${CMAKE_CURRENT_SOURCE_DIR}/locale/bitcoin_en.ts
     COMMAND ${SED_EXECUTABLE} -i.old -e "s|source-language=\"en\" target-language=\"en\"|source-language=\"en\"|" -e "/<target xml:space=\"preserve\"><\\/target>/d" ${CMAKE_CURRENT_SOURCE_DIR}/locale/bitcoin_en.xlf

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -447,8 +447,12 @@ else()
   get_translatable_sources(translatable_sources ${translatable_sources_directories})
   get_translatable_sources(qt_translatable_sources src/qt)
   file(GLOB ui_files ${CMAKE_CURRENT_SOURCE_DIR}/forms/*.ui)
+  list(REMOVE_DUPLICATES translatable_sources)
+  list(JOIN translatable_sources "\n" translatable_sources_content)
+  set(translatable_sources_file "${CMAKE_CURRENT_BINARY_DIR}/translation_sources.txt")
+  file(GENERATE OUTPUT "${translatable_sources_file}" CONTENT "${translatable_sources_content}\n")
   add_custom_target(translate
-    COMMAND ${CMAKE_COMMAND} -E env XGETTEXT=${XGETTEXT_EXECUTABLE} "PACKAGE_NAME=${CLIENT_NAME}" "COPYRIGHT_HOLDERS=${COPYRIGHT_HOLDERS}" "COPYRIGHT_HOLDERS_SUBSTITUTION=${CLIENT_NAME}" $<TARGET_FILE:Python3::Interpreter> ${PROJECT_SOURCE_DIR}/share/qt/extract_strings_qt.py ${translatable_sources}
+    COMMAND ${CMAKE_COMMAND} -E env XGETTEXT=${XGETTEXT_EXECUTABLE} "PACKAGE_NAME=${CLIENT_NAME}" "COPYRIGHT_HOLDERS=${COPYRIGHT_HOLDERS}" "COPYRIGHT_HOLDERS_SUBSTITUTION=${CLIENT_NAME}" $<TARGET_FILE:Python3::Interpreter> ${PROJECT_SOURCE_DIR}/share/qt/extract_strings_qt.py --files-from=${translatable_sources_file}
     COMMAND Qt6::lupdate -no-obsolete -I ${PROJECT_SOURCE_DIR}/src -locations relative ${CMAKE_CURRENT_SOURCE_DIR}/bitcoinstrings.cpp ${ui_files} ${qt_translatable_sources} -ts ${CMAKE_CURRENT_SOURCE_DIR}/locale/bitcoin_en.ts
     COMMAND Qt6::lconvert -drop-translations -o ${CMAKE_CURRENT_SOURCE_DIR}/locale/bitcoin_en.xlf -i ${CMAKE_CURRENT_SOURCE_DIR}/locale/bitcoin_en.ts
     COMMAND ${SED_EXECUTABLE} -i.old -e "s|source-language=\"en\" target-language=\"en\"|source-language=\"en\"|" -e "/<target xml:space=\"preserve\"><\\/target>/d" ${CMAKE_CURRENT_SOURCE_DIR}/locale/bitcoin_en.xlf

--- a/src/qt/bitcoinstrings.cpp
+++ b/src/qt/bitcoinstrings.cpp
@@ -28,6 +28,9 @@ QT_TRANSLATE_NOOP("firo-core", ""
 "single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0) or "
 "a network/CIDR (e.g. 1.2.3.4/24). This option can be specified multiple times"),
 QT_TRANSLATE_NOOP("firo-core", ""
+"Amount for private recipient %1% is too small to send after the fee has been "
+"deducted"),
+QT_TRANSLATE_NOOP("firo-core", ""
 "Amount for recipient %1% is too small to send after the fee has been deducted"),
 QT_TRANSLATE_NOOP("firo-core", ""
 "Bind to given address and always listen on it. Use [host]:port notation for "
@@ -63,6 +66,9 @@ QT_TRANSLATE_NOOP("firo-core", ""
 "Distributed under the MIT software license, see the accompanying file %s or "
 "%s"),
 QT_TRANSLATE_NOOP("firo-core", ""
+"Do not check for masternode payout when handling listtransactions, "
+"listsinceblock and gettransaction calls (improves performance)"),
+QT_TRANSLATE_NOOP("firo-core", ""
 "Do not keep transactions in the mempool longer than <n> hours (default: %u)"),
 QT_TRANSLATE_NOOP("firo-core", ""
 "Equivalent bytes per sigop in transactions for relay and mining (default: %u)"),
@@ -74,18 +80,18 @@ QT_TRANSLATE_NOOP("firo-core", ""
 QT_TRANSLATE_NOOP("firo-core", ""
 "Error: Listening for incoming connections failed (listen returned error %s)"),
 QT_TRANSLATE_NOOP("firo-core", ""
+"Error: The transaction was rejected after %u of %u mint transactions were "
+"already sent. Do not retry the whole mint."),
+QT_TRANSLATE_NOOP("firo-core", ""
 "Error: The transaction was rejected! This might happen if some of the coins "
 "in your wallet were already spent, such as if you used a copy of wallet.dat "
 "and coins were spent in the copy but not marked as spent here."),
-QT_TRANSLATE_NOOP("firo-core", ""
-"Error: This transaction requires a transaction fee of at least %s because of "
-"its amount, complexity, or use of recently received funds!"),
 QT_TRANSLATE_NOOP("firo-core", ""
 "Execute command when a relevant alert is received or we see a really long "
 "fork (%s in cmd is replaced by message)"),
 QT_TRANSLATE_NOOP("firo-core", ""
 "Execute command when a wallet transaction changes (%s in cmd is replaced by "
-"TxID)"),
+"TxID, %t is replaced by transaction type: 'spark' or 'regular')"),
 QT_TRANSLATE_NOOP("firo-core", ""
 "Execute command when the best block changes (%s in cmd is replaced by block "
 "hash)"),
@@ -106,16 +112,14 @@ QT_TRANSLATE_NOOP("firo-core", ""
 "Force relay of transactions from whitelisted peers even if they violate "
 "local relay policy (default: %d)"),
 QT_TRANSLATE_NOOP("firo-core", ""
-"Found unconfirmed denominated outputs, will wait till they confirm to "
-"continue."),
-QT_TRANSLATE_NOOP("firo-core", ""
 "Has to have at least two mint coins with at least 1 confirmation in order to "
 "spend a coin"),
 QT_TRANSLATE_NOOP("firo-core", ""
 "How thorough the block verification of -checkblocks is (0-4, default: %u)"),
 QT_TRANSLATE_NOOP("firo-core", ""
-"If <category> is not supplied or if <category> = 1, output all debugging "
-"information."),
+"If <category> is not supplied or is 1 or all, output all debugging "
+"information. The value none resets categories specified before it. The value "
+"0 retains Firo's historical behavior and disables all logging except errors."),
 QT_TRANSLATE_NOOP("firo-core", ""
 "If paytxfee is not set, include enough fee so transactions begin "
 "confirmation on average within n blocks (default: %u)"),
@@ -124,11 +128,20 @@ QT_TRANSLATE_NOOP("firo-core", ""
 "potentially skip their script verification (0 to verify all, default: %s, "
 "testnet: %s)"),
 QT_TRANSLATE_NOOP("firo-core", ""
+"In case of sync/reindex verifies privacy (Spark) proofs with batch "
+"verification, default: true"),
+QT_TRANSLATE_NOOP("firo-core", ""
+"Interval in seconds for rebroadcasting InstantSend-locked mempool "
+"transactions to peers (0 = disabled, default: %u)"),
+QT_TRANSLATE_NOOP("firo-core", ""
 "Invalid amount for -maxtxfee=<amount>: '%s' (must be at least the minrelay "
 "fee of %s to prevent stuck transactions)"),
 QT_TRANSLATE_NOOP("firo-core", ""
 "Maintain a full transaction index, used by the getrawtransaction rpc call "
 "(default: %u)"),
+QT_TRANSLATE_NOOP("firo-core", ""
+"Make automatic outbound connections only to network <net> (ipv4, ipv6 or "
+"onion). Can be specified multiple times to allow multiple networks."),
 QT_TRANSLATE_NOOP("firo-core", ""
 "Maximum allowed median peer time offset adjustment. Local perspective of "
 "time may be influenced by peers forward or backward by this amount. "
@@ -148,22 +161,22 @@ QT_TRANSLATE_NOOP("firo-core", ""
 QT_TRANSLATE_NOOP("firo-core", ""
 "Optionally add the \"W\" flag to produce a pay-to-witness-script-hash output"),
 QT_TRANSLATE_NOOP("firo-core", ""
+"Outbound connections restricted to Tor (-onlynet=onion) but the proxy for "
+"reaching the Tor network is explicitly forbidden: -onion=0"),
+QT_TRANSLATE_NOOP("firo-core", ""
+"Outbound connections restricted to Tor (-onlynet=onion) but the proxy for "
+"reaching the Tor network is not provided: none of -proxy, -onion, -torsetup "
+"or -listenonion (with a usable -torcontrol) is given."),
+QT_TRANSLATE_NOOP("firo-core", ""
 "Output debugging information (default: %u, supplying <category> is optional)"),
 QT_TRANSLATE_NOOP("firo-core", ""
 "Output only the hex-encoded transaction id of the resultant transaction."),
-QT_TRANSLATE_NOOP("firo-core", ""
-"Please add txindex=1 to your configuration file manually.\n"
-"\n"
-"Omni Core will now shutdown."),
 QT_TRANSLATE_NOOP("firo-core", ""
 "Please check that your computer's date and time are correct! If your clock "
 "is wrong, %s will not work properly."),
 QT_TRANSLATE_NOOP("firo-core", ""
 "Please contribute if you find %s useful. Visit %s for further information "
 "about the software."),
-QT_TRANSLATE_NOOP("firo-core", ""
-"PrivateSend uses exact denominated amounts to send funds, you might simply "
-"need to anonymize some more coins."),
 QT_TRANSLATE_NOOP("firo-core", ""
 "Prune configured below the minimum of %d MiB.  Please use a higher number."),
 QT_TRANSLATE_NOOP("firo-core", ""
@@ -202,22 +215,40 @@ QT_TRANSLATE_NOOP("firo-core", ""
 "Sets the serialization of raw transaction or block hex returned in non-"
 "verbose mode, non-segwit(0) or segwit(1) (default: %d)"),
 QT_TRANSLATE_NOOP("firo-core", ""
+"Spark Coin Control temporarily supports selecting at most one coin. Clear "
+"the selection to let the wallet split the payment automatically."),
+QT_TRANSLATE_NOOP("firo-core", ""
+"Spark batch verification failed. The invalid spend transactions are listed "
+"in debug.log. Restart the node: batching is disabled and a reindex is "
+"started automatically so chainstate is rebuilt and Spark proofs are checked "
+"block by block."),
+QT_TRANSLATE_NOOP("firo-core", ""
+"Spark multi-input spends are temporarily disabled. No single available Spark "
+"coin can fund this transaction."),
+QT_TRANSLATE_NOOP("firo-core", ""
+"Spark spend batch failed after committing %u of %u transactions: %s. Do not "
+"retry the whole payment. Already sent: %s"),
+QT_TRANSLATE_NOOP("firo-core", ""
+"Subtracting the fee from the amount is temporarily unavailable when a Spark "
+"spend must be split across multiple transactions."),
+QT_TRANSLATE_NOOP("firo-core", ""
 "Support filtering of blocks and transaction with bloom filters (default: %u)"),
+QT_TRANSLATE_NOOP("firo-core", ""
+"The available Spark coins cannot cover the amount and the required "
+"transaction fees."),
 QT_TRANSLATE_NOOP("firo-core", ""
 "The block database contains a block which appears to be from the future. "
 "This may be due to your computer's date and time being set incorrectly. Only "
 "rebuild the block database if you are sure that your computer's date and "
 "time are correct"),
 QT_TRANSLATE_NOOP("firo-core", ""
-"The file may be write protected or you may not have the required permissions "
-"to edit it.\n"),
-QT_TRANSLATE_NOOP("firo-core", ""
 "The transaction amount is too small to send after the fee has been deducted"),
 QT_TRANSLATE_NOOP("firo-core", ""
 "This is a pre-release test build - use at your own risk - do not use for "
 "mining or merchant applications"),
 QT_TRANSLATE_NOOP("firo-core", ""
-"This is the transaction fee you may pay when fee estimates are not available."),
+"This product includes Masternodes software developed by the Dash Core "
+"developers %s."),
 QT_TRANSLATE_NOOP("firo-core", ""
 "This product includes software developed by the OpenSSL Project for use in "
 "the OpenSSL Toolkit %s and cryptographic software written by Eric Young and "
@@ -226,16 +257,11 @@ QT_TRANSLATE_NOOP("firo-core", ""
 "Total length of network version string (%i) exceeds maximum length (%i). "
 "Reduce the number or size of uacomments."),
 QT_TRANSLATE_NOOP("firo-core", ""
+"Transaction is too large (size limit: 250Kb). Select less inputs or "
+"consolidate your UTXOs"),
+QT_TRANSLATE_NOOP("firo-core", ""
 "Tries to keep outbound traffic under the given target (in MiB per 24h), 0 = "
 "no limit (default: %d)"),
-QT_TRANSLATE_NOOP("firo-core", ""
-"Unable to locate enough PrivateSend denominated funds for this transaction."),
-QT_TRANSLATE_NOOP("firo-core", ""
-"Unable to locate enough PrivateSend non-denominated funds for this "
-"transaction that are not equal 1000 FIRO."),
-QT_TRANSLATE_NOOP("firo-core", ""
-"Unable to locate enough funds for this transaction that are not equal 1000 "
-"FIRO."),
 QT_TRANSLATE_NOOP("firo-core", ""
 "Unable to rewind the database to a pre-fork state. You will need to "
 "redownload the blockchain"),
@@ -246,6 +272,12 @@ QT_TRANSLATE_NOOP("firo-core", ""
 "Unsupported argument -whitelistalwaysrelay ignored, use -whitelistrelay and/"
 "or -whitelistforcerelay."),
 QT_TRANSLATE_NOOP("firo-core", ""
+"Unsupported logging level or category %s. Valid levels are: %s. Valid "
+"categories are: %s."),
+QT_TRANSLATE_NOOP("firo-core", ""
+"Use Mnemonic code for generating deterministic keys. Only has effect during "
+"wallet creation/first start"),
+QT_TRANSLATE_NOOP("firo-core", ""
 "Use UPnP to map the listening port (default: 1 when listening and no -proxy)"),
 QT_TRANSLATE_NOOP("firo-core", ""
 "Use hierarchical deterministic key generation (HD) after BIP32. Only has "
@@ -254,19 +286,26 @@ QT_TRANSLATE_NOOP("firo-core", ""
 "Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: "
 "%s)"),
 QT_TRANSLATE_NOOP("firo-core", ""
+"Use this argument when you want to keep additional data in block index for "
+"mobile api, default: false"),
+QT_TRANSLATE_NOOP("firo-core", ""
+"User defined mnemonic for HD wallet (bip39). Only has effect during wallet "
+"creation/first start (default: randomly generated)"),
+QT_TRANSLATE_NOOP("firo-core", ""
+"User defined mnemonic passphrase for HD wallet (BIP39). Only has effect "
+"during wallet creation/first start (default: empty string)"),
+QT_TRANSLATE_NOOP("firo-core", ""
+"User defined seed for HD wallet (should be in hex). Only has effect during "
+"wallet creation/first start (default: randomly generated)"),
+QT_TRANSLATE_NOOP("firo-core", ""
 "Username and hashed password for JSON-RPC connections. The field <userpw> "
 "comes in the format: <USERNAME>:<SALT>$<HASH>. A canonical python script is "
 "included in share/rpcuser. The client then connects normally using the "
 "rpcuser=<USERNAME>/rpcpassword=<PASSWORD> pair of arguments. This option can "
 "be specified multiple times"),
 QT_TRANSLATE_NOOP("firo-core", ""
-"WARNING! Failed to replenish keypool, please unlock your wallet to do so."),
-QT_TRANSLATE_NOOP("firo-core", ""
 "Wallet is locked, can't replenish keypool! Automatic backups and mixing are "
 "disabled, please unlock your wallet to replenish keypool."),
-QT_TRANSLATE_NOOP("firo-core", ""
-"Wallet will not create transactions that violate mempool chain limits "
-"(default: %u"),
 QT_TRANSLATE_NOOP("firo-core", ""
 "Wallet will not create transactions that violate mempool chain limits "
 "(default: %u)"),
@@ -284,40 +323,31 @@ QT_TRANSLATE_NOOP("firo-core", ""
 "Warning: We do not appear to fully agree with our peers! You may need to "
 "upgrade, or other nodes may need to upgrade."),
 QT_TRANSLATE_NOOP("firo-core", ""
-"Warning: incorrect parameter -walletbackupsdir, path must exist! Using "
-"default path."),
-QT_TRANSLATE_NOOP("firo-core", ""
 "Whitelist peers connecting from the given IP address (e.g. 1.2.3.4) or CIDR "
 "notated network (e.g. 1.2.3.0/24). Can be specified multiple times."),
 QT_TRANSLATE_NOOP("firo-core", ""
 "Whitelisted peers cannot be DoS banned and their transactions are always "
 "relayed, even if they are already in the mempool, useful e.g. for a gateway"),
 QT_TRANSLATE_NOOP("firo-core", ""
-"You must specify a znodeprivkey in the configuration. Please see "
+"You are starting in lite mode, all Dash-specific functionality is disabled."),
+QT_TRANSLATE_NOOP("firo-core", ""
+"You must specify a znodeblsprivkey in the configuration. Please see "
 "documentation for help."),
 QT_TRANSLATE_NOOP("firo-core", ""
 "You need to rebuild the database using -reindex to go back to unpruned "
 "mode.  This will redownload the entire blockchain"),
 QT_TRANSLATE_NOOP("firo-core", ""
 "You need to rebuild the database using -reindex-chainstate to change -txindex"),
-QT_TRANSLATE_NOOP("firo-core", ""
-"it has to have at least two mint coins with at least 2 confirmation in order "
-"to spend a coin"),
-QT_TRANSLATE_NOOP("firo-core", ""
-"znodeaddr option is deprecated. Please use znode.conf to manage your remote "
-"znodes."),
-QT_TRANSLATE_NOOP("firo-core", "%s - %d confirmations"),
 QT_TRANSLATE_NOOP("firo-core", "%s Daemon"),
 QT_TRANSLATE_NOOP("firo-core", "%s RPC client version"),
 QT_TRANSLATE_NOOP("firo-core", "%s corrupt, salvage failed"),
-QT_TRANSLATE_NOOP("firo-core", "%s is set very high!"),
 QT_TRANSLATE_NOOP("firo-core", "%s firo-tx utility version"),
-QT_TRANSLATE_NOOP("firo-core", "(%d could be used only on mainnet)"),
 QT_TRANSLATE_NOOP("firo-core", "(default: %s)"),
 QT_TRANSLATE_NOOP("firo-core", "(default: %u)"),
-QT_TRANSLATE_NOOP("firo-core", "(must be %d for mainnet)"),
 QT_TRANSLATE_NOOP("firo-core", "-maxmempool must be at least %d MB"),
+QT_TRANSLATE_NOOP("firo-core", "-wallet parameter must only specify a filename (not a path)"),
 QT_TRANSLATE_NOOP("firo-core", "<category> can be:"),
+QT_TRANSLATE_NOOP("firo-core", "A Spark payment may use at most %u transactions."),
 QT_TRANSLATE_NOOP("firo-core", "Accept command line and JSON-RPC commands"),
 QT_TRANSLATE_NOOP("firo-core", "Accept public REST requests (default: %u)"),
 QT_TRANSLATE_NOOP("firo-core", "Add Pay To n-of-m Multi-sig output to TX. n = REQUIRED, m = PUBKEYS"),
@@ -329,29 +359,27 @@ QT_TRANSLATE_NOOP("firo-core", "Add pay-to-pubkey output to TX"),
 QT_TRANSLATE_NOOP("firo-core", "Add raw script output to TX"),
 QT_TRANSLATE_NOOP("firo-core", "Add zero or more signatures to transaction"),
 QT_TRANSLATE_NOOP("firo-core", "Allow DNS lookups for -addnode, -seednode and -connect"),
-QT_TRANSLATE_NOOP("firo-core", "Already have that input."),
 QT_TRANSLATE_NOOP("firo-core", "Always query for peer addresses via DNS lookup (default: %u)"),
 QT_TRANSLATE_NOOP("firo-core", "Amount for recipient %1% is too small to pay the fee"),
 QT_TRANSLATE_NOOP("firo-core", "Amount for recipient %1% is too small"),
-QT_TRANSLATE_NOOP("firo-core", "Amount limit is exceed max money"),
 QT_TRANSLATE_NOOP("firo-core", "Anonymous communication with TOR - Quickstart (default: %d)"),
 QT_TRANSLATE_NOOP("firo-core", "Append comment to the user agent string"),
 QT_TRANSLATE_NOOP("firo-core", "Attempt to recover private keys from a corrupt wallet on startup"),
-QT_TRANSLATE_NOOP("firo-core", "Automatic backups disabled"),
 QT_TRANSLATE_NOOP("firo-core", "Automatically create Tor hidden service (default: %d)"),
 QT_TRANSLATE_NOOP("firo-core", "Bad change address"),
 QT_TRANSLATE_NOOP("firo-core", "Block creation options:"),
 QT_TRANSLATE_NOOP("firo-core", "Block index is outdated, reindex required\n"),
-QT_TRANSLATE_NOOP("firo-core", "Can not choose coins within limit."),
-QT_TRANSLATE_NOOP("firo-core", "Can't find random Znode."),
-QT_TRANSLATE_NOOP("firo-core", "Can't mix while sync in progress."),
-QT_TRANSLATE_NOOP("firo-core", "Can't mix: no compatible inputs found!"),
 QT_TRANSLATE_NOOP("firo-core", "Cannot downgrade wallet"),
 QT_TRANSLATE_NOOP("firo-core", "Cannot resolve -%s address: '%s'"),
 QT_TRANSLATE_NOOP("firo-core", "Cannot write default address"),
+QT_TRANSLATE_NOOP("firo-core", "Cannot write default spark address"),
+QT_TRANSLATE_NOOP("firo-core", "Chain height changed during Spark name construction; retry"),
+QT_TRANSLATE_NOOP("firo-core", "Chain height changed during Spark transaction construction; retry"),
 QT_TRANSLATE_NOOP("firo-core", "Chain selection options:"),
+QT_TRANSLATE_NOOP("firo-core", "Chain tip changed during Spark name construction; retry"),
+QT_TRANSLATE_NOOP("firo-core", "Chain tip changed during Spark transaction construction; retry"),
+QT_TRANSLATE_NOOP("firo-core", "Chain tip is unavailable during Spark name construction"),
 QT_TRANSLATE_NOOP("firo-core", "Change index out of range"),
-QT_TRANSLATE_NOOP("firo-core", "Collateral not valid."),
 QT_TRANSLATE_NOOP("firo-core", "Commands:"),
 QT_TRANSLATE_NOOP("firo-core", "Connect through SOCKS5 proxy"),
 QT_TRANSLATE_NOOP("firo-core", "Connect to JSON-RPC on <port> (default: %u or testnet: %u)"),
@@ -359,7 +387,7 @@ QT_TRANSLATE_NOOP("firo-core", "Connect to a node to retrieve peer addresses, an
 QT_TRANSLATE_NOOP("firo-core", "Connection options:"),
 QT_TRANSLATE_NOOP("firo-core", "Copyright (C) %i-%i"),
 QT_TRANSLATE_NOOP("firo-core", "Corrupted block database detected"),
-QT_TRANSLATE_NOOP("firo-core", "Could not parse znode.conf"),
+QT_TRANSLATE_NOOP("firo-core", "Could not open debug log file %s"),
 QT_TRANSLATE_NOOP("firo-core", "Create hex-encoded Firo transaction"),
 QT_TRANSLATE_NOOP("firo-core", "Create new, empty TX."),
 QT_TRANSLATE_NOOP("firo-core", "Debugging/Testing options:"),
@@ -368,14 +396,12 @@ QT_TRANSLATE_NOOP("firo-core", "Delete output N from TX"),
 QT_TRANSLATE_NOOP("firo-core", "Do not load the wallet and disable wallet RPC calls"),
 QT_TRANSLATE_NOOP("firo-core", "Do you want to rebuild the block database now?"),
 QT_TRANSLATE_NOOP("firo-core", "Done loading"),
-QT_TRANSLATE_NOOP("firo-core", "ERROR! Failed to create automatic backup"),
+QT_TRANSLATE_NOOP("firo-core", "Either recipients or newMints has to be nonempty."),
 QT_TRANSLATE_NOOP("firo-core", "Enable publish hash block in <address>"),
 QT_TRANSLATE_NOOP("firo-core", "Enable publish hash transaction in <address>"),
 QT_TRANSLATE_NOOP("firo-core", "Enable publish raw block in <address>"),
 QT_TRANSLATE_NOOP("firo-core", "Enable publish raw transaction in <address>"),
 QT_TRANSLATE_NOOP("firo-core", "Enable transaction replacement in the memory pool (default: %u)"),
-QT_TRANSLATE_NOOP("firo-core", "Entries are full."),
-QT_TRANSLATE_NOOP("firo-core", "Error connecting to Znode."),
 QT_TRANSLATE_NOOP("firo-core", "Error initializing block database"),
 QT_TRANSLATE_NOOP("firo-core", "Error initializing wallet database environment %s!"),
 QT_TRANSLATE_NOOP("firo-core", "Error loading %s"),
@@ -385,95 +411,67 @@ QT_TRANSLATE_NOOP("firo-core", "Error loading %s: You can't disable HD on a alre
 QT_TRANSLATE_NOOP("firo-core", "Error loading block database"),
 QT_TRANSLATE_NOOP("firo-core", "Error opening block database"),
 QT_TRANSLATE_NOOP("firo-core", "Error reading from database, shutting down."),
+QT_TRANSLATE_NOOP("firo-core", "Error upgrading chainstate database"),
 QT_TRANSLATE_NOOP("firo-core", "Error"),
 QT_TRANSLATE_NOOP("firo-core", "Error: A fatal internal error occurred, see debug.log for details"),
 QT_TRANSLATE_NOOP("firo-core", "Error: Disk space is low!"),
-QT_TRANSLATE_NOOP("firo-core", "Error: It cannot delete coin serial number in wallet"),
 QT_TRANSLATE_NOOP("firo-core", "Error: Wallet locked, unable to create transaction!"),
+QT_TRANSLATE_NOOP("firo-core", "Fail to generate mints, "),
 QT_TRANSLATE_NOOP("firo-core", "Failed to create backup, error: %s"),
 QT_TRANSLATE_NOOP("firo-core", "Failed to delete backup, error: %s"),
 QT_TRANSLATE_NOOP("firo-core", "Failed to listen on any port. Use -listen=0 if you want this."),
-QT_TRANSLATE_NOOP("firo-core", "Failed to parse host:port string"),
-QT_TRANSLATE_NOOP("firo-core", "Failed to write coin serial number into wallet"),
 QT_TRANSLATE_NOOP("firo-core", "Fee (in %s/kB) to add to transactions you send (default: %s)"),
-QT_TRANSLATE_NOOP("firo-core", "Found enough users, signing ( waiting %s )"),
-QT_TRANSLATE_NOOP("firo-core", "Found enough users, signing ..."),
+QT_TRANSLATE_NOOP("firo-core", "Firo Core"),
 QT_TRANSLATE_NOOP("firo-core", "Get help for a command"),
 QT_TRANSLATE_NOOP("firo-core", "How many blocks to check at startup (default: %u, 0 = all)"),
 QT_TRANSLATE_NOOP("firo-core", "Importing..."),
 QT_TRANSLATE_NOOP("firo-core", "Imports blocks from external blk000??.dat file on startup"),
 QT_TRANSLATE_NOOP("firo-core", "Include IP addresses in debug output (default: %u)"),
-QT_TRANSLATE_NOOP("firo-core", "Incompatible mode."),
-QT_TRANSLATE_NOOP("firo-core", "Incompatible version."),
 QT_TRANSLATE_NOOP("firo-core", "Incorrect or no genesis block found. Wrong datadir for network?"),
 QT_TRANSLATE_NOOP("firo-core", "Information"),
 QT_TRANSLATE_NOOP("firo-core", "Initialization sanity check failed. %s is shutting down."),
-QT_TRANSLATE_NOOP("firo-core", "Input is not valid."),
 QT_TRANSLATE_NOOP("firo-core", "Insufficient funds"),
-QT_TRANSLATE_NOOP("firo-core", "Insufficient funds."),
 QT_TRANSLATE_NOOP("firo-core", "Invalid -onion address: '%s'"),
 QT_TRANSLATE_NOOP("firo-core", "Invalid -proxy address: '%s'"),
-QT_TRANSLATE_NOOP("firo-core", "Invalid Firo address"),
-QT_TRANSLATE_NOOP("firo-core", "Invalid amount for -%s=<amount>: '%s'"),
+QT_TRANSLATE_NOOP("firo-core", "Invalid Spark spend amount."),
 QT_TRANSLATE_NOOP("firo-core", "Invalid amount for -fallbackfee=<amount>: '%s'"),
 QT_TRANSLATE_NOOP("firo-core", "Invalid amount for -mininput=<amount>: '%s'"),
 QT_TRANSLATE_NOOP("firo-core", "Invalid amount for -paytxfee=<amount>: '%s' (must be at least %s)"),
-QT_TRANSLATE_NOOP("firo-core", "Invalid amount"),
+QT_TRANSLATE_NOOP("firo-core", "Invalid characters in -wallet filename"),
 QT_TRANSLATE_NOOP("firo-core", "Invalid netmask specified in -whitelist: '%s'"),
-QT_TRANSLATE_NOOP("firo-core", "Invalid port detected in znode.conf"),
-QT_TRANSLATE_NOOP("firo-core", "Invalid script detected."),
+QT_TRANSLATE_NOOP("firo-core", "Invalid spark address"),
+QT_TRANSLATE_NOOP("firo-core", "Invalid znodeblsprivkey. Please see documentation."),
 QT_TRANSLATE_NOOP("firo-core", "Keep at most <n> unconnectable transactions in memory (default: %u)"),
 QT_TRANSLATE_NOOP("firo-core", "Keep the transaction memory pool below <n> megabytes (default: %u)"),
 QT_TRANSLATE_NOOP("firo-core", "Keypool ran out, please call keypoolrefill first"),
-QT_TRANSLATE_NOOP("firo-core", "Last PrivateSend was too recent."),
-QT_TRANSLATE_NOOP("firo-core", "Last successful PrivateSend action was too recent."),
-QT_TRANSLATE_NOOP("firo-core", "Line: %d"),
 QT_TRANSLATE_NOOP("firo-core", "List commands"),
 QT_TRANSLATE_NOOP("firo-core", "Listen for JSON-RPC connections on <port> (default: %u or testnet: %u)"),
 QT_TRANSLATE_NOOP("firo-core", "Listen for connections on <port> (default: %u or testnet: %u)"),
 QT_TRANSLATE_NOOP("firo-core", "Load JSON file FILENAME into register NAME"),
-QT_TRANSLATE_NOOP("firo-core", "Loading Znode payment cache..."),
+QT_TRANSLATE_NOOP("firo-core", "Loading Spark wallet..."),
 QT_TRANSLATE_NOOP("firo-core", "Loading addresses..."),
 QT_TRANSLATE_NOOP("firo-core", "Loading banlist..."),
 QT_TRANSLATE_NOOP("firo-core", "Loading block index..."),
-QT_TRANSLATE_NOOP("firo-core", "Loading fulfilled requests cache..."),
+QT_TRANSLATE_NOOP("firo-core", "Loading wallet... (%d transactions)"),
 QT_TRANSLATE_NOOP("firo-core", "Loading wallet..."),
-QT_TRANSLATE_NOOP("firo-core", "Loading znode cache..."),
 QT_TRANSLATE_NOOP("firo-core", "Location of the auth cookie (default: data dir)"),
-QT_TRANSLATE_NOOP("firo-core", "Lock is already in place."),
 QT_TRANSLATE_NOOP("firo-core", "Maintain at most <n> connections to peers (default: %u)"),
 QT_TRANSLATE_NOOP("firo-core", "Make the wallet broadcast transactions"),
 QT_TRANSLATE_NOOP("firo-core", "Maximum per-connection receive buffer, <n>*1000 bytes (default: %u)"),
 QT_TRANSLATE_NOOP("firo-core", "Maximum per-connection send buffer, <n>*1000 bytes (default: %u)"),
-QT_TRANSLATE_NOOP("firo-core", "Missing input transaction information."),
-QT_TRANSLATE_NOOP("firo-core", "Mixing in progress..."),
 QT_TRANSLATE_NOOP("firo-core", "Need to specify a port with -whitebind: '%s'"),
-QT_TRANSLATE_NOOP("firo-core", "No Znodes detected."),
-QT_TRANSLATE_NOOP("firo-core", "No compatible Znode found."),
-QT_TRANSLATE_NOOP("firo-core", "No errors detected."),
-QT_TRANSLATE_NOOP("firo-core", "No matching denominations found for mixing."),
-QT_TRANSLATE_NOOP("firo-core", "No recipients"),
+QT_TRANSLATE_NOOP("firo-core", "No Spark spend recipients were provided."),
+QT_TRANSLATE_NOOP("firo-core", "No such coin in set"),
 QT_TRANSLATE_NOOP("firo-core", "Node relay options:"),
-QT_TRANSLATE_NOOP("firo-core", "Non-standard public key detected."),
-QT_TRANSLATE_NOOP("firo-core", "Not compatible with existing transactions."),
+QT_TRANSLATE_NOOP("firo-core", "Not enough fee estimated"),
 QT_TRANSLATE_NOOP("firo-core", "Not enough file descriptors available."),
-QT_TRANSLATE_NOOP("firo-core", "Not enough funds to anonymize."),
-QT_TRANSLATE_NOOP("firo-core", "Not in the Znode list."),
-QT_TRANSLATE_NOOP("firo-core", "One of minted coin does not found in the chain"),
-QT_TRANSLATE_NOOP("firo-core", "One of the minted coin is invalid"),
-QT_TRANSLATE_NOOP("firo-core", "Only connect to nodes in network <net> (ipv4, ipv6 or onion)"),
 QT_TRANSLATE_NOOP("firo-core", "Options:"),
 QT_TRANSLATE_NOOP("firo-core", "Pass named instead of positional arguments (default: %s)"),
 QT_TRANSLATE_NOOP("firo-core", "Password for JSON-RPC connections"),
-QT_TRANSLATE_NOOP("firo-core", "Port: %d"),
 QT_TRANSLATE_NOOP("firo-core", "Prepend debug output with timestamp (default: %u)"),
 QT_TRANSLATE_NOOP("firo-core", "Print this help message and exit"),
 QT_TRANSLATE_NOOP("firo-core", "Print version and exit"),
-QT_TRANSLATE_NOOP("firo-core", "PrivateSend is idle."),
-QT_TRANSLATE_NOOP("firo-core", "PrivateSend request complete:"),
-QT_TRANSLATE_NOOP("firo-core", "PrivateSend request incomplete:"),
-QT_TRANSLATE_NOOP("firo-core", "Problem with coin selection for re-mint while spending."),
-QT_TRANSLATE_NOOP("firo-core", "Problem with coin selection for spend."),
+QT_TRANSLATE_NOOP("firo-core", "Private recipient has invalid amount"),
 QT_TRANSLATE_NOOP("firo-core", "Prune cannot be configured with a negative value."),
 QT_TRANSLATE_NOOP("firo-core", "Prune mode is incompatible with -txindex."),
 QT_TRANSLATE_NOOP("firo-core", "Pruning blockstore..."),
@@ -485,22 +483,19 @@ QT_TRANSLATE_NOOP("firo-core", "Reducing -maxconnections from %d to %d, because 
 QT_TRANSLATE_NOOP("firo-core", "Register Commands:"),
 QT_TRANSLATE_NOOP("firo-core", "Relay and mine data carrier transactions (default: %u)"),
 QT_TRANSLATE_NOOP("firo-core", "Relay non-P2SH multisig (default: %u)"),
-QT_TRANSLATE_NOOP("firo-core", "Required amount exceed value spend limit"),
-QT_TRANSLATE_NOOP("firo-core", "The required amount exceeds spend limit"),
 QT_TRANSLATE_NOOP("firo-core", "Rescan the block chain for missing wallet transactions on startup"),
 QT_TRANSLATE_NOOP("firo-core", "Rescanning..."),
 QT_TRANSLATE_NOOP("firo-core", "Rewinding blocks..."),
 QT_TRANSLATE_NOOP("firo-core", "Run in the background as a daemon and accept commands"),
 QT_TRANSLATE_NOOP("firo-core", "See signrawtransaction docs for format of sighash flags, JSON objects."),
 QT_TRANSLATE_NOOP("firo-core", "Select JSON output"),
+QT_TRANSLATE_NOOP("firo-core", "Selected Spark cover set is not yet bound to a canonical state hash"),
 QT_TRANSLATE_NOOP("firo-core", "Send command to %s (with named arguments)"),
 QT_TRANSLATE_NOOP("firo-core", "Send command to %s"),
 QT_TRANSLATE_NOOP("firo-core", "Send commands to node running on <ip> (default: %s)"),
 QT_TRANSLATE_NOOP("firo-core", "Send trace/debug info to console instead of debug.log file"),
 QT_TRANSLATE_NOOP("firo-core", "Send transactions as zero-fee transactions if possible (default: %u)"),
 QT_TRANSLATE_NOOP("firo-core", "Send transactions with full-RBF opt-in enabled (default: %u)"),
-QT_TRANSLATE_NOOP("firo-core", "Session not complete!"),
-QT_TRANSLATE_NOOP("firo-core", "Session timed out."),
 QT_TRANSLATE_NOOP("firo-core", "Set TX lock time to N"),
 QT_TRANSLATE_NOOP("firo-core", "Set TX version to N"),
 QT_TRANSLATE_NOOP("firo-core", "Set database cache size in megabytes (%d to %d, default: %d)"),
@@ -512,57 +507,66 @@ QT_TRANSLATE_NOOP("firo-core", "Set the number of threads to service RPC calls (
 QT_TRANSLATE_NOOP("firo-core", "Show all debugging options (usage: --help -help-debug)"),
 QT_TRANSLATE_NOOP("firo-core", "Shrink debug.log file on client startup (default: 1 when no -debug)"),
 QT_TRANSLATE_NOOP("firo-core", "Signing transaction failed"),
+QT_TRANSLATE_NOOP("firo-core", "Spark V2 spends are limited to %1% inputs"),
+QT_TRANSLATE_NOOP("firo-core", "Spark address doesn't belong to the wallet"),
+QT_TRANSLATE_NOOP("firo-core", "Spark coin selection changed during transaction construction; retry"),
+QT_TRANSLATE_NOOP("firo-core", "Spark fee estimate did not match the wallet (planned %s, wallet %s)."),
+QT_TRANSLATE_NOOP("firo-core", "Spark name transaction size is out of range"),
+QT_TRANSLATE_NOOP("firo-core", "Spark shielded output limit exceeded."),
+QT_TRANSLATE_NOOP("firo-core", "Spark spend amount is out of range"),
+QT_TRANSLATE_NOOP("firo-core", "Spark spend amount plus fee is out of range"),
+QT_TRANSLATE_NOOP("firo-core", "Spark spend fee is out of range"),
+QT_TRANSLATE_NOOP("firo-core", "Spark spend output amount is out of range"),
+QT_TRANSLATE_NOOP("firo-core", "Spark spend size estimate is out of range"),
+QT_TRANSLATE_NOOP("firo-core", "Spark transaction fee is too high."),
+QT_TRANSLATE_NOOP("firo-core", "Spark transactions are disabled at the moment"),
 QT_TRANSLATE_NOOP("firo-core", "Specify configuration file (default: %s)"),
 QT_TRANSLATE_NOOP("firo-core", "Specify connection timeout in milliseconds (minimum: 1, default: %d)"),
 QT_TRANSLATE_NOOP("firo-core", "Specify data directory"),
 QT_TRANSLATE_NOOP("firo-core", "Specify pid file (default: %s)"),
 QT_TRANSLATE_NOOP("firo-core", "Specify wallet file (within data directory)"),
 QT_TRANSLATE_NOOP("firo-core", "Specify your own public address"),
+QT_TRANSLATE_NOOP("firo-core", "Spend to transparent address limit exceeded."),
 QT_TRANSLATE_NOOP("firo-core", "Spend unconfirmed change when sending transactions (default: %u)"),
 QT_TRANSLATE_NOOP("firo-core", "Start %s Daemon"),
 QT_TRANSLATE_NOOP("firo-core", "Starting network threads..."),
-QT_TRANSLATE_NOOP("firo-core", "Submitted following entries to znode: %u / %d"),
-QT_TRANSLATE_NOOP("firo-core", "Submitted to znode, waiting for more entries ( %u / %d ) %s"),
-QT_TRANSLATE_NOOP("firo-core", "Submitted to znode, waiting in queue %s"),
 QT_TRANSLATE_NOOP("firo-core", "Synchronization failed"),
 QT_TRANSLATE_NOOP("firo-core", "Synchronization finished"),
 QT_TRANSLATE_NOOP("firo-core", "Synchronization pending..."),
-QT_TRANSLATE_NOOP("firo-core", "Synchronizing znode payments..."),
-QT_TRANSLATE_NOOP("firo-core", "Synchronizing znodes..."),
+QT_TRANSLATE_NOOP("firo-core", "Synchronizing blockchain..."),
+QT_TRANSLATE_NOOP("firo-core", "Synchronizing governance objects..."),
 QT_TRANSLATE_NOOP("firo-core", "The source code is available from %s."),
-QT_TRANSLATE_NOOP("firo-core", "The spend coin transaction failed to verify"),
 QT_TRANSLATE_NOOP("firo-core", "The transaction amount is too small to pay the fee"),
 QT_TRANSLATE_NOOP("firo-core", "The wallet will avoid paying less than the minimum relay fee."),
 QT_TRANSLATE_NOOP("firo-core", "This command requires JSON registers:"),
 QT_TRANSLATE_NOOP("firo-core", "This help message"),
 QT_TRANSLATE_NOOP("firo-core", "This is experimental software."),
-QT_TRANSLATE_NOOP("firo-core", "This is not a Znode."),
 QT_TRANSLATE_NOOP("firo-core", "This is the minimum transaction fee you pay on every transaction."),
-QT_TRANSLATE_NOOP("firo-core", "This is the transaction fee you will pay if you send a transaction."),
 QT_TRANSLATE_NOOP("firo-core", "Threshold for disconnecting misbehaving peers (default: %u)"),
 QT_TRANSLATE_NOOP("firo-core", "Timeout during HTTP requests (default: %d)"),
-QT_TRANSLATE_NOOP("firo-core", "Too many %f denominations, removing."),
 QT_TRANSLATE_NOOP("firo-core", "Tor control port password (default: empty)"),
 QT_TRANSLATE_NOOP("firo-core", "Tor control port to use if onion listening enabled (default: %s)"),
 QT_TRANSLATE_NOOP("firo-core", "Transaction amount too small"),
-QT_TRANSLATE_NOOP("firo-core", "Transaction amounts must be positive"),
 QT_TRANSLATE_NOOP("firo-core", "Transaction amounts must not be negative"),
-QT_TRANSLATE_NOOP("firo-core", "Transaction created successfully."),
-QT_TRANSLATE_NOOP("firo-core", "Transaction fees are too high."),
+QT_TRANSLATE_NOOP("firo-core", "Transaction commit failed."),
 QT_TRANSLATE_NOOP("firo-core", "Transaction has too long of a mempool chain"),
 QT_TRANSLATE_NOOP("firo-core", "Transaction must have at least one recipient"),
-QT_TRANSLATE_NOOP("firo-core", "Transaction not valid."),
+QT_TRANSLATE_NOOP("firo-core", "Transaction not allowed in mempool"),
 QT_TRANSLATE_NOOP("firo-core", "Transaction too large for fee policy"),
-QT_TRANSLATE_NOOP("firo-core", "Transaction is too large (size limit: 100Kb). Select less inputs or consolidate your UTXOs"),
-QT_TRANSLATE_NOOP("firo-core", "Trying to spend an already spent serial #, try again."),
 QT_TRANSLATE_NOOP("firo-core", "Unable to bind to %s on this computer (bind returned error %s)"),
 QT_TRANSLATE_NOOP("firo-core", "Unable to bind to %s on this computer. %s is probably already running."),
-QT_TRANSLATE_NOOP("firo-core", "Unable to convert denomination to integer."),
+QT_TRANSLATE_NOOP("firo-core", "Unable to create a single-input Spark transaction."),
+QT_TRANSLATE_NOOP("firo-core", "Unable to create a valid Spark name transaction"),
+QT_TRANSLATE_NOOP("firo-core", "Unable to create spend transaction."),
+QT_TRANSLATE_NOOP("firo-core", "Unable to estimate the final Spark name transaction fee"),
+QT_TRANSLATE_NOOP("firo-core", "Unable to generate spend key, wallet is locked."),
+QT_TRANSLATE_NOOP("firo-core", "Unable to generate spend key."),
+QT_TRANSLATE_NOOP("firo-core", "Unable to mint full amount; only partial minting was possible"),
+QT_TRANSLATE_NOOP("firo-core", "Unable to select Spark coins for spend."),
+QT_TRANSLATE_NOOP("firo-core", "Unable to select coins for minting"),
+QT_TRANSLATE_NOOP("firo-core", "Unable to select cons for spend"),
 QT_TRANSLATE_NOOP("firo-core", "Unable to start HTTP server. See debug log for details."),
-QT_TRANSLATE_NOOP("firo-core", "Unable to update configuration file at"),
 QT_TRANSLATE_NOOP("firo-core", "Unknown network specified in -onlynet: '%s'"),
-QT_TRANSLATE_NOOP("firo-core", "Unknown response."),
-QT_TRANSLATE_NOOP("firo-core", "Unknown state: id = %u"),
 QT_TRANSLATE_NOOP("firo-core", "Unsupported argument -benchmark ignored, use -debug=bench."),
 QT_TRANSLATE_NOOP("firo-core", "Unsupported argument -debugnet ignored, use -debug=net."),
 QT_TRANSLATE_NOOP("firo-core", "Unsupported argument -tor found, use -onion."),
@@ -570,17 +574,15 @@ QT_TRANSLATE_NOOP("firo-core", "Update hex-encoded Firo transaction"),
 QT_TRANSLATE_NOOP("firo-core", "Upgrade wallet to latest format on startup"),
 QT_TRANSLATE_NOOP("firo-core", "Usage:"),
 QT_TRANSLATE_NOOP("firo-core", "Use UPnP to map the listening port (default: %u)"),
+QT_TRANSLATE_NOOP("firo-core", "Use the dev chain"),
 QT_TRANSLATE_NOOP("firo-core", "Use the test chain"),
 QT_TRANSLATE_NOOP("firo-core", "User Agent comment (%s) contains unsafe characters."),
 QT_TRANSLATE_NOOP("firo-core", "Username for JSON-RPC connections"),
-QT_TRANSLATE_NOOP("firo-core", "Value more than PrivateSend pool maximum allows."),
 QT_TRANSLATE_NOOP("firo-core", "Verifying blocks..."),
 QT_TRANSLATE_NOOP("firo-core", "Verifying wallet..."),
-QT_TRANSLATE_NOOP("firo-core", "Very low number of keys left: %d"),
 QT_TRANSLATE_NOOP("firo-core", "Wait for RPC server to start"),
 QT_TRANSLATE_NOOP("firo-core", "Wallet %s resides outside data directory %s"),
 QT_TRANSLATE_NOOP("firo-core", "Wallet debugging/testing options:"),
-QT_TRANSLATE_NOOP("firo-core", "Wallet is locked."),
 QT_TRANSLATE_NOOP("firo-core", "Wallet locked"),
 QT_TRANSLATE_NOOP("firo-core", "Wallet locked, unable to create transaction!"),
 QT_TRANSLATE_NOOP("firo-core", "Wallet needed to be rewritten: restart %s to complete"),
@@ -589,22 +591,12 @@ QT_TRANSLATE_NOOP("firo-core", "Warning"),
 QT_TRANSLATE_NOOP("firo-core", "Warning: unknown new rules activated (versionbit %i)"),
 QT_TRANSLATE_NOOP("firo-core", "Wasn't able to create wallet backup folder %s!"),
 QT_TRANSLATE_NOOP("firo-core", "Whether to operate in a blocks only mode (default: %u)"),
-QT_TRANSLATE_NOOP("firo-core", "Will retry..."),
-QT_TRANSLATE_NOOP("firo-core", "Your entries added successfully."),
-QT_TRANSLATE_NOOP("firo-core", "Your transaction was accepted into the pool!"),
+QT_TRANSLATE_NOOP("firo-core", "You can not start a masternode in lite mode."),
+QT_TRANSLATE_NOOP("firo-core", "You can not start a znode in lite mode."),
 QT_TRANSLATE_NOOP("firo-core", "Zapping all Sigma mints from wallet..."),
 QT_TRANSLATE_NOOP("firo-core", "Zapping all transactions from wallet..."),
 QT_TRANSLATE_NOOP("firo-core", "ZeroMQ notification options:"),
-QT_TRANSLATE_NOOP("firo-core", "Znode cache is empty, skipping payments cache..."),
-QT_TRANSLATE_NOOP("firo-core", "Znode queue is full."),
-QT_TRANSLATE_NOOP("firo-core", "Znode:"),
-QT_TRANSLATE_NOOP("firo-core", "it cannot write coin serial number into wallet"),
-QT_TRANSLATE_NOOP("firo-core", "no mixing available."),
 QT_TRANSLATE_NOOP("firo-core", "prevtxs=JSON object"),
 QT_TRANSLATE_NOOP("firo-core", "privatekeys=JSON object"),
-QT_TRANSLATE_NOOP("firo-core", "see debug.log for details."),
-QT_TRANSLATE_NOOP("firo-core", "the coin spend has been used"),
-QT_TRANSLATE_NOOP("firo-core", "the selected mint coin is an invalid coin"),
-QT_TRANSLATE_NOOP("firo-core", "the spend coin transaction did not verify"),
 QT_TRANSLATE_NOOP("firo-core", "version"),
 };

--- a/src/qt/locale/bitcoin_bg.ts
+++ b/src/qt/locale/bitcoin_bg.ts
@@ -1334,7 +1334,7 @@
     </message>
     <message>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
-        <translation>Въведeте &lt;/b&gt;помощ&lt;/b&gt; за да видите наличните команди.</translation>
+        <translation>Напишете &lt;b&gt;help&lt;/b&gt;, за да прегледате възможните команди.</translation>
     </message>
     <message>
         <source>%1 B</source>

--- a/src/qt/locale/bitcoin_ca.ts
+++ b/src/qt/locale/bitcoin_ca.ts
@@ -1610,11 +1610,11 @@
     </message>
     <message>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
-        <translation>Utilitza les fletxes d'amunt i avall per navegar per l'historial, i &lt;b&gt;Ctrl-L&lt;\b&gt; per netejar la pantalla.</translation>
+        <translation>Utilitza les fletxes d'amunt i avall per navegar per l'historial, i &lt;b&gt;Ctrl-L&lt;/b&gt; per netejar la pantalla.</translation>
     </message>
     <message>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
-        <translation>Escriviu &lt;b&gt;help&lt;\b&gt; per a obtenir un llistat de les ordres disponibles.</translation>
+        <translation>Escriviu &lt;b&gt;help&lt;/b&gt; per a obtenir un llistat de les ordres disponibles.</translation>
     </message>
     <message>
         <source>%1 B</source>

--- a/src/qt/locale/bitcoin_ca@valencia.ts
+++ b/src/qt/locale/bitcoin_ca@valencia.ts
@@ -1378,11 +1378,11 @@
     </message>
     <message>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
-        <translation>Utilitza les fletxes d'amunt i avall per navegar per l'historial, i &lt;b&gt;Ctrl-L&lt;\b&gt; per netejar la pantalla.</translation>
+        <translation>Utilitza les fletxes d'amunt i avall per navegar per l'historial, i &lt;b&gt;Ctrl-L&lt;/b&gt; per netejar la pantalla.</translation>
     </message>
     <message>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
-        <translation>Escriviu &lt;b&gt;help&lt;\b&gt; per a obtindre un llistat de les ordes disponibles.</translation>
+        <translation>Escriviu &lt;b&gt;help&lt;/b&gt; per a obtindre un llistat de les ordes disponibles.</translation>
     </message>
     <message>
         <source>%1 B</source>

--- a/src/qt/locale/bitcoin_ca_ES.ts
+++ b/src/qt/locale/bitcoin_ca_ES.ts
@@ -1610,11 +1610,11 @@
     </message>
     <message>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
-        <translation>Utilitza les fletxes d'amunt i avall per navegar per l'historial, i &lt;b&gt;Ctrl-L&lt;\b&gt; per netejar la pantalla.</translation>
+        <translation>Utilitza les fletxes d'amunt i avall per navegar per l'historial, i &lt;b&gt;Ctrl-L&lt;/b&gt; per netejar la pantalla.</translation>
     </message>
     <message>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
-        <translation>Escriviu &lt;b&gt;help&lt;\b&gt; per a obtenir un llistat de les ordres disponibles.</translation>
+        <translation>Escriviu &lt;b&gt;help&lt;/b&gt; per a obtenir un llistat de les ordres disponibles.</translation>
     </message>
     <message>
         <source>%1 B</source>

--- a/src/qt/locale/bitcoin_en.ts
+++ b/src/qt/locale/bitcoin_en.ts
@@ -4,7 +4,7 @@
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
+        <location filename="../forms/addressbookpage.ui" line="+51"/>
         <source>Right-click to edit address or label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19,7 +19,18 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+10"/>
+        <source>Extend address expiration date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <location filename="../addressbookpage.cpp" line="+191"/>
+        <source>&amp;Extend</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Copy the currently selected address to the system clipboard</translation>
     </message>
@@ -29,17 +40,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
+        <location line="+55"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-53"/>
+        <location line="-45"/>
         <source>Delete the currently selected address from the list</source>
         <translation>Delete the currently selected address from the list</translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+26"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Export the data in the current tab to a file</translation>
     </message>
@@ -49,12 +60,17 @@
         <translation>&amp;Export</translation>
     </message>
     <message>
-        <location line="-30"/>
+        <location line="-26"/>
         <source>&amp;Delete</source>
         <translation>&amp;Delete</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+50"/>
+        <location filename="../addressbookpage.cpp" line="-110"/>
+        <source>(no label)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+76"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"></translation>
     </message>
@@ -85,11 +101,12 @@
     </message>
     <message>
         <location line="+4"/>
+        <location line="+447"/>
         <source>These are your Firo addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-441"/>
         <source>&amp;Copy Address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -104,7 +121,30 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+193"/>
+        <location line="+74"/>
+        <location line="+8"/>
+        <source>Spark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-7"/>
+        <location line="+11"/>
+        <source>Transparent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-9"/>
+        <source>Spark names</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+6"/>
+        <source>My own spark names</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+291"/>
         <source>Export Address List</source>
         <translation type="unfinished"></translation>
     </message>
@@ -114,7 +154,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+21"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -123,17 +163,37 @@
         <source>There was an error trying to save the address list to %1. Please try again.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+10"/>
+        <source>&amp;Copy Spark Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>&amp;Copy Transparent Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+30"/>
+        <source>Spark addresses can safely receive multiple payments, although reusing one can link those requests.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+170"/>
+        <location filename="../addresstablemodel.cpp" line="+412"/>
         <source>Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+0"/>
         <source>Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>Address Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -150,12 +210,17 @@
         <translation>Passphrase Dialog</translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+48"/>
+        <source>passphraseWarning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+36"/>
         <source>Enter passphrase</source>
         <translation>Enter passphrase</translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+26"/>
         <source>New passphrase</source>
         <translation>New passphrase</translation>
     </message>
@@ -165,7 +230,7 @@
         <translation>Repeat new passphrase</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+46"/>
+        <location filename="../askpassphrasedialog.cpp" line="+54"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -205,7 +270,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+49"/>
         <source>Confirm wallet encryption</source>
         <translation type="unfinished"></translation>
     </message>
@@ -278,8 +343,123 @@
     </message>
     <message>
         <location line="+47"/>
-        <location line="+24"/>
+        <location line="+25"/>
         <source>Warning: The Caps Lock key is on!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>AutoMintDialog</name>
+    <message>
+        <location filename="../forms/automintdialog.ui" line="+26"/>
+        <source>Make Funds Private</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Unlock your wallet to make all transparent funds private with Spark.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>Enter passphrase</source>
+        <translation type="unfinished">Enter passphrase</translation>
+    </message>
+    <message>
+        <location line="+30"/>
+        <source>Lock wallet immediately after making funds private</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>AutoMintSparkDialog</name>
+    <message>
+        <location filename="../automintdialog.cpp" line="+28"/>
+        <source>Make Private</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+53"/>
+        <source>Wallet unlock failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The passphrase was incorrect.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Unable to generate mint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+62"/>
+        <source>Make all available transparent funds private with Spark?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Unlocking wallet...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>Making funds private...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>AutoMintSparkModel</name>
+    <message>
+        <location filename="../automintmodel.cpp" line="+355"/>
+        <source>Successfully made %1 private with Spark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Fail to mint, %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Fail to unlock wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Automatic Spark Privacy</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>AutomintNotification</name>
+    <message>
+        <location filename="../forms/automintnotification.ui" line="+29"/>
+        <source>Make Funds Private</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>Make all available transparent funds private with Spark?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>AutomintSparkNotification</name>
+    <message>
+        <location filename="../automintnotification.cpp" line="+16"/>
+        <source>Make Private</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Dismiss</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -297,29 +477,47 @@
     </message>
 </context>
 <context>
+    <name>BitcoinApplication</name>
+    <message>
+        <location filename="../bitcoin.cpp" line="+433"/>
+        <source>You need to unlock to allow Spark wallet be created.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../firogui.cpp" line="+357"/>
+        <location filename="../bitcoingui.cpp" line="+445"/>
         <source>Sign &amp;message...</source>
         <translation>Sign &amp;message...</translation>
     </message>
     <message>
-        <location line="+429"/>
+        <location line="+1279"/>
         <source>Synchronizing with network...</source>
         <translation>Synchronizing with network...</translation>
     </message>
     <message>
-        <location line="-507"/>
+        <location line="-1385"/>
         <source>&amp;Overview</source>
         <translation>&amp;Overview</translation>
     </message>
     <message>
-        <location line="-143"/>
+        <location line="-164"/>
         <source>Node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
+        <location line="+69"/>
+        <source>Tor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Tor quickstart is enabled for this session. This confirms configuration, not Tor bootstrap or routing health. Manual proxy settings may override affected routes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+93"/>
         <source>Show general overview of wallet</source>
         <translation>Show general overview of wallet</translation>
     </message>
@@ -334,7 +532,27 @@
         <translation>Browse transaction history</translation>
     </message>
     <message>
-        <location line="+23"/>
+        <location line="+6"/>
+        <source>&amp;Spark Names</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Manage your registered Spark Names</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>&amp;Masternodes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Browse masternodes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+31"/>
         <source>E&amp;xit</source>
         <translation>E&amp;xit</translation>
     </message>
@@ -379,17 +597,37 @@
         <translation>&amp;Encrypt Wallet...</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>&amp;Backup Wallet...</source>
         <translation>&amp;Backup Wallet...</translation>
     </message>
     <message>
         <location line="+2"/>
+        <source>&amp;Export View Key...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Export Spark view key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>&amp;Change Passphrase...</source>
         <translation>&amp;Change Passphrase...</translation>
     </message>
     <message>
         <location line="+12"/>
+        <source>&amp;Console</source>
+        <translation type="unfinished">&amp;Console</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Open the console in the debug window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -404,7 +642,82 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+359"/>
+        <location line="+1"/>
+        <source>Open a firo: URI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+140"/>
+        <source>Toggle light / dark theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Light or dark theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+107"/>
+        <source>Wallet navigation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+24"/>
+        <source>Console</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Options</source>
+        <translation type="unfinished">Options</translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+1"/>
+        <source>Show synchronization details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <location line="+386"/>
+        <source>Syncing...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-333"/>
+        <location line="+1"/>
+        <location line="+457"/>
+        <source>Hide navigation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-143"/>
+        <location line="+538"/>
+        <source>Network activity disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-534"/>
+        <source>Synced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+139"/>
+        <source>Show navigation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+360"/>
         <source>Click to disable network activity.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -419,27 +732,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
-        <source>Syncing Headers (%1%)...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+37"/>
+        <location line="+80"/>
         <source>Reindexing blocks on disk...</source>
         <translation>Reindexing blocks on disk...</translation>
     </message>
     <message>
-        <location line="-510"/>
+        <location line="-1388"/>
         <source>Send coins to a Firo address</source>
         <translation>Send coins to a Firo address</translation>
     </message>
     <message>
-        <location line="+67"/>
+        <location line="+93"/>
         <source>Backup wallet to another location</source>
         <translation>Backup wallet to another location</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+4"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Change the passphrase used for wallet encryption</translation>
     </message>
@@ -459,17 +767,17 @@
         <translation>&amp;Verify message...</translation>
     </message>
     <message>
-        <location line="+516"/>
+        <location line="+1440"/>
         <source>Firo</source>
         <translation>Firo</translation>
     </message>
     <message>
-        <location line="-741"/>
+        <location line="-1714"/>
         <source>Wallet</source>
         <translation>Wallet</translation>
     </message>
     <message>
-        <location line="+152"/>
+        <location line="+173"/>
         <source>&amp;Send</source>
         <translation>&amp;Send</translation>
     </message>
@@ -479,7 +787,7 @@
         <translation>&amp;Receive</translation>
     </message>
     <message>
-        <location line="+50"/>
+        <location line="+75"/>
         <source>&amp;Show / Hide</source>
         <translation>&amp;Show / Hide</translation>
     </message>
@@ -494,7 +802,7 @@
         <translation>Encrypt the private keys that belong to your wallet</translation>
     </message>
     <message>
-        <location line="+7"/>
+        <location line="+10"/>
         <source>Sign messages with your Firo addresses to prove you own them</source>
         <translation>Sign messages with your Firo addresses to prove you own them</translation>
     </message>
@@ -504,12 +812,12 @@
         <translation>Verify messages to ensure they were signed with specified Firo addresses</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+66"/>
         <source>&amp;File</source>
         <translation>&amp;File</translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+15"/>
         <source>&amp;Settings</source>
         <translation>&amp;Settings</translation>
     </message>
@@ -519,17 +827,12 @@
         <translation>&amp;Help</translation>
     </message>
     <message>
-        <location line="+15"/>
-        <source>Tabs toolbar</source>
-        <translation>Tabs toolbar</translation>
-    </message>
-    <message>
-        <location line="-158"/>
+        <location line="-180"/>
         <source>Request payments (generates QR codes and firo: URIs)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+70"/>
+        <location line="+102"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"></translation>
     </message>
@@ -539,17 +842,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Open a firo: URI or payment request</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
+        <location line="+5"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="+356"/>
+        <location line="+1186"/>
         <source>%n active connection(s) to Firo network</source>
         <translation>
             <numerusform>%n active connection to Firo network</numerusform>
@@ -557,7 +855,7 @@
         </translation>
     </message>
     <message>
-        <location line="+60"/>
+        <location line="+76"/>
         <source>Indexing blocks on disk...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -575,12 +873,12 @@
         </translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+22"/>
         <source>%1 behind</source>
         <translation>%1 behind</translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+27"/>
         <source>Last received block was generated %1 ago.</source>
         <translation>Last received block was generated %1 ago.</translation>
     </message>
@@ -590,7 +888,7 @@
         <translation>Transactions after this will not yet be visible.</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+100"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
@@ -605,32 +903,44 @@
         <translation>Information</translation>
     </message>
     <message>
-        <location line="-78"/>
+        <location line="-61"/>
         <source>Up to date</source>
         <translation>Up to date</translation>
     </message>
     <message>
-        <location line="-440"/>
+        <location line="-1377"/>
         <source>Show the %1 help message to get a list with possible Firo command-line options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+199"/>
+        <location line="+1011"/>
         <source>%1 client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+227"/>
+        <location line="-328"/>
+        <location line="+523"/>
+        <location line="+66"/>
         <source>Connecting to peers...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="-44"/>
+        <source>Syncing Headers...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+84"/>
         <source>Catching up...</source>
         <translation>Catching up...</translation>
     </message>
     <message>
-        <location line="+145"/>
+        <location line="+84"/>
+        <source>Synchronizing additional data: %p%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+137"/>
         <source>Date: %1
 </source>
         <translation type="unfinished"></translation>
@@ -660,7 +970,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+3"/>
         <source>Sent transaction</source>
         <translation>Sent transaction</translation>
     </message>
@@ -670,7 +980,7 @@
         <translation>Incoming transaction</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <location line="+78"/>
         <source>HD key generation is &lt;b&gt;enabled&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -680,7 +990,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
+        <location line="+20"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</translation>
     </message>
@@ -690,8 +1000,17 @@
         <translation>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../firo.cpp" line="+518"/>
+        <location filename="../bitcoin.cpp" line="+170"/>
         <source>A fatal error occurred. Firo can no longer continue safely and will quit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CancelPasswordDialog</name>
+    <message>
+        <location filename="../cancelpassworddialog.cpp" line="+38"/>
+        <location line="+5"/>
+        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -738,7 +1057,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+68"/>
         <source>(un)select all</source>
         <translation type="unfinished"></translation>
     </message>
@@ -783,7 +1102,7 @@
         <translation type="unfinished">Confirmed</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+55"/>
+        <location filename="../coincontroldialog.cpp" line="+113"/>
         <source>Copy address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -844,12 +1163,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+325"/>
+        <location line="+398"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+181"/>
+        <location line="+233"/>
         <source>yes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -870,18 +1189,232 @@
     </message>
     <message>
         <location line="+42"/>
-        <location line="+52"/>
+        <location line="+73"/>
         <source>(no label)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-7"/>
+        <location line="-14"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+2"/>
+        <source>(sigma mint)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>(mint)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>(change)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CreateSparkNamePage</name>
+    <message>
+        <location filename="../forms/createsparkname.ui" line="+35"/>
+        <source>Create spark name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+58"/>
+        <source>Spark Names serve as a convenient way to associate your Spark Address with a memorable name of your choice. This way you can share your Spark Names to other users for them to send funds to you (for e.g. @sparky) instead of a long Spark Address while protecting your privacy.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+32"/>
+        <source>Spark address:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Generate new</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+29"/>
+        <source>Spark name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+17"/>
+        <source>1-20 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>Number of years:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+54"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;To get this spark name you must pay a fee of &lt;span style=&quot; font-weight:600;&quot;&gt;%1 FIRO(s)&lt;/span&gt;. Fee depends on spark name lengths, shorter names are more expensive. Fee can be paid only with private funds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+52"/>
+        <source>Additional information you want to associate with this spark name (max. 1024 symbols):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../createsparknamepage.cpp" line="+63"/>
+        <source>Register</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
+        <source>Extend</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Extend Spark Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+37"/>
+        <source>This Spark Name cannot be extended by a full year yet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>This Spark Name could not be found and cannot be extended.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+36"/>
+        <location line="+10"/>
+        <location line="+10"/>
+        <location line="+2"/>
+        <location line="+142"/>
+        <location line="+40"/>
+        <location line="+10"/>
+        <source>Error</source>
+        <translation type="unfinished">Error</translation>
+    </message>
+    <message>
+        <location line="-214"/>
+        <source>The wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Extension unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Spark names are not yet allowed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Invalid spark address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Error details: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Transaction submitted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>The updated expiry will appear after the extension transaction is confirmed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The Spark Name will appear after the registration transaction is confirmed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+52"/>
+        <source>Fee: %1 FIRO. New estimated expiration: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Extension fee: %1 FIRO. The updated expiration estimate is unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+43"/>
+        <source>Error validating Spark Name parameter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>Failed to prepare the Spark Name extension transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Failed to prepare the Spark Name registration transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Are you sure you want to extend this Spark Name?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Are you sure you want to register this Spark Name?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source> You are sending FIRO from a Spark address to the Spark Name fee address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Confirm Spark Name extension</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>Confirm Spark Name registration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>Failed to submit the Spark Name extension transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Failed to submit the Spark Name registration transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+17"/>
+        <source>Failed to extend the Spark Name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Failed to register the Spark Name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+31"/>
+        <source>⚠️ Not enough private funds to extend this Spark Name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>⚠️ Not enough private funds to register this Spark Name.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -913,28 +1446,75 @@
         <translation>&amp;Address</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
-        <source>New receiving address</source>
+        <location filename="../editaddressdialog.cpp" line="+34"/>
+        <source>New transparent receiving address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+4"/>
-        <source>New sending address</source>
+        <source>New transparent sending address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
-        <source>Edit receiving address</source>
+        <source>Edit transparent receiving address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+4"/>
-        <source>Edit sending address</source>
+        <source>Edit transparent sending address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+71"/>
+        <location line="+3"/>
+        <source>New RAP payment code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+4"/>
+        <source>RAP address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>Edit RAP payment code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>New spark sending address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+4"/>
+        <source>Spark address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-1"/>
+        <source>Edit spark sending address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>New spark receiving address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Edit spark receiving address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+123"/>
         <source>The entered address &quot;%1&quot; is not a valid Firo address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The entered address &quot;%1&quot; is not a valid spark Firo address.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -952,11 +1532,29 @@
         <source>New key generation failed.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+5"/>
+        <source>New RAP address validation failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Receiving RAP addresses cannot be relabeled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ExportViewKeyDialog</name>
+    <message>
+        <location filename="../forms/exportviewkeydialog.ui" line="+14"/>
+        <source>Export View Key</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+78"/>
+        <location filename="../intro.cpp" line="+82"/>
         <source>A new data directory will be created.</source>
         <translation>A new data directory will be created.</translation>
     </message>
@@ -984,7 +1582,7 @@
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+40"/>
+        <location filename="../utilitydialog.cpp" line="+44"/>
         <source>version</source>
         <translation type="unfinished">version</translation>
     </message>
@@ -1020,7 +1618,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+1"/>
         <source>Choose data directory on startup (default: %u)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1083,7 +1681,7 @@
         <translation>Use a custom data directory:</translation>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+94"/>
+        <location filename="../intro.cpp" line="+122"/>
         <source>Error: Specified data directory &quot;%1&quot; cannot be created.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1110,6 +1708,340 @@
     </message>
 </context>
 <context>
+    <name>ManualMintDialog</name>
+    <message>
+        <location filename="../forms/manualmintdialog.ui" line="+14"/>
+        <source>Coin Selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Available amount to mint:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <location line="+234"/>
+        <source>0.00000000</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-227"/>
+        <location line="+170"/>
+        <source>FIRO</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-128"/>
+        <location line="+33"/>
+        <location line="+26"/>
+        <location line="+23"/>
+        <location line="+62"/>
+        <source>FIRO : Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-126"/>
+        <source>Total:</source>
+        <translation type="unfinished">Total:</translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>10</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+26"/>
+        <source>1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+23"/>
+        <source>0.1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+62"/>
+        <source>0.5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+47"/>
+        <source>100</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+45"/>
+        <source>&amp;Mint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>&amp;Clear All</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MasternodeList</name>
+    <message>
+        <location filename="../forms/masternodelist.ui" line="+14"/>
+        <source>Form</source>
+        <translation type="unfinished">Form</translation>
+    </message>
+    <message>
+        <location line="+59"/>
+        <source>Filter List:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Filter masternode list</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Filter List</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Show only masternodes this wallet has keys for.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>My masternodes only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+23"/>
+        <source>Node Count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../masternodelist.cpp" line="+193"/>
+        <source>Collateral · %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>PoSe %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+53"/>
+        <source>REGISTERED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>LAST PAID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>NEXT PAYMENT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>COLLATERAL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>PAYOUT ADDRESS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>OPERATOR REWARD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>COLLATERAL ADDRESS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>OWNER ADDRESS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+57"/>
+        <source>Filter masternodes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>Sort masternodes by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sort the masternode list</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Service</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>PoSe score</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Registered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Last paid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Next payment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Payout address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Operator reward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Collateral amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Collateral address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Owner address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+36"/>
+        <source>Masternode list</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+26"/>
+        <source>No masternodes found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Masternodes matching your filters will appear here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Copy ProTx Hash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Copy Collateral Outpoint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+263"/>
+        <source>Sort ascending</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>Sort descending</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+93"/>
+        <source>Pre-enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>PoSe Banned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>%1, not claimed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>%1 to %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>%1 to unknown address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
+        <source>Service: %1
+Status: %2
+PoSe score: %3
+Registered: %4
+Last paid: %5
+Next payment: %6
+Payout address: %7
+Operator reward: %8
+Collateral: %9
+Collateral address: %10
+Owner address: %11
+ProTx hash: %12
+Collateral outpoint: %13</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+18"/>
+        <source>%1, %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+92"/>
+        <source>Additional information for DIP3 Masternode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ModalOverlay</name>
     <message>
         <location filename="../forms/modaloverlay.ui" line="+14"/>
@@ -1117,24 +2049,27 @@
         <translation type="unfinished">Form</translation>
     </message>
     <message>
-        <location line="+119"/>
-        <source>Recent transactions may not yet be visible, and therefore your wallet&apos;s balance might be incorrect. This information will be correct once your wallet has finished synchronizing with the firo network, as detailed below.</source>
+        <location line="+129"/>
+        <location filename="../modaloverlay.cpp" line="+226"/>
+        <source>Wallet is still syncing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
-        <source>Attempting to spend firos that are affected by not-yet-displayed transactions will not be accepted by the network.</source>
+        <location line="+7"/>
+        <location filename="../modaloverlay.cpp" line="+3"/>
+        <source>Recent transactions may not yet be visible, and your balance might be incorrect until the wallet finishes synchronizing with the Firo network.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+63"/>
+        <location line="+50"/>
         <source>Number of blocks left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+7"/>
         <location line="+26"/>
-        <location filename="../modaloverlay.cpp" line="+138"/>
+        <location filename="../modaloverlay.cpp" line="+3"/>
+        <location line="+132"/>
         <source>Unknown...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1165,13 +2100,76 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+40"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modaloverlay.cpp" line="-1"/>
+        <location filename="../modaloverlay.cpp" line="-139"/>
+        <source>Wallet is synchronized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>The wallet is up to date with the Firo network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Complete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+122"/>
         <source>Unknown. Syncing Headers (%1)...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>NotifyMnemonic</name>
+    <message>
+        <location filename="../forms/notifymnemonic.ui" line="+20"/>
+        <source>Notification</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+25"/>
+        <source>Your wallet has been created successfully. Using the following recovery seed phrase, you will be able to recover your wallet and balances at any time.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Recovery seed phrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+70"/>
+        <source>Please write down these recovery seed phrase and wallet birth date and keep them in a secure location. Specifying the wallet&apos;s birth date when restoring your wallet speeds up and optimizes the scanning of your wallet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>WARNING: Anyone with access to the recovery seed phrase can recover your wallet and will have control over your funds!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>Please re-enter the recovery seed phrase to ensure you have written it down correctly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../notifymnemonic.cpp" line="+78"/>
+        <source>Warning</source>
+        <translation type="unfinished">Warning</translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>Are you sure you wish to proceed without confirming whether you have written down your seed words correctly?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+28"/>
+        <source>Your entered words do not match, please press back to re-check your mnemonic.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1179,27 +2177,12 @@
     <name>OpenURIDialog</name>
     <message>
         <location filename="../forms/openuridialog.ui" line="+14"/>
-        <source>Open URI</source>
+        <source>Open bitcoin URI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <source>Open payment request from URI or file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+9"/>
+        <location line="+8"/>
         <source>URI:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+10"/>
-        <source>Select payment request file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
-        <source>Select payment request file to open</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1241,7 +2224,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+114"/>
+        <location line="+163"/>
         <source>Accept connections from outside</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1257,7 +2240,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
+        <location line="+114"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1288,12 +2271,12 @@
         <translation>&amp;Reset Options</translation>
     </message>
     <message>
-        <location line="-514"/>
+        <location line="-534"/>
         <source>&amp;Network</source>
         <translation>&amp;Network</translation>
     </message>
     <message>
-        <location line="-85"/>
+        <location line="-134"/>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1320,6 +2303,51 @@
     <message>
         <location line="+3"/>
         <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Restore Spark and wallet transaction data following a full reindex (deletes Spark mint records from the wallet, then reindexes the chain and reapplies wallet transactions). This can take several hours.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>&amp;Reindex Spark wallet data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Spark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>When enabled, the wallet can prompt to make transparent funds private with Spark.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Enable automatic Spark &amp;privacy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Split outputs when minting to Spark for better privacy.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Enable &amp;splitting when minting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Show the Make Private control in the overview.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Show Spark &amp;privacy controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1398,7 +2426,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+88"/>
+        <source>Automatically launch an embedded Tor instance and configure Firo to use it. Manual proxy settings above can override routing for affected connection types. A client restart is required.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Route connection through Tor (quickstart)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+31"/>
         <source>&amp;Window</source>
         <translation>&amp;Window</translation>
     </message>
@@ -1453,12 +2491,12 @@
         <translation>Choose the default subdivision unit to show in the interface and when sending coins.</translation>
     </message>
     <message>
-        <location line="-450"/>
+        <location line="-519"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+612"/>
+        <location line="+681"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
@@ -1468,33 +2506,73 @@
         <translation>&amp;Cancel</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+86"/>
+        <location filename="../optionsdialog.cpp" line="+168"/>
         <source>default</source>
         <translation>default</translation>
     </message>
     <message>
-        <location line="+64"/>
+        <location line="+68"/>
         <source>none</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
+        <location line="+92"/>
         <source>Confirm options reset</source>
         <translation>Confirm options reset</translation>
     </message>
     <message>
         <location line="+1"/>
-        <location line="+43"/>
+        <location line="+89"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-43"/>
+        <location line="-89"/>
         <source>Client will be shut down. Do you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
+        <location line="+40"/>
+        <source>Confirm Spark reindex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Warning: On restart, this setting will wipe your transaction list, reindex the blockchain, and restore wallet data from your seed. Spark mint records are cleared and rebuilt from the chain. This will likely take a few hours. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Tor quickstart is enabled for this session by -torsetup. It cannot be changed here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Tor quickstart is disabled for this session by -torsetup. It cannot be changed here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Tor quickstart is enabled for this session.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Tor quickstart is enabled. Restart the client to apply this change.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Tor quickstart is disabled. Restart the client to apply this change.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Tor quickstart is disabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1512,88 +2590,375 @@
         <translation>Form</translation>
     </message>
     <message>
-        <location line="+62"/>
-        <location line="+386"/>
+        <location line="+109"/>
+        <location line="+384"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Firo network after a connection is established, but this process has not completed yet.</source>
         <translation>The displayed information may be out of date. Your wallet automatically synchronizes with the Firo network after a connection is established, but this process has not completed yet.</translation>
     </message>
     <message>
-        <location line="-139"/>
-        <source>Watch-only:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+10"/>
+        <location line="-221"/>
+        <location line="+58"/>
+        <location line="+63"/>
         <source>Available:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="-57"/>
         <source>Your current spendable balance</source>
         <translation>Your current spendable balance</translation>
     </message>
     <message>
-        <location line="+41"/>
+        <location line="-47"/>
+        <location line="+58"/>
+        <location line="+63"/>
         <source>Pending:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-236"/>
+        <location line="-398"/>
+        <source>font-size: 14px; color: #92400E; background-color:#FEF3C7;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+86"/>
+        <source>FIRO (Primary)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+89"/>
+        <source>Transparent 0.00000000 FIRO (0%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>Private (Spark): 0.00000000 FIRO (0%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Send</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Receive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Make Private...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+18"/>
+        <source>Private Balances (Spark)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Your current spendable private Spark balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+17"/>
+        <location line="+15"/>
+        <source>0.00000000 FIRO</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-16"/>
+        <source>Total of Spark mint transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>Available to make private:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+18"/>
+        <source>Transparent Balances</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+29"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</translation>
     </message>
     <message>
-        <location line="+112"/>
+        <location line="+11"/>
+        <location line="+63"/>
         <source>Immature:</source>
         <translation>Immature:</translation>
     </message>
     <message>
-        <location line="-29"/>
+        <location line="-57"/>
         <source>Mined balance that has not yet matured</source>
         <translation>Mined balance that has not yet matured</translation>
     </message>
     <message>
-        <location line="-177"/>
-        <source>Balances</source>
+        <location line="+113"/>
+        <source>Recent Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+161"/>
+        <location line="-345"/>
+        <location line="+306"/>
         <source>Total:</source>
         <translation>Total:</translation>
     </message>
     <message>
-        <location line="+61"/>
+        <location line="-299"/>
         <source>Your current total balance</source>
         <translation>Your current total balance</translation>
     </message>
     <message>
-        <location line="+92"/>
+        <location line="+242"/>
+        <source>Watch-only Balances</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>Your current balance in watch-only addresses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <source>Spendable:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+49"/>
+        <location filename="../overviewpage.cpp" line="+215"/>
         <source>Recent transactions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-317"/>
+        <location line="+51"/>
+        <source>Mainnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Testnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Devnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Regtest</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+29"/>
+        <source>↗  Send</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>↙  Receive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+393"/>
+        <source>Make Private</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-376"/>
+        <location line="+629"/>
+        <source>No transactions yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-626"/>
+        <location line="+629"/>
+        <source>Your history will appear here after the first transfer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-432"/>
+        <source>Make Funds Private</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Move FIRO from your transparent balance into Spark, Firo&apos;s private balance.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>From</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>Transparent balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>To</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>Private balance (Spark)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+18"/>
+        <source>Max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Amount</source>
+        <translation type="unfinished">Amount</translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>The network fee will be deducted from this amount.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Review</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <source>The amount exceeds your available transparent balance.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>The amount and transaction fee exceed your available transparent balance.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>The transaction fee is higher than the configured maximum of %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The transaction was rejected: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Unable to create the Spark transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Make funds private</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+31"/>
+        <location line="+62"/>
+        <source>Unable to Make Funds Private</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-61"/>
+        <source>Firo could not create a Spark transaction for this amount.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Use Maximum fills in the highest amount that can be made private, with the network fee deducted from it. No funds were moved.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Change the amount and try again. No funds were moved.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Use Maximum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Change Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>Review Private Transfer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount to make private: &lt;b&gt;%1&lt;/b&gt;&lt;br&gt;Network fee: %2&lt;br&gt;Total from transparent balance: %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <source>The transfer could not be fully completed. Part of it may already have been sent; check the Transactions tab before trying again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The transfer could not be completed. No funds were moved.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Funds Moving to Spark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>%1 is moving to your private Spark balance. It will become available after confirmation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+77"/>
+        <source>Transparent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Private (Spark):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Private (Spark) %1%  ·  Transparent %2%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+125"/>
+        <source>Wallet is still syncing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Transactions will appear here as synchronization completes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../forms/overviewpage.ui" line="+17"/>
         <source>Unconfirmed transactions to watch-only addresses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+50"/>
+        <location line="+17"/>
         <source>Mined balance in watch-only addresses that has not yet matured</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+128"/>
+        <location line="+17"/>
         <source>Current total balance in watch-only addresses</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1601,34 +2966,42 @@
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+326"/>
-        <location line="+216"/>
-        <location line="+42"/>
-        <location line="+113"/>
-        <location line="+14"/>
-        <location line="+18"/>
+        <location filename="../paymentserver.cpp" line="+172"/>
         <source>Payment request error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-402"/>
+        <location line="+1"/>
         <source>Cannot start firo: click-to-pay handler</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+103"/>
-        <location line="+14"/>
+        <location line="+60"/>
+        <location line="+6"/>
         <location line="+7"/>
         <source>URI handling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-20"/>
-        <source>Payment request fetch URL is invalid: %1</source>
+        <location line="-12"/>
+        <location line="+23"/>
+        <source>Cannot process payment request because BIP70 is not supported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="-22"/>
+        <location line="+23"/>
+        <source>Due to widespread security flaws in BIP70 it&apos;s strongly recommended that any merchant instructions to switch wallets be ignored.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-22"/>
+        <location line="+23"/>
+        <source>If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-20"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1638,96 +3011,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+9"/>
         <source>Payment request file handling</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Payment request file cannot be read! This can be caused by an invalid payment request file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+61"/>
-        <location line="+9"/>
-        <location line="+31"/>
-        <location line="+10"/>
-        <location line="+17"/>
-        <location line="+88"/>
-        <source>Payment request rejected</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-155"/>
-        <source>Payment request network doesn&apos;t match client network.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+9"/>
-        <source>Payment request expired.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+6"/>
-        <source>Payment request is not initialized.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+26"/>
-        <source>Unverified payment requests to custom payment scripts are unsupported.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+9"/>
-        <location line="+17"/>
-        <source>Invalid payment request.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-10"/>
-        <source>Requested payment amount of %1 is too small (considered dust).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+55"/>
-        <source>Refund from %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+44"/>
-        <source>Payment request %1 is too large (%2 bytes, allowed %3 bytes).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+9"/>
-        <source>Error communicating with %1: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+20"/>
-        <source>Payment request cannot be parsed!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+13"/>
-        <source>Bad response from server %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+22"/>
-        <source>Network request error</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+11"/>
-        <source>Payment acknowledged</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PeerTableModel</name>
     <message>
-        <location filename="../peertablemodel.cpp" line="+117"/>
+        <location filename="../peertablemodel.cpp" line="+126"/>
         <source>User Agent</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1746,21 +3038,36 @@
         <source>Ping</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+0"/>
+        <source>Network</source>
+        <translation type="unfinished">Network</translation>
+    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../firounits.cpp" line="+176"/>
+        <location filename="../bitcoinunits.cpp" line="+176"/>
         <source>Amount</source>
         <translation type="unfinished">Amount</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+136"/>
+        <location filename="../guiutil.cpp" line="+187"/>
         <source>Enter a Firo address (e.g. %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+762"/>
+        <location line="+2"/>
+        <source> or a payment code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source> or a Firo spark address (e.g. pr1cjgedy25xhr4fmzx8cm5gf940v5j2482m94uaa0yguxxw2yrel0f0hyjesg77px7at47f4s3jy8hthmyr6ajhvn025yp28fyuwzvar0gcc7p27rvttn2tyl9ejwthjpaavlmy3cm3sysz)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+646"/>
         <source>%1 d</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1850,15 +3157,84 @@
         </translation>
     </message>
     <message>
-        <location filename="../firo.cpp" line="+172"/>
+        <location filename="../bitcoin.cpp" line="+333"/>
         <source>%1 didn&apos;t yet exit safely...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../rosenbridge.cpp" line="+50"/>
+        <location line="+40"/>
+        <source>OP_RETURN metadata exceeds the 80-byte Rosen limit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-37"/>
+        <source>Rosen metadata is too short.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Rosen metadata contains an unknown destination chain.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Rosen metadata contains an empty destination address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Rosen metadata destination-address length is inconsistent.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+18"/>
+        <source>OP_RETURN metadata is empty.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>OP_RETURN metadata must be an even-length hexadecimal string.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+36"/>
+        <source>Destination chain: %1
+Bridge fee: %2 atomic units
+Network fee: %3 atomic units
+Destination address (hex): %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../test/test_sendcoinsentry.cpp" line="+14"/>
+        <source> You are sending Firo to an Exchange Address. Exchange Addresses can only receive funds from a transparent address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source> You are sending Firo from a transparent address to another transparent address. To protect your privacy, we recommend using Spark addresses instead.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source> You are sending Firo from a transparent address to a Spark address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source> You are sending Firo from a Spark address to another Spark address. This transaction is fully private.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source> You are sending Firo from a private Spark pool to a transparent address. Please note that some exchanges do not accept direct Spark deposits.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>QObject::QObject</name>
     <message>
-        <location line="-81"/>
+        <location filename="../bitcoin.cpp" line="-93"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1876,7 +3252,7 @@
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
+        <location filename="../receiverequestdialog.cpp" line="+40"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1886,7 +3262,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
+        <location line="+30"/>
         <source>Save QR Code</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1910,7 +3286,7 @@
         <location line="+23"/>
         <location line="+36"/>
         <location line="+23"/>
-        <location line="+663"/>
+        <location line="+649"/>
         <location line="+23"/>
         <location line="+23"/>
         <location line="+23"/>
@@ -1932,7 +3308,7 @@
         <translation>N/A</translation>
     </message>
     <message>
-        <location line="-1345"/>
+        <location line="-1331"/>
         <source>Client version</source>
         <translation>Client version</translation>
     </message>
@@ -2007,31 +3383,31 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+404"/>
-        <location line="+558"/>
+        <location line="+384"/>
+        <location line="+564"/>
         <source>Received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-478"/>
-        <location line="+455"/>
+        <location line="-484"/>
+        <location line="+461"/>
         <source>Sent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-414"/>
+        <location line="-420"/>
         <source>&amp;Peers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+56"/>
         <source>Banned peers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+60"/>
-        <location filename="../rpcconsole.cpp" line="+460"/>
-        <location line="+719"/>
+        <location line="+63"/>
+        <location filename="../rpcconsole.cpp" line="+477"/>
+        <location line="+850"/>
         <source>Select a peer to view detailed information.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2066,13 +3442,13 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1079"/>
-        <location line="+987"/>
+        <location line="-1065"/>
+        <location line="+973"/>
         <source>User Agent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-684"/>
+        <location line="-670"/>
         <source>Open the %1 debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2087,7 +3463,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+610"/>
+        <location line="+596"/>
         <source>Services</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2137,7 +3513,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1116"/>
+        <location line="-1102"/>
         <source>Last block time</source>
         <translation>Last block time</translation>
     </message>
@@ -2152,7 +3528,7 @@
         <translation>&amp;Console</translation>
     </message>
     <message>
-        <location line="+195"/>
+        <location line="+175"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2167,7 +3543,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-413"/>
+        <location filename="../rpcconsole.cpp" line="-415"/>
         <source>In:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2177,7 +3553,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../forms/debugwindow.ui" line="-299"/>
+        <location filename="../forms/debugwindow.ui" line="-279"/>
         <source>Debug log file</source>
         <translation>Debug log file</translation>
     </message>
@@ -2187,7 +3563,7 @@
         <translation>Clear console</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-214"/>
+        <location filename="../rpcconsole.cpp" line="-236"/>
         <source>1 &amp;hour</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2220,12 +3596,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
+        <location line="+38"/>
         <source>&amp;Unban</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+126"/>
+        <location line="+95"/>
         <source>Welcome to the %1 RPC console.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2245,7 +3621,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
+        <location line="+99"/>
         <source>Network activity disabled</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2270,7 +3646,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+99"/>
+        <location line="+100"/>
+        <source>(inbound onion)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>(node id: %1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2315,22 +3696,7 @@
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
-        <source>&amp;Amount:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-16"/>
-        <source>&amp;Label:</source>
-        <translation type="unfinished">&amp;Label:</translation>
-    </message>
-    <message>
-        <location line="-37"/>
-        <source>&amp;Message:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-20"/>
+        <location filename="../forms/receivecoinsdialog.ui" line="+198"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2340,30 +3706,25 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
+        <location line="-23"/>
+        <location line="+13"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Firo network.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
+        <location line="-59"/>
+        <location line="+13"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-7"/>
-        <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+23"/>
-        <location line="+22"/>
+        <location line="+7"/>
+        <location line="+19"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+32"/>
+        <location line="+58"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2373,17 +3734,62 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+75"/>
+        <location line="+66"/>
         <source>Requested payments history</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-95"/>
+        <location line="-82"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
+        <location line="-164"/>
+        <source>Choose Spark or Transparent for the payment request address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>ADDRESS TYPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>Choose one of this wallet&apos;s Spark Names for the payment request.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Use My Spark Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Register a new Spark Name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Register Spark Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+29"/>
+        <source>LABEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>AMOUNT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+26"/>
+        <source>MESSAGE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+161"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2393,7 +3799,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
+        <location line="+13"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2403,7 +3809,29 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+47"/>
+        <location filename="../receivecoinsdialog.cpp" line="+157"/>
+        <source>REQUESTED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+61"/>
+        <location line="+4"/>
+        <source>Spark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3"/>
+        <location line="+4"/>
+        <source>Transparent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-2"/>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
         <source>Copy URI</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2422,11 +3850,69 @@
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+36"/>
+        <source>No payment requests yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Requests you create will be listed here</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+243"/>
+        <location line="+20"/>
+        <location line="+7"/>
+        <location line="+6"/>
+        <source>Error</source>
+        <translation type="unfinished">Error</translation>
+    </message>
+    <message>
+        <location line="-32"/>
+        <source>The selected Spark address does not belong to this wallet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>&quot;%1&quot; is not a valid Spark Name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Spark Name &quot;%1&quot; was not found or has expired.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>Spark Name &quot;%1&quot; does not belong to this wallet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+163"/>
+        <source>&amp;Use an existing Spark address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Spark addresses can safely receive multiple payments, although sharing one address can link those requests.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>R&amp;euse an existing transparent address (not recommended)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Reusing transparent addresses has security and privacy risks. Only use this to recreate an earlier payment request.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
+        <location filename="../forms/receiverequestdialog.ui" line="+44"/>
         <source>QR Code</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2446,22 +3932,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+65"/>
+        <location line="+14"/>
+        <source>&amp;Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../receiverequestdialog.cpp" line="+114"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <source>Payment information</source>
+        <location line="+16"/>
+        <source>Payment URI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>URI</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2477,11 +3963,27 @@
     </message>
     <message>
         <location line="+2"/>
+        <location line="+2"/>
+        <source>Address Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-2"/>
+        <source>transparent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>spark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+11"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2494,7 +3996,7 @@
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+29"/>
+        <location filename="../recentrequeststablemodel.cpp" line="+34"/>
         <source>Date</source>
         <translation type="unfinished">Date</translation>
     </message>
@@ -2509,12 +4011,27 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+0"/>
+        <source>Address Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+40"/>
         <source>(no label)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+9"/>
+        <source>transparent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>spark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
         <source>(no message)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2530,10 +4047,121 @@
     </message>
 </context>
 <context>
+    <name>Recover</name>
+    <message>
+        <location filename="../forms/recover.ui" line="+20"/>
+        <source>Create or Recover Wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Let&apos;s create or restore your Firo wallet!
+
+You will be prompted to write down a recovery seed phrase that allows you to restore your wallet in the future.
+
+Please ensure that you store this securely as anyone with access to the recovery seed phrase can access your funds!
+
+By default, we recommend a 24 word recovery seed phrase.
+
+You can also choose to further encrypt your recovery seed phrase with an additional passphrase (only recommended for advanced users).
+You will need to save this passphrase as well with the recovery seed phrase. Failing to save the passphrase will lead to your funds being irrecoverable.
+
+If you have an existing recovery seed phrase, please select &quot;Recover existing wallet&quot;. If you have secured your recovery seed phrase with an additional passphrase, enter it too.
+Also you can choose wallet birth date for more faster and optimised wallet scan.
+      </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+29"/>
+        <source>Create new wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Recover existing wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+37"/>
+        <source>12 Words</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>24 Words</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+32"/>
+        <source>Input recovery seed phrase here:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+17"/>
+        <source>Choose the wallet creation date:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>dd-MM-yyyy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+33"/>
+        <source>Use additional passphrase (optional) [Recommended for advanced users only]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>Enter passphrase:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+23"/>
+        <source>Enter passphrase again:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+41"/>
+        <source>If you use RAP addresses, and are restoring a wallet, enter the number of RAP addresses you have created to recover funds received using RAP addresses.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>Number of RAP addresses:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>The number of RAP addresses will be created in the wallet for the initial blockchain scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../recover.cpp" line="+280"/>
+        <source>Wrong number of words. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
+        <source>You have entered an invalid recovery seed phrase. Please double check the spelling and order.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
+        <source>Passphrases don&apos;t match.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Passphrase can&apos;t be empty.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+554"/>
+        <location filename="../sendcoinsdialog.cpp" line="+1170"/>
         <source>Send Coins</source>
         <translation>Send Coins</translation>
     </message>
@@ -2553,7 +4181,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
+        <location line="+16"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2598,17 +4226,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+206"/>
-        <source>Transaction Fee:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+14"/>
+        <location line="+220"/>
         <source>Choose...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+59"/>
         <source>collapse fee-settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2624,7 +4247,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-64"/>
+        <location line="-140"/>
+        <source>Transaction Fee</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
+        <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until your have validated the complete chain.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Warning: Fee estimation is currently not possible.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+29"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2670,7 +4308,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+94"/>
         <source>Send to multiple recipients at once</source>
         <translation>Send to multiple recipients at once</translation>
     </message>
@@ -2680,32 +4318,40 @@
         <translation>Add &amp;Recipient</translation>
     </message>
     <message>
-        <location line="-20"/>
+        <location line="+47"/>
+        <location filename="../sendcoinsdialog.cpp" line="+97"/>
+        <source>Private Balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <location filename="../sendcoinsdialog.cpp" line="-1"/>
+        <source>Use Transparent Balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-98"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-876"/>
+        <location line="-894"/>
         <source>Dust:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+691"/>
+        <location line="+713"/>
         <source>Confirmation time target:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+188"/>
+        <location line="+184"/>
         <source>Clear &amp;All</source>
         <translation>Clear &amp;All</translation>
     </message>
     <message>
-        <location line="+55"/>
-        <source>Balance:</source>
-        <translation>Balance:</translation>
-    </message>
-    <message>
-        <location line="-84"/>
+        <location line="-25"/>
+        <location filename="../sendcoinsdialog.cpp" line="-257"/>
         <source>Confirm the send action</source>
         <translation>Confirm the send action</translation>
     </message>
@@ -2715,7 +4361,7 @@
         <translation>S&amp;end</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-486"/>
+        <location filename="../sendcoinsdialog.cpp" line="-935"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2750,25 +4396,75 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+205"/>
+        <location line="+336"/>
+        <source>Spark name %1 not found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+203"/>
         <location line="+5"/>
+        <location line="+20"/>
         <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+10"/>
+        <source>EX-addresses can only receive FIRO from transparent addresses.&lt;br /&gt;&lt;br /&gt;Your FIRO will go from Spark to a newly generated transparent address %1 and then immediately be sent to the EX-address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Rosen Bridge metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination chain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Bridge fee (atomic units)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Network fee (atomic units)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Destination address (hex)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Raw data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
+        <location line="+7"/>
+        <source>Messages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+32"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
+        <location line="+11"/>
+        <source>. An additional transaction fee of %1 will apply to complete the send from the transparent address to the EX-address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+37"/>
         <source>Total Amount %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2783,7 +4479,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
+        <location line="+54"/>
+        <source>Private transaction staging produced an unexpected transaction count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+24"/>
+        <source>Intermediate address was not found in the transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+158"/>
+        <source>Switch to Transparent Balance to send this Rosen Bridge transfer.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+118"/>
         <source>The recipient address is not valid. Please recheck.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2808,8 +4519,13 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Transaction creation failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Transaction creation failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2827,6 +4543,16 @@
         <source>Payment request expired.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location line="+4"/>
+        <source>The Rosen Bridge metadata is invalid, duplicated, or incompatible with fee subtraction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Rosen Bridge transfers must be sent from the transparent balance.</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message numerus="yes">
         <location line="+67"/>
         <source>%n block(s)</source>
@@ -2836,12 +4562,22 @@
         </translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+44"/>
+        <source>Use Private Balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Transparent Balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+40"/>
         <source>Pay only the required fee of %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="+25"/>
+        <location line="+32"/>
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation>
             <numerusform>Estimated to begin confirmation within %n block.</numerusform>
@@ -2849,7 +4585,7 @@
         </translation>
     </message>
     <message>
-        <location line="+102"/>
+        <location line="+104"/>
         <source>Warning: Invalid Firo address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2874,17 +4610,18 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="334"/>
+        <location line="-1066"/>
+        <location line="+19"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Error</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="335"/>
+        <location line="+1"/>
         <source>Sending private funds to an exchange address is temporarily unavailable. Move the funds to a transparent address first, then send from there.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="598"/>
+        <location line="+303"/>
         <source>This payment does not fit in one Spark coin and will be sent as %1 separate transactions. Each pays its own fee, they can be linked to each other, and if one of them is rejected the recipients will have been paid only in part.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2892,24 +4629,7 @@
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+155"/>
-        <location line="+539"/>
-        <location line="+533"/>
-        <source>A&amp;mount:</source>
-        <translation>A&amp;mount:</translation>
-    </message>
-    <message>
-        <location line="-1185"/>
-        <source>Pay &amp;To:</source>
-        <translation>Pay &amp;To:</translation>
-    </message>
-    <message>
-        <location line="+93"/>
-        <source>&amp;Label:</source>
-        <translation>&amp;Label:</translation>
-    </message>
-    <message>
-        <location line="-68"/>
+        <location filename="../forms/sendcoinsentry.ui" line="+67"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2919,7 +4639,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
+        <location line="+18"/>
+        <source>PAY &amp;TO</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
         <source>The Firo address to send the payment to</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2940,68 +4665,123 @@
     </message>
     <message>
         <location line="+7"/>
-        <location line="+548"/>
-        <location line="+533"/>
         <source>Remove this entry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1021"/>
+        <location line="+31"/>
+        <source>Resolves to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+60"/>
+        <location line="+157"/>
+        <source>margin-top:2px;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-140"/>
+        <source>&amp;LABEL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+23"/>
+        <source>A&amp;MOUNT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
         <source>The fee will be deducted from the amount being sent. The recipient will receive less firos than you enter in the amount field. If multiple recipients are selected, the fee is split equally.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
-        <source>S&amp;ubtract fee from amount</source>
+        <source>S&amp;UBTRACT FEE FROM AMOUNT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <source>Message:</source>
+        <location line="+31"/>
+        <source>Rosen Bridge:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+443"/>
-        <source>This is an unauthenticated payment request.</source>
+        <location line="+23"/>
+        <source>MESSAGE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+529"/>
-        <source>This is an authenticated payment request.</source>
+        <location line="+7"/>
+        <source>Optional message for this transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1009"/>
+        <location line="-90"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
-        <source>A message that was attached to the firo: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Firo network.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+448"/>
-        <location line="+529"/>
-        <source>Pay To:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-495"/>
-        <location line="+533"/>
-        <source>Memo:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../sendcoinsentry.cpp" line="+37"/>
+        <location filename="../sendcoinsentry.cpp" line="+54"/>
         <source>Enter a label for this address to add it to your address book</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+184"/>
+        <source>Message exceeds %1 bytes limit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+143"/>
+        <source>Metadata: %1 bytes
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>
+Raw data: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Switch to Transparent Balance to send this Rosen Bridge transfer.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>This transaction includes Rosen Bridge OP_RETURN metadata.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
+        <source> You are sending Firo to an Exchange Address. Exchange Addresses can only receive funds from a transparent address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source> You are sending Firo from a transparent address to another transparent address. To protect your privacy, we recommend using Spark addresses instead.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source> You are sending Firo from a transparent address to a Spark address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source> You are sending Firo from a Spark address to another Spark address. This transaction is fully private.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source> You are sending Firo from a private Spark pool to a transparent address. Please note that some exchanges do not accept direct Spark deposits.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SendConfirmationDialog</name>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="+95"/>
+        <location filename="../sendcoinsdialog.cpp" line="+845"/>
         <location line="+5"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
@@ -3010,7 +4790,7 @@
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+78"/>
+        <location filename="../utilitydialog.cpp" line="+112"/>
         <source>%1 is shutting down...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3039,23 +4819,23 @@
     </message>
     <message>
         <location line="+18"/>
-        <source>The Firo address to sign the message with</source>
+        <source>The Firo or Spark address to sign the message with</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+7"/>
-        <location line="+210"/>
+        <location line="+205"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
+        <location line="-195"/>
+        <location line="+205"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
+        <location line="-195"/>
         <source>Paste address from clipboard</source>
         <translation>Paste address from clipboard</translation>
     </message>
@@ -3075,33 +4855,43 @@
         <translation>Signature</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+30"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation>Copy the current signature to the system clipboard</translation>
     </message>
     <message>
         <location line="+21"/>
-        <source>Sign the message to prove you own this Firo address</source>
-        <translation>Sign the message to prove you own this Firo address</translation>
+        <source>Sign the message to prove you own this Firo or Spark address</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+98"/>
+        <source>The Firo or Spark address the message was signed with</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+37"/>
+        <source>Verify the message to ensure it was signed with the specified Firo or Spark address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-132"/>
         <source>Sign &amp;Message</source>
         <translation>Sign &amp;Message</translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+10"/>
         <source>Reset all sign message fields</source>
         <translation>Reset all sign message fields</translation>
     </message>
     <message>
         <location line="+3"/>
-        <location line="+143"/>
+        <location line="+135"/>
         <source>Clear &amp;All</source>
         <translation>Clear &amp;All</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-80"/>
         <source>&amp;Verify Message</source>
         <translation>&amp;Verify Message</translation>
     </message>
@@ -3111,52 +4901,46 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <source>The Firo address the message was signed with</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+37"/>
-        <source>Verify the message to ensure it was signed with the specified Firo address</source>
-        <translation>Verify the message to ensure it was signed with the specified Firo address</translation>
-    </message>
-    <message>
-        <location line="+3"/>
+        <location line="+61"/>
         <source>Verify &amp;Message</source>
         <translation>Verify &amp;Message</translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+10"/>
         <source>Reset all verify message fields</source>
         <translation>Reset all verify message fields</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+41"/>
+        <location filename="../signverifymessagedialog.cpp" line="+95"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+83"/>
-        <location line="+80"/>
+        <location line="+166"/>
+        <location line="+124"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-80"/>
+        <location line="-162"/>
+        <location line="+38"/>
         <location line="+8"/>
-        <location line="+72"/>
+        <location line="+73"/>
+        <location line="+24"/>
+        <location line="+19"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
+        <location line="-124"/>
+        <location line="+124"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-158"/>
+        <location line="+42"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3171,17 +4955,31 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="-46"/>
+        <location line="+51"/>
         <source>Message signed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="-79"/>
+        <location line="+119"/>
+        <source>The entered Spark name is not registered.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+24"/>
+        <source>The entered address is for a different network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <location line="+32"/>
         <source>The signature could not be decoded.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
+        <location line="-32"/>
+        <location line="+32"/>
         <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"></translation>
@@ -3192,13 +4990,104 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
+        <location line="-41"/>
+        <location line="+48"/>
         <source>Message verification failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="-63"/>
+        <location line="+68"/>
         <source>Message verified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SparkNamesPage</name>
+    <message>
+        <location filename="../forms/sparknamespage.ui" line="+14"/>
+        <source>Form</source>
+        <translation type="unfinished">Form</translation>
+    </message>
+    <message>
+        <location line="+51"/>
+        <source>Spark Names registered to this wallet, along with their expiry.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+28"/>
+        <source>Register a new Spark Name for this wallet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Create Spark Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../sparknamespage.cpp" line="+215"/>
+        <source>No Spark Names yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Register a Spark Name to give your Spark address a memorable, human-readable name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+196"/>
+        <source>EXPIRES</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>ADDITIONAL INFO</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Copy Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Copy the Spark Name to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Copy Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Copy the resolved Spark address to the clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Extend</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Extend the validity of this Spark Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+43"/>
+        <location line="+1"/>
+        <source>Expired</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Expiring Soon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3209,11 +5098,16 @@
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
+    <message>
+        <location line="+1"/>
+        <source>[devnet]</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
+        <location filename="../trafficgraphwidget.cpp" line="+86"/>
         <source>KB/s</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3221,7 +5115,7 @@
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
-        <location filename="../transactiondesc.cpp" line="+30"/>
+        <location filename="../transactiondesc.cpp" line="+31"/>
         <source>Open for %n more block(s)</source>
         <translation>
             <numerusform>Open for %n more block</numerusform>
@@ -3234,7 +5128,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>conflicted with a transaction with %1 confirmations</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3244,27 +5138,14 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>0/unconfirmed, %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+0"/>
-        <source>in memory pool</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+0"/>
-        <source>not in memory pool</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+0"/>
+        <location line="+4"/>
+        <location line="+3"/>
+        <location line="+3"/>
         <source>abandoned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+4"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3274,7 +5155,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
+        <location line="+3"/>
+        <source>locked via LLMQ based ChainLocks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>verified via LLMQ based InstantSend</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+24"/>
         <source>Status</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3308,50 +5199,54 @@
     </message>
     <message>
         <location line="+5"/>
-        <location line="+13"/>
-        <location line="+72"/>
+        <location line="+8"/>
+        <location line="+86"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-86"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <location line="+20"/>
-        <location line="+69"/>
+        <location line="+34"/>
+        <location line="+67"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-87"/>
+        <location line="-94"/>
+        <location line="+9"/>
         <source>own address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
+        <location line="-9"/>
+        <location line="+9"/>
         <location line="+69"/>
         <source>watch-only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-67"/>
+        <location line="-76"/>
+        <location line="+9"/>
         <source>label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+34"/>
         <location line="+12"/>
-        <location line="+53"/>
-        <location line="+26"/>
-        <location line="+55"/>
+        <location line="+62"/>
+        <location line="+2"/>
+        <location line="+38"/>
+        <location line="+95"/>
         <source>Credit</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="-144"/>
+        <location line="-207"/>
         <source>matures in %n more block(s)</source>
         <translation>
             <numerusform>matures in %n more block</numerusform>
@@ -3364,14 +5259,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+59"/>
-        <location line="+25"/>
-        <location line="+55"/>
+        <location line="+63"/>
+        <location line="+2"/>
+        <location line="+42"/>
+        <location line="+95"/>
         <source>Debit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-70"/>
+        <location line="-120"/>
         <source>Total debit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3381,7 +5277,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+15"/>
         <source>Transaction fee</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3392,12 +5288,11 @@
     </message>
     <message>
         <location line="+6"/>
-        <location line="+11"/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
+        <location line="+2"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3417,17 +5312,28 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
-        <source>Merchant</source>
+        <location line="+20"/>
+        <location line="+13"/>
+        <source>Messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
+        <location line="+11"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+16"/>
+        <source>Received with RAP address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Sent to RAP address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+11"/>
         <source>Debug information</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3442,7 +5348,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
+        <location line="+20"/>
         <source>Amount</source>
         <translation type="unfinished">Amount</translation>
     </message>
@@ -3462,12 +5368,12 @@
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+20"/>
+        <location filename="../forms/transactiondescdialog.ui" line="+44"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>This pane shows a detailed description of the transaction</translation>
     </message>
     <message>
-        <location filename="../transactiondescdialog.cpp" line="+17"/>
+        <location filename="../transactiondescdialog.cpp" line="+30"/>
         <source>Details for %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3475,7 +5381,7 @@
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+246"/>
+        <location filename="../transactiontablemodel.cpp" line="+256"/>
         <source>Date</source>
         <translation type="unfinished">Date</translation>
     </message>
@@ -3486,11 +5392,11 @@
     </message>
     <message>
         <location line="+0"/>
-        <source>Label</source>
+        <source>Address / Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="+58"/>
+        <location line="+102"/>
         <source>Open for %n more block(s)</source>
         <translation>
             <numerusform>Open for %n more block</numerusform>
@@ -3548,7 +5454,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+39"/>
+        <location line="+68"/>
         <source>Received with</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3573,22 +5479,87 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
-        <source>watch-only</source>
+        <location line="+2"/>
+        <source>Spend to</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <source>(n/a)</source>
+        <location line="+2"/>
+        <source>Spend to yourself</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+213"/>
-        <source>(no label)</source>
+        <location line="+2"/>
+        <source>Anonymize</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Sent to RAP address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Received with RAP address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Mint spark to yourself</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Spend spark to yourself</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Mint spark to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Spend spark to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Received Spark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+39"/>
+        <source>watch-only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>Anonymized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>(n/a)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+106"/>
+        <source>Involves a watch-only address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Locked by InstantSend.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+136"/>
+        <source>(no label)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+41"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3609,6 +5580,11 @@
     </message>
     <message>
         <location line="+2"/>
+        <source>Whether or not this transaction was locked by InstantSend.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>User-defined intent/purpose of the transaction.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3621,13 +5597,7 @@
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+69"/>
-        <location line="+16"/>
-        <source>All</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-15"/>
+        <location filename="../transactionview.cpp" line="+304"/>
         <source>Today</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3657,17 +5627,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+8"/>
         <source>Received with</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+3"/>
         <source>Sent to</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+3"/>
         <source>To yourself</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3682,7 +5652,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+15"/>
         <source>Enter address or label to search</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3692,22 +5662,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
+        <location line="+111"/>
         <source>Abandon transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+3"/>
         <source>Copy address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Copy label</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
+        <location line="+2"/>
         <source>Copy amount</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3737,7 +5702,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+186"/>
+        <location line="+471"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3752,12 +5717,14 @@
         <translation type="unfinished">Confirmed</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="-539"/>
+        <location line="+541"/>
         <source>Watch-only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-547"/>
+        <location line="+548"/>
         <source>Date</source>
         <translation type="unfinished">Date</translation>
     </message>
@@ -3772,12 +5739,230 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-547"/>
+        <location line="+548"/>
         <source>Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="-762"/>
+        <source>RECEIVED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>SENT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+87"/>
+        <source>Filter by watch-only involvement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Watch-only filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>All transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Watch-only transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Non-watch-only transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>Filter by InstantSend status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Any InstantSend status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Locked by InstantSend</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Not locked by InstantSend</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>Filter by date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Any date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Filter by transaction type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Any type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Spend to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Spend to yourself</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Anonymize</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sent to RAP address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Received with RAP address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Mint spark to yourself</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Spend spark to yourself</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Mint spark to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Spend spark to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Received Spark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+59"/>
+        <source>Sort by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Sort transactions by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sort the transaction history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Transaction type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
+        <source>Amount</source>
+        <translation type="unfinished">Amount</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>InstantSend</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Export the data in the current tab to a file</source>
+        <translation type="unfinished">Export the data in the current tab to a file</translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <location line="+237"/>
+        <source>No transactions yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-232"/>
+        <location line="+235"/>
+        <source>Your history will appear here after the first transfer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-229"/>
+        <source>Re-broadcast transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+226"/>
+        <source>Wallet is still syncing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Transactions will appear here as synchronization completes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>No matching transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Try adjusting the filters above</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+217"/>
+        <source>Sort ascending</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>Sort descending</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+49"/>
         <source>ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3802,7 +5987,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+147"/>
+        <location line="+63"/>
+        <location line="+2"/>
+        <source>Re-broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-2"/>
+        <source>Broadcast succeeded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>There was an error trying to broadcast the message: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+153"/>
         <source>Range:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3815,7 +6016,7 @@
 <context>
     <name>UnitDisplayStatusBarControl</name>
     <message>
-        <location filename="../firogui.cpp" line="+129"/>
+        <location filename="../bitcoingui.cpp" line="+154"/>
         <source>Unit to show amounts in. Click to select another unit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3823,7 +6024,7 @@
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+27"/>
+        <location filename="../walletframe.cpp" line="+28"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3831,69 +6032,129 @@
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+291"/>
+        <location filename="../walletmodel.cpp" line="+435"/>
         <source>Send Coins</source>
         <translation type="unfinished">Send Coins</translation>
     </message>
     <message>
-        <location filename="../walletmodel.cpp" line="1322"/>
+        <location line="+687"/>
+        <source>You have received a payment to a RAP address, please unlock your wallet to receive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>RAP address payment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>RAP addresses require you to unlock your wallet every time a payment to it is received.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>If you do not enter your password now, you will need to rescan your wallet to receive your FIRO.&lt;br/&gt;&lt;br/&gt;Re-enter your password?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+50"/>
+        <source>Spark wallet is not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>The entered address is invalid.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>The entered address is for a different network.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The entered address does not belong to this wallet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+141"/>
         <source>Spark Coin Control temporarily supports selecting at most one coin. Clear the selection to let the wallet split the payment automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../walletmodel.cpp" line="1352"/>
+        <location line="+30"/>
         <source>Subtracting the fee from the amount is temporarily unavailable for Spark spends.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../walletmodel.cpp" line="1455"/>
+        <location line="+112"/>
         <source>Spend to transparent address limit exceeded.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../walletmodel.cpp" line="1461"/>
+        <location line="+6"/>
         <source>A Spark payment may use at most %1 transactions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../walletmodel.cpp" line="1466"/>
+        <location line="+5"/>
         <source>The available Spark coins cannot cover the amount and the required transaction fees.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../walletmodel.cpp" line="1517"/>
-        <location filename="../walletmodel.cpp" line="1678"/>
+        <location line="+52"/>
         <source>Unable to create a single-input Spark transaction.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../walletmodel.cpp" line="1527"/>
+        <location line="+13"/>
         <source>Spark fee estimate did not match the wallet (planned %1, wallet %2).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../walletmodel.cpp" line="1619"/>
+        <location line="+135"/>
+        <source>Unable to create a versioned Spark transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+98"/>
+        <source>Chain height changed during Spark name construction; retry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>Spark name registration temporarily uses a single Spark coin. Please select at most one.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../walletmodel.cpp" line="1635"/>
+        <location line="+13"/>
         <source>Unable to select a Spark coin.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../walletmodel.cpp" line="1654"/>
+        <location line="+26"/>
         <source>Spark name registration temporarily requires one Spark coin large enough to cover the registration and transaction fees.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../walletmodel.cpp" line="1754"/>
-        <location filename="../walletmodel.cpp" line="1810"/>
-        <source>Refusing to commit a non-single-input Spark transaction.</source>
+        <location line="+17"/>
+        <source>Unable to create the expected Spark transaction format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../walletmodel.cpp" line="1854"/>
+        <location line="+103"/>
+        <location line="+87"/>
+        <location line="+27"/>
+        <source>Refusing to commit an incompatible Spark transaction format.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-48"/>
+        <source>Refusing to commit an incomplete Spark transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+70"/>
         <source> This payment was split across %1 transactions and %2 of them were already sent, so the recipients have been paid only in part. Do not retry the whole payment. Already sent: %3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3901,17 +6162,7 @@
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+46"/>
-        <source>&amp;Export</source>
-        <translation type="unfinished">&amp;Export</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Export the data in the current tab to a file</source>
-        <translation type="unfinished">Export the data in the current tab to a file</translation>
-    </message>
-    <message>
-        <location line="+201"/>
+        <location filename="../walletview.cpp" line="+320"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3944,52 +6195,47 @@
 <context>
     <name>firo-core</name>
     <message>
-        <location filename="../firostrings.cpp" line="+318"/>
+        <location filename="../bitcoinstrings.cpp" line="+468"/>
         <source>Options:</source>
         <translation>Options:</translation>
     </message>
     <message>
-        <location line="+31"/>
+        <location line="+57"/>
         <source>Specify data directory</source>
         <translation>Specify data directory</translation>
     </message>
     <message>
-        <location line="-90"/>
+        <location line="-139"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation>Connect to a node to retrieve peer addresses, and disconnect</translation>
     </message>
     <message>
-        <location line="+93"/>
+        <location line="+142"/>
         <source>Specify your own public address</source>
         <translation>Specify your own public address</translation>
     </message>
     <message>
-        <location line="-108"/>
+        <location line="-177"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>Accept command line and JSON-RPC commands</translation>
     </message>
     <message>
-        <location line="-221"/>
+        <location line="-331"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect/-noconnect)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+27"/>
         <source>Connect only to the specified node(s); -noconnect or -connect=0 alone to disable automatic connections</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+18"/>
         <source>Distributed under the MIT software license, see the accompanying file %s or %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
-        <source>If &lt;category&gt; is not supplied or if &lt;category&gt; = 1, output all debugging information.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+36"/>
+        <location line="+115"/>
         <source>Prune configured below the minimum of %d MiB.  Please use a higher number.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3999,47 +6245,48 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+21"/>
         <source>Rescans are not possible in pruned mode. You will need to use -reindex which will download the whole blockchain again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+213"/>
         <source>Error: A fatal internal error occurred, see debug.log for details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+7"/>
         <source>Fee (in %s/kB) to add to transactions you send (default: %s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
+        <location line="+54"/>
         <source>Pruning blockstore...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+12"/>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>Run in the background as a daemon and accept commands</translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+79"/>
         <source>Unable to start HTTP server. See debug log for details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-360"/>
+        <location line="-556"/>
+        <location line="+412"/>
         <source>Firo Core</source>
         <translation type="unfinished">Firo Core</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="-411"/>
         <source>The %s developers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
+        <location line="+4"/>
         <source>A fee rate (in %s/kB) that will be used when fee estimation has insufficient data (default: %s)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4049,7 +6296,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
+        <location line="+12"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation>Bind to given address and always listen on it. Use [host]:port notation for IPv6</translation>
     </message>
@@ -4059,12 +6306,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+14"/>
         <source>Delete all wallet transactions and only recover those parts of the blockchain through -rescan on startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Error loading %s: You can&apos;t enable HD on a already existing non-HD wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4074,22 +6321,47 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
-        <translation>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</translation>
-    </message>
-    <message>
-        <location line="+6"/>
+        <location line="+21"/>
         <source>Extra transactions to keep in memory for compact block reconstructions (default: %u)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="+3"/>
+        <source>Failed to create backup, file already exists! This could happen if you restarted wallet in less than 60 seconds. You can continue if you are ok with this.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Has to have at least two mint coins with at least 1 confirmation in order to spend a coin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>If &lt;category&gt; is not supplied or is 1 or all, output all debugging information. The value none resets categories specified before it. The value 0 retains Firo&apos;s historical behavior and disables all logging except errors.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <source>If this block is in the chain assume that it and its ancestors are valid and potentially skip their script verification (0 to verify all, default: %s, testnet: %s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+4"/>
+        <source>In case of sync/reindex verifies privacy (Spark) proofs with batch verification, default: true</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Interval in seconds for rebroadcasting InstantSend-locked mempool transactions to peers (0 = disabled, default: %u)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Make automatic outbound connections only to network &lt;net&gt; (ipv4, ipv6 or onion). Can be specified multiple times to allow multiple networks.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Maximum allowed median peer time offset adjustment. Local perspective of time may be influenced by peers forward or backward by this amount. (default: %u seconds)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4099,7 +6371,37 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
+        <location line="+5"/>
+        <source>Optionally add the &quot;S&quot; flag to wrap the output in a pay-to-script-hash.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Optionally add the &quot;W&quot; flag to produce a pay-to-witness-pubkey-hash output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Optionally add the &quot;W&quot; flag to produce a pay-to-witness-script-hash output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is explicitly forbidden: -onion=0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is not provided: none of -proxy, -onion, -torsetup or -listenonion (with a usable -torcontrol) is given.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>Output only the hex-encoded transaction id of the resultant transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Please check that your computer&apos;s date and time are correct! If your clock is wrong, %s will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4110,6 +6412,11 @@
     </message>
     <message>
         <location line="+14"/>
+        <source>Read extra arguments from standard input, one per line until EOF/Ctrl-D (recommended for sensitive information such as passphrases)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Reduce storage requirements by enabling pruning (deleting) of old blocks. This allows the pruneblockchain RPC to be called to delete specific blocks, and enables automatic pruning of old blocks if a target size in MiB is provided. This mode is incompatible with -txindex and -rescan. Warning: Reverting this setting requires re-downloading the entire blockchain. (default: 0 = disable pruning blocks, 1 = allow manual pruning via RPC, &gt;%u = automatically prune block files to stay under the specified target size in MiB)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4124,7 +6431,37 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+6"/>
+        <source>Spark Coin Control temporarily supports selecting at most one coin. Clear the selection to let the wallet split the payment automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Spark batch verification failed. The invalid spend transactions are listed in debug.log. Restart the node: batching is disabled and a reindex is started automatically so chainstate is rebuilt and Spark proofs are checked block by block.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Spark multi-input spends are temporarily disabled. No single available Spark coin can fund this transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Spark spend batch failed after committing %u of %u transactions: %s. Do not retry the whole payment. Already sent: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Subtracting the fee from the amount is temporarily unavailable when a Spark spend must be split across multiple transactions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>The available Spark coins cannot cover the amount and the required transaction fees.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>The block database contains a block which appears to be from the future. This may be due to your computer&apos;s date and time being set incorrectly. Only rebuild the block database if you are sure that your computer&apos;s date and time are correct</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4134,22 +6471,67 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
+        <location line="+3"/>
+        <source>This product includes Masternodes software developed by the Dash Core developers %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Transaction is too large (size limit: 250Kb). Select less inputs or consolidate your UTXOs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
         <source>Unable to rewind the database to a pre-fork state. You will need to redownload the blockchain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+9"/>
+        <source>Unsupported logging level or category %s. Valid levels are: %s. Valid categories are: %s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Use Mnemonic code for generating deterministic keys. Only has effect during wallet creation/first start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Use UPnP to map the listening port (default: 1 when listening and no -proxy)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+8"/>
+        <source>Use this argument when you want to keep additional data in block index for mobile api, default: false</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>User defined mnemonic for HD wallet (bip39). Only has effect during wallet creation/first start (default: randomly generated)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>User defined mnemonic passphrase for HD wallet (BIP39). Only has effect during wallet creation/first start (default: empty string)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>User defined seed for HD wallet (should be in hex). Only has effect during wallet creation/first start (default: randomly generated)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Username and hashed password for JSON-RPC connections. The field &lt;userpw&gt; comes in the format: &lt;USERNAME&gt;:&lt;SALT&gt;$&lt;HASH&gt;. A canonical python script is included in share/rpcuser. The client then connects normally using the rpcuser=&lt;USERNAME&gt;/rpcpassword=&lt;PASSWORD&gt; pair of arguments. This option can be specified multiple times</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+6"/>
+        <source>Wallet is locked, can&apos;t replenish keypool! Automatic backups and mixing are disabled, please unlock your wallet to replenish keypool.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Wallet will not create transactions that violate mempool chain limits (default: %u)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4164,18 +6546,48 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+9"/>
+        <source>You are starting in lite mode, all Dash-specific functionality is disabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>You must specify a znodeblsprivkey in the configuration. Please see documentation for help.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
         <source>You need to rebuild the database using -reindex-chainstate to change -txindex</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
+        <source>%s Daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>%s RPC client version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>%s corrupt, salvage failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+1"/>
+        <source>%s firo-tx utility version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>-maxmempool must be at least %d MB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>-wallet parameter must only specify a filename (not a path)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4184,7 +6596,62 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+1"/>
+        <source>A Spark payment may use at most %u transactions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Add Pay To n-of-m Multi-sig output to TX. n = REQUIRED, m = PUBKEYS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Add address-based output to TX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Add data-based output to TX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Add input to TX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Add pay-to-pubkey output to TX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Add raw script output to TX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Add zero or more signatures to transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Amount for recipient %1% is too small to pay the fee</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Amount for recipient %1% is too small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Anonymous communication with TOR - Quickstart (default: %d)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>Append comment to the user agent string</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4195,8 +6662,19 @@
     </message>
     <message>
         <location line="+2"/>
+        <source>Bad change address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>Block creation options:</source>
         <translation>Block creation options:</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Block index is outdated, reindex required
+</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
@@ -4205,7 +6683,37 @@
     </message>
     <message>
         <location line="+2"/>
+        <source>Cannot write default spark address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Chain height changed during Spark name construction; retry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Chain height changed during Spark transaction construction; retry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>Chain selection options:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Chain tip changed during Spark name construction; retry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Chain tip changed during Spark transaction construction; retry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Chain tip is unavailable during Spark name construction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4214,7 +6722,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+1"/>
+        <source>Commands:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Connect to JSON-RPC on &lt;port&gt; (default: %u or testnet: %u)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Connection options:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4230,7 +6748,32 @@
     </message>
     <message>
         <location line="+1"/>
+        <source>Could not open debug log file %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Create hex-encoded Firo transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Create new, empty TX.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>Debugging/Testing options:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Delete input N from TX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Delete output N from TX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4245,6 +6788,11 @@
     </message>
     <message>
         <location line="+2"/>
+        <source>Either recipients or newMints has to be nonempty.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>Enable publish hash block in &lt;address&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4309,9 +6857,34 @@
         <translation>Error opening block database</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+2"/>
+        <source>Error upgrading chainstate database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Error: Disk space is low!</source>
         <translation>Error: Disk space is low!</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Error: Wallet locked, unable to create transaction!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Fail to generate mints, </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Failed to create backup, error: %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Failed to delete backup, error: %s</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
@@ -4320,6 +6893,11 @@
     </message>
     <message>
         <location line="+3"/>
+        <source>Get help for a command</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Importing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4339,42 +6917,47 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Invalid amount for -%s=&lt;amount&gt;: &apos;%s&apos;</source>
+        <location line="+165"/>
+        <source>prevtxs=JSON object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
+        <source>privatekeys=JSON object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>version</source>
+        <translation type="unfinished">version</translation>
+    </message>
+    <message>
+        <location line="-164"/>
         <source>Invalid amount for -fallbackfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+8"/>
         <source>Keep the transaction memory pool below &lt;n&gt; megabytes (default: %u)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+8"/>
         <source>Loading banlist...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Location of the auth cookie (default: data dir)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
+        <location line="+10"/>
         <source>Not enough file descriptors available.</source>
         <translation>Not enough file descriptors available.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Only connect to nodes in network &lt;net&gt; (ipv4, ipv6 or onion)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
+        <location line="+5"/>
         <source>Print this help message and exit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4384,7 +6967,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+2"/>
         <source>Prune cannot be configured with a negative value.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4404,12 +6987,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+8"/>
         <source>Rewinding blocks...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+13"/>
         <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4419,18 +7002,68 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
+        <location line="+23"/>
         <source>Specify wallet file (within data directory)</source>
         <translation>Specify wallet file (within data directory)</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+11"/>
         <source>The source code is available from %s.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+19"/>
         <source>Unable to bind to %s on this computer. %s is probably already running.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Unable to create a single-input Spark transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Unable to create a valid Spark name transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Unable to create spend transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Unable to estimate the final Spark name transaction fee</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Unable to generate spend key, wallet is locked.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Unable to generate spend key.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Unable to mint full amount; only partial minting was possible</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Unable to select Spark coins for spend.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Unable to select coins for minting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Unable to select cons for spend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4449,8 +7082,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>Update hex-encoded Firo transaction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
+        <source>Usage:</source>
+        <translation type="unfinished">Usage:</translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: %u)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Use the dev chain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4475,12 +7123,27 @@
     </message>
     <message>
         <location line="+1"/>
+        <source>Wait for RPC server to start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation>Wallet %s resides outside data directory %s</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>Wallet debugging/testing options:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet locked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet locked, unable to create transaction!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4494,12 +7157,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-358"/>
+        <location line="-563"/>
         <source>Allow JSON-RPC connections from specified source. Valid for &lt;ip&gt; are a single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0) or a network/CIDR (e.g. 1.2.3.4/24). This option can be specified multiple times</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
+        <location line="+4"/>
+        <source>Amount for private recipient %1% is too small to send after the fee has been deducted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Amount for recipient %1% is too small to send after the fee has been deducted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Bind to given address and whitelist peers connecting to it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4510,7 +7183,17 @@
     </message>
     <message>
         <location line="+9"/>
+        <source>Could not locate RPC credentials. No authentication cookie could be found, and no rpcpassword is set in the configuration file (%s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Create new files with system default permissions, instead of umask 077 (only effective with disabled wallet functionality)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Delete all Sigma mints and only recover those parts of the blockchain through -reindex on startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4519,92 +7202,112 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
+        <location line="+6"/>
+        <source>Do not check for masternode payout when handling listtransactions, listsinceblock and gettransaction calls (improves performance)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
         <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
-        <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
-        <translation>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</translation>
-    </message>
-    <message>
-        <location line="+12"/>
-        <source>Fees (in %s/kB) smaller than this are considered zero fee for relaying, mining and transaction creation (default: %s)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+14"/>
-        <source>If paytxfee is not set, include enough fee so transactions begin confirmation on average within n blocks (default: %u)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
-        <source>Invalid amount for -maxtxfee=&lt;amount&gt;: &apos;%s&apos; (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+10"/>
-        <source>Maximum size of data in data carrier transactions we relay and mine (default: %u)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+24"/>
-        <source>Randomize credentials for every proxy connection. This enables Tor stream isolation (default: %u)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+18"/>
-        <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+15"/>
-        <source>The transaction amount is too small to send after the fee has been deducted</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+28"/>
-        <source>Use hierarchical deterministic key generation (HD) after BIP32. Only has effect during wallet creation/first start</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+31"/>
-        <source>Whitelisted peers cannot be DoS banned and their transactions are always relayed, even if they are already in the mempool, useful e.g. for a gateway</source>
+        <source>Error: The transaction was rejected after %u of %u mint transactions were already sent. Do not retry the whole mint.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
-        <source>You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>(default: %u)</source>
+        <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+4"/>
-        <source>Accept public REST requests (default: %u)</source>
+        <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
+        <translation>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID, %t is replaced by transaction type: &apos;spark&apos; or &apos;regular&apos;)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <source>Automatically create Tor hidden service (default: %d)</source>
+        <location line="+13"/>
+        <source>Fees (in %s/kB) smaller than this are considered zero fee for relaying, mining and transaction creation (default: %s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <source>Connect through SOCKS5 proxy</source>
+        <location line="+18"/>
+        <source>If paytxfee is not set, include enough fee so transactions begin confirmation on average within n blocks (default: %u)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
-        <source>Error reading from database, shutting down.</source>
+        <location line="+13"/>
+        <source>Invalid amount for -maxtxfee=&lt;amount&gt;: &apos;%s&apos; (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Maximum size of data in data carrier transactions we relay and mine (default: %u)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+39"/>
+        <source>Randomize credentials for every proxy connection. This enables Tor stream isolation (default: %u)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <source>The transaction amount is too small to send after the fee has been deducted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
+        <source>Use hierarchical deterministic key generation (HD) after BIP32. Only has effect during wallet creation/first start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+46"/>
+        <source>Whitelisted peers cannot be DoS banned and their transactions are always relayed, even if they are already in the mempool, useful e.g. for a gateway</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+8"/>
+        <source>You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>(default: %u)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>Accept public REST requests (default: %u)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Automatically create Tor hidden service (default: %d)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+16"/>
+        <source>Connect through SOCKS5 proxy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+29"/>
+        <source>Error reading from database, shutting down.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+15"/>
         <source>Imports blocks from external blk000??.dat file on startup</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4614,8 +7317,23 @@
         <translation>Information</translation>
     </message>
     <message>
-        <location line="+7"/>
+        <location line="+5"/>
+        <source>Invalid Spark spend amount.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Invalid amount for -mininput=&lt;amount&gt;: &apos;%s&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos; (must be at least %s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Invalid characters in -wallet filename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4625,12 +7343,52 @@
     </message>
     <message>
         <location line="+1"/>
+        <source>Invalid spark address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Invalid znodeblsprivkey. Please see documentation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>Keep at most &lt;n&gt; unconnectable transactions in memory (default: %u)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+3"/>
+        <source>List commands</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Load JSON file FILENAME into register NAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Loading Spark wallet...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Loading wallet... (%d transactions)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <source>Need to specify a port with -whitebind: &apos;%s&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No Spark spend recipients were provided.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No such coin in set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4639,13 +7397,38 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+1"/>
+        <source>Not enough fee estimated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Pass named instead of positional arguments (default: %s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Private recipient has invalid amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>RPC server options:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+3"/>
+        <source>Recipient %1% has invalid amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Register Commands:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4655,6 +7438,36 @@
     </message>
     <message>
         <location line="+4"/>
+        <source>See signrawtransaction docs for format of sighash flags, JSON objects.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Select JSON output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Selected Spark cover set is not yet bound to a canonical state hash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Send command to %s (with named arguments)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Send command to %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Send commands to node running on &lt;ip&gt; (default: %s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>Send trace/debug info to console instead of debug.log file</translation>
     </message>
@@ -4664,7 +7477,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
+        <location line="+2"/>
+        <source>Set TX lock time to N</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Set TX version to N</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Set register NAME to given JSON-STRING</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Show all debugging options (usage: --help -help-debug)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4679,17 +7507,132 @@
         <translation>Signing transaction failed</translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+1"/>
+        <source>Spark V2 spends are limited to %1% inputs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Spark address doesn&apos;t belong to the wallet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Spark coin selection changed during transaction construction; retry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Spark fee estimate did not match the wallet (planned %s, wallet %s).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Spark name transaction size is out of range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Spark shielded output limit exceeded.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Spark spend amount is out of range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Spark spend amount plus fee is out of range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Spark spend fee is out of range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Spark spend output amount is out of range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Spark spend size estimate is out of range</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Spark transaction fee is too high.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Spark transactions are disabled at the moment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Spend to transparent address limit exceeded.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Start %s Daemon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Synchronization failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Synchronization finished</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Synchronization pending...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Synchronizing blockchain...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Synchronizing governance objects...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>The transaction amount is too small to pay the fee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
+        <source>This command requires JSON registers:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>This help message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>This is experimental software.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+3"/>
+        <source>Timeout during HTTP requests (default: %d)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>Tor control port password (default: empty)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4704,14 +7647,19 @@
         <translation>Transaction amount too small</translation>
     </message>
     <message>
-        <location line="+4"/>
-        <source>Transaction too large for fee policy</source>
+        <location line="+2"/>
+        <source>Transaction commit failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Transaction not allowed in mempool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Transaction too large</source>
-        <translation>Transaction too large</translation>
+        <source>Transaction too large for fee policy</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
@@ -4719,17 +7667,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
+        <location line="+18"/>
         <source>Upgrade wallet to latest format on startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+6"/>
         <source>Username for JSON-RPC connections</source>
         <translation>Username for JSON-RPC connections</translation>
     </message>
     <message>
-        <location line="+7"/>
+        <location line="+10"/>
         <source>Warning</source>
         <translation>Warning</translation>
     </message>
@@ -4740,7 +7688,27 @@
     </message>
     <message>
         <location line="+1"/>
+        <source>Wasn&apos;t able to create wallet backup folder %s!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>Whether to operate in a blocks only mode (default: %u)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>You can not start a masternode in lite mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>You can not start a znode in lite mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Zapping all Sigma mints from wallet...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4754,37 +7722,32 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-73"/>
+        <location line="-128"/>
         <source>Password for JSON-RPC connections</source>
         <translation>Password for JSON-RPC connections</translation>
     </message>
     <message>
-        <location line="-242"/>
+        <location line="-375"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation>Execute command when the best block changes (%s in cmd is replaced by block hash)</translation>
     </message>
     <message>
-        <location line="+170"/>
+        <location line="+266"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation>Allow DNS lookups for -addnode, -seednode and -connect</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+91"/>
         <source>Loading addresses...</source>
         <translation>Loading addresses...</translation>
     </message>
     <message>
-        <location line="-291"/>
+        <location line="-438"/>
         <source>(1 = keep tx meta data e.g. account owner and payment request information, 2 = drop tx meta data)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>-maxtxfee is set very high! Fees this large could be paid on a single transaction.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+43"/>
+        <location line="+57"/>
         <source>Do not keep transactions in the mempool longer than &lt;n&gt; hours (default: %u)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4794,7 +7757,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+35"/>
         <source>Fees (in %s/kB) smaller than this are considered zero fee for transaction creation (default: %s)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4804,47 +7767,42 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+6"/>
         <source>How thorough the block verification of -checkblocks is (0-4, default: %u)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
+        <location line="+22"/>
         <source>Maintain a full transaction index, used by the getrawtransaction rpc call (default: %u)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+16"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: %u)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+15"/>
         <source>Output debugging information (default: %u, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
+        <location line="+15"/>
         <source>Query for peer addresses via DNS lookup, if low on addresses (default: 1 unless -connect/-noconnect)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
+        <location line="+29"/>
         <source>Sets the serialization of raw transaction or block hex returned in non-verbose mode, non-segwit(0) or segwit(1) (default: %d)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+20"/>
         <source>Support filtering of blocks and transaction with bloom filters (default: %u)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <source>This is the transaction fee you may pay when fee estimates are not available.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+2"/>
+        <location line="+18"/>
         <source>This product includes software developed by the OpenSSL Project for use in the OpenSSL Toolkit %s and cryptographic software written by Eric Young and UPnP software written by Thomas Bernard.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4854,7 +7812,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+6"/>
         <source>Tries to keep outbound traffic under the given target (in MiB per 24h), 0 = no limit (default: %d)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4869,12 +7827,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+14"/>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: %s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
+        <location line="+30"/>
         <source>Warning: Unknown block versions being mined! It&apos;s possible unknown rules are in effect</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4889,22 +7847,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <source>%s is set very high!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
+        <location line="+20"/>
         <source>(default: %s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+17"/>
         <source>Always query for peer addresses via DNS lookup (default: %u)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+38"/>
+        <location line="+64"/>
         <source>How many blocks to check at startup (default: %u, 0 = all)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4919,12 +7872,12 @@
         <translation>Invalid -proxy address: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+7"/>
+        <location line="+11"/>
         <source>Keypool ran out, please call keypoolrefill first</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+2"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: %u or testnet: %u)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4934,7 +7887,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+9"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: %u)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4954,12 +7907,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
+        <location line="+10"/>
         <source>Prepend debug output with timestamp (default: %u)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+13"/>
         <source>Relay and mine data carrier transactions (default: %u)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4969,12 +7922,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
+        <location line="+13"/>
         <source>Send transactions with full-RBF opt-in enabled (default: %u)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+4"/>
         <source>Set key pool size to &lt;n&gt; (default: %u)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4984,12 +7937,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+3"/>
         <source>Set the number of threads to service RPC calls (default: %d)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+17"/>
         <source>Specify configuration file (default: %s)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5004,28 +7957,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Spend unconfirmed change when sending transactions (default: %u)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+2"/>
         <source>Starting network threads...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+8"/>
         <source>The wallet will avoid paying less than the minimum relay fee.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+4"/>
         <source>This is the minimum transaction fee you pay on every transaction.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>This is the transaction fee you will pay if you send a transaction.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5034,12 +7982,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+5"/>
         <source>Transaction amounts must not be negative</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+2"/>
         <source>Transaction has too long of a mempool chain</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5049,32 +7997,32 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+16"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Unknown network specified in -onlynet: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-80"/>
+        <location line="-136"/>
         <source>Insufficient funds</source>
         <translation>Insufficient funds</translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="+21"/>
         <source>Loading block index...</source>
         <translation>Loading block index...</translation>
     </message>
     <message>
-        <location line="-61"/>
+        <location line="-100"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation>Add a node to connect to and attempt to keep the connection open</translation>
     </message>
     <message>
-        <location line="+62"/>
+        <location line="+102"/>
         <source>Loading wallet...</source>
         <translation>Loading wallet...</translation>
     </message>
     <message>
-        <location line="-55"/>
+        <location line="-84"/>
         <source>Cannot downgrade wallet</source>
         <translation>Cannot downgrade wallet</translation>
     </message>
@@ -5084,19 +8032,24 @@
         <translation>Cannot write default address</translation>
     </message>
     <message>
-        <location line="+78"/>
+        <location line="+113"/>
         <source>Rescanning...</source>
         <translation>Rescanning...</translation>
     </message>
     <message>
-        <location line="-67"/>
+        <location line="-89"/>
         <source>Done loading</source>
         <translation>Done loading</translation>
     </message>
     <message>
-        <location line="+15"/>
+        <location line="+17"/>
         <source>Error</source>
         <translation>Error</translation>
+    </message>
+    <message>
+        <location filename="../transactionrecord.cpp" line="+137"/>
+        <source>Zerocoin-&gt;Sigma remint</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/qt/locale/bitcoin_et.ts
+++ b/src/qt/locale/bitcoin_et.ts
@@ -133,7 +133,7 @@
     </message>
     <message>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
-        <translation>Sisesta uus salafraas rahakotti.&lt;br/&gt;Kasuta salafraasi millles on&lt;b&gt;kümme või rohkem juhuslikku sümbolit&lt;b&gt;,või&lt;b&gt;kaheksa või rohkem sõna&lt;b/&gt;.</translation>
+        <translation>Sisesta uus salafraas rahakotti.&lt;br/&gt;Kasuta salafraasi milles on &lt;b&gt;kümme või rohkem juhuslikku sümbolit&lt;/b&gt;, või &lt;b&gt;kaheksa või rohkem sõna&lt;/b&gt;.</translation>
     </message>
     <message>
         <source>Encrypt wallet</source>

--- a/src/qt/locale/bitcoin_fa.ts
+++ b/src/qt/locale/bitcoin_fa.ts
@@ -1257,7 +1257,7 @@
     </message>
     <message>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
-        <translation>برای درخواست پرداخت از این فرم استفاده کنید.تمام قسمت ها &lt;b&gt;اختیاری&lt;b&gt; هستند.</translation>
+        <translation>برای درخواست پرداخت از این فرم استفاده کنید.تمام قسمت ها &lt;b&gt;اختیاری&lt;/b&gt; هستند.</translation>
     </message>
     <message>
         <source>Clear all fields of the form.</source>

--- a/src/qt/locale/bitcoin_id_ID.ts
+++ b/src/qt/locale/bitcoin_id_ID.ts
@@ -129,7 +129,7 @@
     </message>
     <message>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
-        <translation>Masukan kata sandi baru ke dompet.&lt;br/&gt;Mohon gunakan kata sandi &lt;b&gt;sepuluh karakter acak atau lebih&lt;/b&gt;, atau &lt;b&gt; delapan atau lebih beberapa kata &lt;/​​b&gt;.</translation>
+        <translation>Masukan kata sandi baru ke dompet.&lt;br/&gt;Mohon gunakan kata sandi &lt;b&gt;sepuluh karakter acak atau lebih&lt;/b&gt;, atau &lt;b&gt; delapan atau lebih beberapa kata &lt;/b&gt;.</translation>
     </message>
     <message>
         <source>Encrypt wallet</source>

--- a/src/qt/locale/bitcoin_it.ts
+++ b/src/qt/locale/bitcoin_it.ts
@@ -836,7 +836,7 @@
     </message>
     <message numerus="yes">
         <source>%n GB of free space available</source>
-        <translation><numerusform>GB di spazio libero disponibile</numerusform><numerusform>%n GB di spazio disponibile</numerusform></translation>
+        <translation><numerusform>%n GB di spazio libero disponibile</numerusform><numerusform>%n GB di spazio disponibile</numerusform></translation>
     </message>
     <message numerus="yes">
         <source>(of %n GB needed)</source>

--- a/src/qt/locale/bitcoin_ko_KR.ts
+++ b/src/qt/locale/bitcoin_ko_KR.ts
@@ -133,7 +133,7 @@
     </message>
     <message>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
-        <translation>지갑에 새로운 비밀문구를 입력하세요.&lt;br/&gt;비밀문구를 &lt;b&gt;열 개 이상의 무작위 글자&lt;/b&gt; 혹은 &lt;b&gt;여덟개 이상의 단어로&lt;b&gt; 정하세요.</translation>
+        <translation>지갑에 새로운 비밀문구를 입력하세요.&lt;br/&gt;비밀문구를 &lt;b&gt;열 개 이상의 무작위 글자&lt;/b&gt; 혹은 &lt;b&gt;여덟개 이상의 단어로&lt;/b&gt; 정하세요.</translation>
     </message>
     <message>
         <source>Encrypt wallet</source>
@@ -1425,7 +1425,7 @@
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
-        <translation><numerusform>&amp;n 일</numerusform></translation>
+        <translation><numerusform>%n 일</numerusform></translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>

--- a/src/qt/locale/bitcoin_vi_VN.ts
+++ b/src/qt/locale/bitcoin_vi_VN.ts
@@ -729,7 +729,7 @@
     </message>
     <message>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
-        <translation>Sử dụng form này để yêu cầu thanh toán. Tất cả các trường &lt;b&gt;không bắt buộc&lt;b&gt;</translation>
+        <translation>Sử dụng form này để yêu cầu thanh toán. Tất cả các trường &lt;b&gt;không bắt buộc&lt;/b&gt;</translation>
     </message>
     <message>
         <source>Clear all fields of the form.</source>

--- a/src/qt/locale/bitcoin_zh_CN.ts
+++ b/src/qt/locale/bitcoin_zh_CN.ts
@@ -2248,7 +2248,7 @@ After the notification transaction is received by the RAP address issuer, funds 
     </message>
     <message>
         <source>Ping</source>
-        <translation> </translation>
+        <translation>Ping</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
## PR intention

Repair and refresh the Qt translation source catalog for the UI redesign. The extractor still emitted `bitcoin-core` while the application and catalogs use `firo-core`, and its CMake invocation omitted Firo package metadata. The checked-in English source catalog also missed current redesign and Spark strings.

This is a prerequisite for native-language translation work. It does not claim that the 85 non-English catalogs are complete. Related to #1914.

## Code changes brief

- Generate core strings under `firo-core` and pass Firo package and copyright metadata.
- Use an xgettext response file to avoid Windows command-line limits, and preserve the generated catalog if extraction fails.
- Regenerate `bitcoinstrings.cpp` and `bitcoin_en.ts` from the current `ui-redesign` sources, yielding 1,525 source messages.
- Correct 15 existing catalog defects, including malformed rich text, broken `%n` placeholders, a blank Chinese `Ping` label, and an Estonian typo.

Validation:

- Re-ran source extraction through the response file and obtained byte-identical generated C++.
- Re-ran Qt 6.7.3 `lupdate`: 1,525 existing messages, 0 new, byte-identical English catalog.
- Parsed all 86 TS files and checked locale IDs, duplicate active keys, blank finished entries, placeholders, rich-text structure, and resource mappings.
- Qt 6.7.3 `lrelease`: 86/86 catalogs compiled with zero failures. Four untouched catalogs emit pre-existing plural-form notices.
- `git diff --check origin/ui-redesign...HEAD` passed.
- Full application build was not run.

Known limitation:

Localized coverage remains 31,088 of 129,625 source-language pairs (23.98%), leaving 98,537 untranslated pairs. Accurate completion requires a Firo-owned localization workflow and native review. This draft is stacked on `ui-redesign`, so the normal PR workflow that targets `master` will not run until this is retargeted after #1914 merges.