### PR TITLE
Net: bound automatic peer discouragement

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -483,8 +483,8 @@ std::string HelpMessage(HelpMessageMode mode)
 
     strUsage += HelpMessageGroup(_("Connection options:"));
     strUsage += HelpMessageOpt("-addnode=<ip>", _("Add a node to connect to and attempt to keep the connection open"));
-    strUsage += HelpMessageOpt("-banscore=<n>", strprintf(_("Threshold for disconnecting misbehaving peers (default: %u)"), DEFAULT_BANSCORE_THRESHOLD));
-    strUsage += HelpMessageOpt("-bantime=<n>", strprintf(_("Number of seconds to keep misbehaving peers from reconnecting (default: %u)"), DEFAULT_MISBEHAVING_BANTIME));
+    strUsage += HelpMessageOpt("-banscore=<n>", strprintf(_("Threshold for disconnecting and discouraging misbehaving peers (default: %u)"), DEFAULT_BANSCORE_THRESHOLD));
+    strUsage += HelpMessageOpt("-bantime=<n>", strprintf(_("Default duration (in seconds) of manually configured bans (default: %u)"), DEFAULT_MISBEHAVING_BANTIME));
     strUsage += HelpMessageOpt("-bind=<addr>", _("Bind to given address and always listen on it. Use [host]:port notation for IPv6"));
     strUsage += HelpMessageOpt("-connect=<ip>", _("Connect only to the specified node(s); -noconnect or -connect=0 alone to disable automatic connections"));
     strUsage += HelpMessageOpt("-discover", _("Discover own IP addresses (default: 1 when listening and no -externalip or -proxy)"));

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -501,7 +501,13 @@ void CConnman::ClearBanned()
         clientInterface->BannedListChanged();
 }
 
-bool CConnman::IsBanned(CNetAddr ip)
+bool CConnman::IsDiscouraged(const CNetAddr& ip)
+{
+    LOCK(cs_setBanned);
+    return setDiscouraged.contains(ip.GetAddrBytes());
+}
+
+bool CConnman::IsBanned(const CNetAddr& ip)
 {
     bool fResult = false;
     {
@@ -518,7 +524,7 @@ bool CConnman::IsBanned(CNetAddr ip)
     return fResult;
 }
 
-bool CConnman::IsBanned(CSubNet subnet)
+bool CConnman::IsBanned(const CSubNet& subnet)
 {
     bool fResult = false;
     {
@@ -537,6 +543,12 @@ bool CConnman::IsBanned(CSubNet subnet)
 void CConnman::Ban(const CNetAddr& addr, const BanReason &banReason, int64_t bantimeoffset, bool sinceUnixEpoch) {
     CSubNet subNet(addr);
     Ban(subNet, banReason, bantimeoffset, sinceUnixEpoch);
+}
+
+void CConnman::Discourage(const CNetAddr& addr)
+{
+    LOCK(cs_setBanned);
+    setDiscouraged.insert(addr.GetAddrBytes());
 }
 
 void CConnman::Ban(const CSubNet& subNet, const BanReason &banReason, int64_t bantimeoffset, bool sinceUnixEpoch) {
@@ -973,6 +985,7 @@ struct NodeEvictionCandidate
     bool fBloomFilter;
     CAddress addr;
     uint64_t nKeyedNetGroup;
+    bool fPreferEvict;
 };
 
 static bool ReverseCompareNodeMinPingTime(const NodeEvictionCandidate &a, const NodeEvictionCandidate &b)
@@ -1048,9 +1061,10 @@ bool CConnman::AttemptToEvictConnection()
             }
 
             NodeEvictionCandidate candidate = {node->id, node->nTimeConnected, node->nMinPingUsecTime,
-                                               node->nLastBlockTime, node->nLastTXTime,
-                                               (node->nServices & nRelevantServices) == nRelevantServices,
-                                               node->fRelayTxes, node->pfilter != NULL, node->addr, node->nKeyedNetGroup};
+                node->nLastBlockTime, node->nLastTXTime,
+                (node->nServices & nRelevantServices) == nRelevantServices,
+                node->fRelayTxes, node->pfilter != NULL, node->addr, node->nKeyedNetGroup,
+                node->fPreferEvict};
             vEvictionCandidates.push_back(candidate);
         }
     }
