### PR TITLE
LLMQ: Handle empty contribution batches

### DIFF
--- a/src/bls/bls_worker.cpp
+++ b/src/bls/bls_worker.cpp
@@ -726,6 +726,10 @@ CBLSPublicKey CBLSWorker::BuildPubKeyShare(const BLSVerificationVectorPtr& vvec,
 void CBLSWorker::AsyncVerifyContributionShares(const CBLSId& forId, const std::vector<BLSVerificationVectorPtr>& vvecs, const BLSSecretKeyVector& skShares,
                                                bool parallel, bool aggregated, std::function<void(const std::vector<bool>&)> doneCallback)
 {
+    if (vvecs.empty()) {
+        doneCallback(std::vector<bool>{});
+        return;
+    }
     if (!forId.IsValid() || !VerifyVerificationVectors(vvecs)) {
         std::vector<bool> result;
         result.assign(vvecs.size(), false);

--- a/src/llmq/quorums_dkgsession.cpp
+++ b/src/llmq/quorums_dkgsession.cpp
@@ -386,6 +386,11 @@ void CDKGSession::VerifyPendingContributions()
         skContributions.emplace_back(receivedSkContributions[idx]);
     }
 
+    // All pending members may have been marked bad after they were enqueued.
+    if (memberIndexes.empty()) {
+        return;
+    }
+
     auto result = blsWorker.VerifyContributionShares(myId, vvecs, skContributions);
     if (result.size() != memberIndexes.size()) {
         logger.Batch("VerifyContributionShares returned result of size %d but size %d was expected, something is wrong", result.size(), memberIndexes.size());

--- a/src/test/bls_tests.cpp
+++ b/src/test/bls_tests.cpp
@@ -4,6 +4,7 @@
 
 #include "bls/bls.h"
 #include "bls/bls_batchverifier.h"
+#include "bls/bls_worker.h"
 #include "test/test_bitcoin.h"
 
 #include <boost/test/unit_test.hpp>
@@ -152,6 +153,30 @@ BOOST_AUTO_TEST_CASE(batch_verifier_tests)
     // last message invalid from one source
     AddMessage(msgs, 1, 7, 1, false);
     Verify(msgs);
+}
+
+BOOST_AUTO_TEST_CASE(bls_verify_contribution_shares_empty_vvecs_tests)
+{
+    CBLSWorker worker;
+    worker.Start();
+
+    const CBLSId id{uint256S("1")};
+    BOOST_REQUIRE(id.IsValid());
+
+    const std::vector<BLSVerificationVectorPtr> vvecs;
+    const BLSSecretKeyVector skShares;
+
+    for (const bool aggregated : {true, false}) {
+        bool completed = false;
+        worker.AsyncVerifyContributionShares(id, vvecs, skShares, true, aggregated,
+            [&](const std::vector<bool>& result) {
+                BOOST_CHECK(result.empty());
+                completed = true;
+            });
+        BOOST_CHECK(completed);
+    }
+
+    worker.Stop();
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Handle contribution batches that become empty after filtering, and complete empty BLS verification requests immediately. This prevents DKG phase processing from waiting indefinitely and adds focused regression coverage.

Upstream: [Dash PR #7486](https://github.com/dashpay/dash/pull/7486).