### PR TITLE
LLMQ: Lock InstantSend input request IDs

### DIFF
--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -467,7 +467,10 @@ bool CInstantSendManager::ProcessTx(const CTransaction& tx, bool allowReSigning,
     for (size_t i = 0; i < tx.vin.size(); i++) {
         auto& in = tx.vin[i];
         auto& id = ids[i];
-        inputRequestIds.emplace(id);
+        {
+            LOCK(cs);
+            inputRequestIds.emplace(id);
+        }
         LogPrint("instantsend", "CInstantSendManager::%s -- txid=%s: trying to vote on input %s with id %s. allowReSigning=%d\n", __func__,
                  tx.GetHash().ToString(), in.prevout.ToStringShort(), id.ToString(), allowReSigning);
         if (quorumSigningManager->AsyncSignIfMember(llmqType, id, tx.GetHash(), allowReSigning)) {


### PR DESCRIPTION
Protect InstantSend input request-ID insertion with the manager mutex already used by readers and cleanup paths. This removes a cross-thread data race without changing protocol behavior.

Upstream: [Dash PR #3829](https://github.com/dashpay/dash/pull/3829).