@@ -1093,6 +1107,16 @@ bool CConnman::AttemptToEvictConnection()
     vEvictionCandidates.erase(vEvictionCandidates.end() - static_cast<int>(vEvictionCandidates.size() / 2), vEvictionCandidates.end());
 
     if (vEvictionCandidates.empty()) return false;
+
+    // If any remaining peers are preferred for eviction, consider only them.
+    if (std::any_of(vEvictionCandidates.begin(), vEvictionCandidates.end(), [](const NodeEvictionCandidate& node) {
+            return node.fPreferEvict;
+        })) {
+        vEvictionCandidates.erase(std::remove_if(vEvictionCandidates.begin(), vEvictionCandidates.end(), [](const NodeEvictionCandidate& node) {
+            return !node.fPreferEvict;
+        }),
+            vEvictionCandidates.end());
+    }
 
     // Identify the network group with the most connections and youngest member.
     // (vEvictionCandidates is already sorted by reverse connect time)
@@ -1255,8 +1279,15 @@ void CConnman::AcceptConnection(const ListenSocket& hListenSocket) {
         return;
     }
 
-    if (nInbound - nVerifiedInboundMasternodes >= nMaxInbound)
-    {
+    bool discouraged = IsDiscouraged(addr);
+    int nCountedInbound = nInbound - nVerifiedInboundMasternodes;
+    if (discouraged && !whitelisted && nCountedInbound + 1 >= nMaxInbound) {
+        LogPrintf("connection from %s dropped (discouraged)\n", addr.ToString());
+        CloseSocket(hSocket);
+        return;
+    }
+
+    if (nCountedInbound >= nMaxInbound) {
         if (!AttemptToEvictConnection()) {
             // No connection to evict, disconnect the new connection
             LogPrint("net", "failed to find an eviction candidate - connection dropped (full)\n");
@@ -1271,6 +1302,7 @@ void CConnman::AcceptConnection(const ListenSocket& hListenSocket) {
     CNode* pnode = new CNode(id, nLocalServices, GetBestHeight(), hSocket, addr, CalculateKeyedNetGroup(addr), nonce, "", true, hListenSocket.is_onion_listener);
     pnode->AddRef();
     pnode->fWhitelisted = whitelisted;
+    pnode->fPreferEvict = discouraged;
     GetNodeSignals().InitializeNode(pnode, *this);
 
     LogPrint("net", "connection from %s accepted%s\n", addr.ToString(),
@@ -2333,7 +2365,7 @@ bool CConnman::OpenNetworkConnection(const CAddress& addrConnect, bool fCountFai
     bool fAllowLocal = fMasternodeMode;
     if (!pszDest) {
         // banned or exact match?
-        if (IsBanned(addrConnect) || FindNode(addrConnect.ToStringIPPort()))
+        if (IsBanned(addrConnect) || IsDiscouraged(addrConnect) || FindNode(addrConnect.ToStringIPPort()))
             return false;
         // local and not a connection to itself?
         if (!fAllowLocal && IsLocal(addrConnect))
@@ -3272,6 +3304,37 @@ bool CConnman::DisconnectNode(const std::string& strNode)
     }
     return false;
 }
+
+bool CConnman::DisconnectNode(const CSubNet& subnet)
+{
+    bool disconnected = false;
+    LOCK(cs_vNodes);
+    for (CNode* pnode : vNodes) {
+        if (subnet.Match(pnode->addr)) {
+            pnode->fDisconnect = true;
+            disconnected = true;
+        }
+    }
+    return disconnected;
+}
+
+bool CConnman::DisconnectNode(const CNetAddr& addr)
+{
+    if (!addr.IsValid()) {
+        return false;
+    }
+
+    bool disconnected = false;
+    LOCK(cs_vNodes);
+    for (CNode* pnode : vNodes) {
+        if (static_cast<const CNetAddr&>(pnode->addr) == addr) {
+            pnode->fDisconnect = true;
+            disconnected = true;
+        }
+    }
+    return disconnected;
+}
+
 bool CConnman::DisconnectNode(NodeId id)
 {
     LOCK(cs_vNodes);
@@ -3499,6 +3562,7 @@ CNode::CNode(NodeId idIn, ServiceFlags nLocalServicesIn, int nMyStartingHeightIn
     nLastWarningTime = 0;
     strSubVer = "";
     fWhitelisted = false;
+    fPreferEvict = false;
     fOneShot = false;
     fAddnode = false;
     fClient = false; // set by version message

--- a/src/net.h
+++ b/src/net.h
@@ -336,7 +336,7 @@ public:
 
     // Denial-of-service detection/prevention
     // The idea is to detect peers that are behaving
-    // badly and disconnect/ban them, but do it in a
+    // badly and disconnect/discourage them, but do it in a
     // one-coding-mistake-won't-shatter-the-entire-network
     // way.
     // IMPORTANT:  There should be nothing I can give a
@@ -348,11 +348,16 @@ public:
     // dangerous, because it can cause a network split
     // between nodes running old code and nodes running
     // new code.
+    // Manual bans are persisted and reject connections. Automatic
+    // discouragement is bounded, avoids outbound connections, and makes
+    // inbound peers preferred for eviction.
     void Ban(const CNetAddr& netAddr, const BanReason& reason, int64_t bantimeoffset = 0, bool sinceUnixEpoch = false);
     void Ban(const CSubNet& subNet, const BanReason& reason, int64_t bantimeoffset = 0, bool sinceUnixEpoch = false);
+    void Discourage(const CNetAddr& netAddr);
     void ClearBanned(); // needed for unit testing
-    bool IsBanned(CNetAddr ip);
-    bool IsBanned(CSubNet subnet);
+    bool IsBanned(const CNetAddr& ip);
+    bool IsBanned(const CSubNet& subnet);
+    bool IsDiscouraged(const CNetAddr& ip);
     bool Unban(const CNetAddr &ip);
     bool Unban(const CSubNet &ip);
     void GetBanned(banmap_t &banmap);
@@ -376,6 +381,8 @@ public:
     size_t GetNodeCount(NumConnections num);
     void GetNodeStats(std::vector<CNodeStats>& vstats);
     bool DisconnectNode(const std::string& node);
+    bool DisconnectNode(const CSubNet& subnet);
+    bool DisconnectNode(const CNetAddr& addr);
     bool DisconnectNode(NodeId id);
 
     unsigned int GetSendBufferSize() const;
@@ -506,6 +513,7 @@ private:
     mutable CCriticalSection cs_vhListenSocket;
     std::atomic<bool> fNetworkActive;
     banmap_t setBanned;
+    CRollingBloomFilter setDiscouraged{50000, 0.000001};
     CCriticalSection cs_setBanned;
     bool setBannedIsDirty;
     bool fAddressesInitialized;
@@ -772,6 +780,7 @@ public:
     std::string strSubVer, cleanSubVer;
     CCriticalSection cs_SubVer; // used for both cleanSubVer and strSubVer
     bool fWhitelisted; // This peer can bypass DoS banning.
+    bool fPreferEvict; // This peer is preferred for eviction.
     bool fFeeler; // If true this node is being used as a short lived feeler.
     bool fOneShot;
     bool fAddnode;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -165,7 +165,7 @@ struct CNodeState {
     bool fCurrentlyConnected;
     //! Accumulated misbehaviour score for this peer.
     int nMisbehavior;
-    //! Whether this peer should be disconnected and banned (unless whitelisted).
+    //! Whether this peer should be disconnected and discouraged (unless whitelisted).
     bool fShouldBan;
     //! String name of this peer (debugging/logging purposes).
     const std::string name;
@@ -744,7 +744,7 @@ void Misbehaving(NodeId pnode, int howmuch)
     int banscore = GetArg("-banscore", DEFAULT_BANSCORE_THRESHOLD);
     if (state->nMisbehavior >= banscore && state->nMisbehavior - howmuch < banscore)
     {
-        LogPrintf("%s: %s peer=%d (%d -> %d) BAN THRESHOLD EXCEEDED\n", __func__, state->name, pnode, state->nMisbehavior-howmuch, state->nMisbehavior);
+        LogPrintf("%s: %s peer=%d (%d -> %d) DISCOURAGEMENT THRESHOLD EXCEEDED\n", __func__, state->name, pnode, state->nMisbehavior - howmuch, state->nMisbehavior);
         state->fShouldBan = true;
     } else
         LogPrintf("%s: %s peer=%d (%d -> %d)\n", __func__, state->name, pnode, state->nMisbehavior-howmuch, state->nMisbehavior);
@@ -3177,11 +3177,12 @@ static bool SendRejectsAndCheckIfBanned(CNode* pnode, CConnman& connman)
                 llmq::quorumSigSharesManager->MarkNodeBanned(pnode->GetId());
             }
             pnode->fDisconnect = true;
-            if (pnode->addr.IsLocal())
-                LogPrintf("Warning: not banning local peer %s!\n", pnode->addr.ToString());
-            else
-            {
-                connman.Ban(pnode->addr, BanReasonNodeMisbehaving);
+            if (pnode->addr.IsLocal()) {
+                LogPrintf("Warning: not discouraging local peer %s!\n", pnode->addr.ToString());
+            } else {
+                LogPrintf("Disconnecting and discouraging peer %s!\n", pnode->addr.ToString());
+                connman.Discourage(pnode->addr);
+                connman.DisconnectNode(pnode->addr);
             }
         }
         return true;

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -16,6 +16,7 @@
 
 #include "test/test_bitcoin.h"
 
+#include <algorithm>
 #include <stdint.h>
 
 #include <boost/assign/list_of.hpp> // for 'map_list_of()'
@@ -56,10 +57,14 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
     GetNodeSignals().InitializeNode(&dummyNode1, *connman);
     dummyNode1.nVersion = 1;
     dummyNode1.fSuccessfullyConnected = true;
-    Misbehaving(dummyNode1.GetId(), 100); // Should get banned
+    Misbehaving(dummyNode1.GetId(), 100); // Should get discouraged
     SendMessages(&dummyNode1, *connman, interruptDummy);
-    BOOST_CHECK(connman->IsBanned(addr1));
-    BOOST_CHECK(!connman->IsBanned(ip(0xa0b0c001|0x0000ff00))); // Different IP, not banned
+    banmap_t banmap;
+    connman->GetBanned(banmap);
+    BOOST_CHECK(banmap.empty());
+    BOOST_CHECK(connman->IsDiscouraged(addr1));
+    BOOST_CHECK(!connman->IsDiscouraged(ip(0xa0b0c001 | 0x0000ff00))); // Different IP, not discouraged
+    BOOST_CHECK(!connman->IsBanned(addr1));
 
     CAddress addr2(ip(0xa0b0c002), NODE_NONE);
     CNode dummyNode2(id++, NODE_NETWORK, 0, INVALID_SOCKET, addr2, 1, 1, "", true);
@@ -69,11 +74,133 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
     dummyNode2.fSuccessfullyConnected = true;
     Misbehaving(dummyNode2.GetId(), 50);
     SendMessages(&dummyNode2, *connman, interruptDummy);
-    BOOST_CHECK(!connman->IsBanned(addr2)); // 2 not banned yet...
-    BOOST_CHECK(connman->IsBanned(addr1));  // ... but 1 still should be
+    BOOST_CHECK(!connman->IsDiscouraged(addr2)); // 2 not discouraged yet...
+    BOOST_CHECK(connman->IsDiscouraged(addr1));  // ... but 1 still should be
     Misbehaving(dummyNode2.GetId(), 50);
     SendMessages(&dummyNode2, *connman, interruptDummy);
-    BOOST_CHECK(connman->IsBanned(addr2));
+    BOOST_CHECK(connman->IsDiscouraged(addr2));
+    connman->GetBanned(banmap);
+    BOOST_CHECK(banmap.empty());
+}
+
+BOOST_AUTO_TEST_CASE(DoS_discouragement_disconnects_address)
+{
+    std::atomic<bool> interruptDummy(false);
+
+    connman->ClearBanned();
+    CAddress addr(ip(0xa0b0c001), NODE_NONE);
+    CAddress sameAddr(CService(addr, Params().GetDefaultPort() + 1), NODE_NONE);
+    CAddress otherAddr(ip(0xa0b0c002), NODE_NONE);
+    CNode offender(id++, NODE_NETWORK, 0, INVALID_SOCKET, addr, 2, 2, "", true);
+    CNode sameAddressPeer(id++, NODE_NETWORK, 0, INVALID_SOCKET, sameAddr, 3, 3, "", true);
+    CNode otherPeer(id++, NODE_NETWORK, 0, INVALID_SOCKET, otherAddr, 4, 4, "", true);
+
+    offender.SetSendVersion(PROTOCOL_VERSION);
+    GetNodeSignals().InitializeNode(&offender, *connman);
+    offender.nVersion = 1;
+    offender.fSuccessfullyConnected = true;
+
+    {
+        LOCK(connman->cs_vNodes);
+        BOOST_REQUIRE(connman->vNodes.empty());
+        connman->vNodes.push_back(&offender);
+        connman->vNodes.push_back(&sameAddressPeer);
+        connman->vNodes.push_back(&otherPeer);
+    }
+
+    Misbehaving(offender.GetId(), 100);
+    SendMessages(&offender, *connman, interruptDummy);
+
+    BOOST_CHECK(offender.fDisconnect);
+    BOOST_CHECK(sameAddressPeer.fDisconnect);
+    BOOST_CHECK(!otherPeer.fDisconnect);
+    BOOST_CHECK(connman->IsDiscouraged(addr));
+    BOOST_CHECK(!connman->IsDiscouraged(otherAddr));
+    BOOST_CHECK(!connman->IsBanned(addr));
+    banmap_t banmap;
+    connman->GetBanned(banmap);
+    BOOST_CHECK(banmap.empty());
+
+    {
+        LOCK(connman->cs_vNodes);
+        for (CNode* node : {&offender, &sameAddressPeer, &otherPeer}) {
+            connman->vNodes.erase(std::remove(connman->vNodes.begin(), connman->vNodes.end(), node), connman->vNodes.end());
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(DoS_discouragement_disconnects_non_ip_address)
+{
+    std::atomic<bool> interruptDummy(false);
+
+    connman->ClearBanned();
+    const std::string onionAddresses[] = {
+        "6hzph5hv6337r6p2.onion",
+        "pg6mmjiyjmcrsslvykfwnntlaru7p5svn6y2ymmju6nubxndf4pscryd.onion",
+    };
+
+    for (const std::string& onionString : onionAddresses) {
+        CNetAddr onion;
+        BOOST_REQUIRE(onion.SetSpecial(onionString));
+        CAddress addr(CService(onion, Params().GetDefaultPort()), NODE_NONE);
+        CAddress sameAddr(CService(onion, Params().GetDefaultPort() + 1), NODE_NONE);
+        CAddress otherAddr(ip(0xa0b0c002), NODE_NONE);
+        CNode offender(id++, NODE_NETWORK, 0, INVALID_SOCKET, addr, 5, 5, "", false);
+        CNode sameAddressPeer(id++, NODE_NETWORK, 0, INVALID_SOCKET, sameAddr, 6, 6, "", false);
+        CNode otherPeer(id++, NODE_NETWORK, 0, INVALID_SOCKET, otherAddr, 7, 7, "", false);
+
+        offender.SetSendVersion(PROTOCOL_VERSION);
+        GetNodeSignals().InitializeNode(&offender, *connman);
+        offender.nVersion = 1;
+        offender.fSuccessfullyConnected = true;
+
+        {
+            LOCK(connman->cs_vNodes);
+            BOOST_REQUIRE(connman->vNodes.empty());
+            connman->vNodes.push_back(&offender);
+            connman->vNodes.push_back(&sameAddressPeer);
+            connman->vNodes.push_back(&otherPeer);
+        }
+
+        Misbehaving(offender.GetId(), 100);
+        SendMessages(&offender, *connman, interruptDummy);
+
+        BOOST_CHECK(offender.fDisconnect);
+        BOOST_CHECK(sameAddressPeer.fDisconnect);
+        BOOST_CHECK(!otherPeer.fDisconnect);
+        BOOST_CHECK(connman->IsDiscouraged(onion));
+        BOOST_CHECK(!connman->IsBanned(onion));
+
+        {
+            LOCK(connman->cs_vNodes);
+            for (CNode* node : {&offender, &sameAddressPeer, &otherPeer}) {
+                connman->vNodes.erase(std::remove(connman->vNodes.begin(), connman->vNodes.end(), node), connman->vNodes.end());
+            }
+        }
+    }
+
+    CAddress invalidAddr;
+    BOOST_REQUIRE(!invalidAddr.IsValid());
+    CNode invalidPeer(id++, NODE_NETWORK, 0, INVALID_SOCKET, invalidAddr, 8, 8, "unresolved.example", false);
+    invalidPeer.SetSendVersion(PROTOCOL_VERSION);
+    GetNodeSignals().InitializeNode(&invalidPeer, *connman);
+    invalidPeer.nVersion = 1;
+    invalidPeer.fSuccessfullyConnected = true;
+
+    {
+        LOCK(connman->cs_vNodes);
+        BOOST_REQUIRE(connman->vNodes.empty());
+        connman->vNodes.push_back(&invalidPeer);
+    }
+
+    Misbehaving(invalidPeer.GetId(), 100);
+    SendMessages(&invalidPeer, *connman, interruptDummy);
+    BOOST_CHECK(invalidPeer.fDisconnect);
+
+    {
+        LOCK(connman->cs_vNodes);
+        connman->vNodes.erase(std::remove(connman->vNodes.begin(), connman->vNodes.end(), &invalidPeer), connman->vNodes.end());
+    }
 }
 
 BOOST_AUTO_TEST_CASE(DoS_banscore)
@@ -90,17 +217,18 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
     dummyNode1.fSuccessfullyConnected = true;
     Misbehaving(dummyNode1.GetId(), 100);
     SendMessages(&dummyNode1, *connman, interruptDummy);
-    BOOST_CHECK(!connman->IsBanned(addr1));
+    BOOST_CHECK(!connman->IsDiscouraged(addr1));
     Misbehaving(dummyNode1.GetId(), 10);
     SendMessages(&dummyNode1, *connman, interruptDummy);
-    BOOST_CHECK(!connman->IsBanned(addr1));
+    BOOST_CHECK(!connman->IsDiscouraged(addr1));
     Misbehaving(dummyNode1.GetId(), 1);
     SendMessages(&dummyNode1, *connman, interruptDummy);
-    BOOST_CHECK(connman->IsBanned(addr1));
+    BOOST_CHECK(connman->IsDiscouraged(addr1));
+    BOOST_CHECK(!connman->IsBanned(addr1));
     ForceSetArg("-banscore", std::to_string(DEFAULT_BANSCORE_THRESHOLD));
 }
 
-BOOST_AUTO_TEST_CASE(DoS_bantime)
+BOOST_AUTO_TEST_CASE(DoS_discouragement_does_not_expire_by_time)
 {
     std::atomic<bool> interruptDummy(false);
 
@@ -117,13 +245,35 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
 
     Misbehaving(dummyNode.GetId(), 100);
     SendMessages(&dummyNode, *connman, interruptDummy);
-    BOOST_CHECK(connman->IsBanned(addr));
+    BOOST_CHECK(connman->IsDiscouraged(addr));
+    BOOST_CHECK(!connman->IsBanned(addr));
 
     SetMockTime(nStartTime+60*60);
+    BOOST_CHECK(connman->IsDiscouraged(addr));
+
+    SetMockTime(nStartTime + 60 * 60 * 24 + 1);
+    BOOST_CHECK(connman->IsDiscouraged(addr));
+    SetMockTime(0);
+}
+
+BOOST_AUTO_TEST_CASE(DoS_manual_bantime)
+{
+    connman->ClearBanned();
+    int64_t nStartTime = GetTime();
+    SetMockTime(nStartTime);
+
+    CAddress addr(ip(0xa0b0c001), NODE_NONE);
+    connman->Ban(addr, BanReasonManuallyAdded);
     BOOST_CHECK(connman->IsBanned(addr));
+
+    banmap_t banmap;
+    connman->GetBanned(banmap);
+    BOOST_REQUIRE_EQUAL(banmap.size(), 1U);
+    BOOST_CHECK_EQUAL(banmap.begin()->second.banReason, BanReasonManuallyAdded);
 
     SetMockTime(nStartTime+60*60*24+1);
     BOOST_CHECK(!connman->IsBanned(addr));
+    SetMockTime(0);
 }
 
 CTransactionRef RandomOrphan()


### PR DESCRIPTION
Replace unbounded persisted automatic bans with bounded rolling discouragement while preserving manual bans. Add coverage for expiry, disconnect behavior, and inbound eviction preference.

Upstream: [Bitcoin Core PR #19219](https://github.com/bitcoin/bitcoin/pull/19219).