### PR TITLE
Evo: Preserve DMN history across reorgs

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -606,9 +606,6 @@ bool CDeterministicMNManager::UndoBlock(
             prevList = GetListForBlock(pindex->pprev);
         }
 
-        evoDb.Erase(std::make_pair(DB_LIST_DIFF, blockHash));
-        evoDb.Erase(std::make_pair(DB_LIST_SNAPSHOT, blockHash));
-
         mnListsCache.erase(blockHash);
     }
 

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -601,6 +601,28 @@ BOOST_FIXTURE_TEST_CASE(dip3_invalidate_does_not_reuse_cached_descendant_mn_list
     BOOST_CHECK_EQUAL(deterministicMNManager->GetListForBlock(chainActive.Tip()).GetAllMNsCount(), dmnHashes.size());
 }
 
+BOOST_FIXTURE_TEST_CASE(dip3_invalidate_preserves_orphan_mn_list, TestChainDIP3Setup)
+{
+    auto utxos = BuildSimpleUtxoMap(coinbaseTxns);
+    auto payoutScript = GetCoinbaseKeyScript(coinbaseKey);
+    int port = 12500;
+
+    auto dmnHashes = RegisterDeterministicMNs(*this, utxos, 3, port, payoutScript);
+    auto orphanTip = chainActive.Tip();
+    const auto orphanHash = orphanTip->GetBlockHash();
+    const auto orphanHeight = orphanTip->nHeight;
+
+    InvalidateBlockAndUpdateMNManager(orphanHash);
+
+    const auto orphanList = deterministicMNManager->GetListForBlock(orphanTip);
+    BOOST_CHECK_EQUAL(orphanList.GetBlockHash().ToString(), orphanHash.ToString());
+    BOOST_CHECK_EQUAL(orphanList.GetHeight(), orphanHeight);
+    BOOST_REQUIRE_EQUAL(orphanList.GetAllMNsCount(), dmnHashes.size());
+    for (const auto& proTxHash : dmnHashes) {
+        BOOST_CHECK(orphanList.HasMN(proTxHash));
+    }
+}
+
 BOOST_FIXTURE_TEST_CASE(dip3_invalidate_pure_disconnect_notification_updates_tip_list, TestChainDIP3Setup)
 {
     auto utxos = BuildSimpleUtxoMap(coinbaseTxns);


### PR DESCRIPTION
Preserve persisted deterministic-masternode diffs and snapshots when disconnecting blocks, while evicting only the in-memory cache entry. Add a regression test proving orphan history remains reconstructible across reorgs.

Upstream: [Dash PR #3435](https://github.com/dashpay/dash/pull/3435).