### PR TITLE
Evo: ignore stale block tip notifications

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -628,6 +628,11 @@ bool CDeterministicMNManager::UndoBlock(
 
 void CDeterministicMNManager::UpdatedBlockTip(const CBlockIndex* pindex)
 {
+    LOCK(cs_main);
+    if (pindex != chainActive.Tip()) {
+        return;
+    }
+
     LOCK(cs);
 
     tipIndex = pindex;

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -613,9 +613,13 @@ BOOST_FIXTURE_TEST_CASE(dip3_invalidate_pure_disconnect_notification_updates_tip
     auto preRemovalTip = chainActive.Tip();
     auto spendTx = CreateCollateralSpendTx(COutPoint(dmnHashes[0], 0), payoutScript, coinbaseKey);
     ProcessBlockAndUpdateMNManager(*this, {spendTx}, coinbaseKey);
+    auto removalTip = chainActive.Tip();
 
     std::vector<uint256> afterSpend{dmnHashes.begin() + 1, dmnHashes.end()};
     AssertTipMNSet(afterSpend);
+
+    InvalidateBlockUsingValidationSignals(removalTip->GetBlockHash());
+    BOOST_REQUIRE(chainActive.Tip() == preRemovalTip);
 
     ExposedDSNotificationInterface notificationInterface(*connman);
     notificationInterface.UpdatedBlockTipForTest(preRemovalTip, preRemovalTip, false);
@@ -648,7 +652,12 @@ BOOST_FIXTURE_TEST_CASE(dip3_repeated_invalidate_signal_restores_each_intermedia
     }
 
     for (size_t i = 0; i < expectedAfterDisconnect.size(); ++i) {
-        InvalidateBlockUsingValidationSignals(chainActive.Tip()->GetBlockHash());
+        const CBlockIndex* staleTip = chainActive.Tip();
+        InvalidateBlockUsingValidationSignals(staleTip->GetBlockHash());
+        AssertTipMNSet(expectedAfterDisconnect[i]);
+
+        // A delayed notification must not restore an obsolete chain tip.
+        deterministicMNManager->UpdatedBlockTip(staleTip);
         AssertTipMNSet(expectedAfterDisconnect[i]);
     }
 }


### PR DESCRIPTION
Ignore delayed deterministic-masternode tip notifications when their block is no longer the active chain tip. Add regressions covering stale callbacks and valid pure-disconnect updates after repeated invalidations.