### PR TITLE
Tests: stabilize Spark mint-spend state

### DIFF
--- a/src/spark/sparkwallet.cpp
+++ b/src/spark/sparkwallet.cpp
@@ -120,6 +120,17 @@ void CSparkWallet::FinishTasks() {
     }
 }
 
+void CSparkWallet::WaitForPendingTasks() {
+    if (!threadPool)
+        return;
+
+    auto* pool = (ParallelOpThreadPool<void>*)threadPool;
+    if (pool->IsPoolShutdown())
+        return;
+
+    pool->PostTask([]() {}).wait();
+}
+
 void CSparkWallet::resetDiversifierFromDB(CWalletDB& walletdb) {
     LOCK(cs_spark_wallet);
     walletdb.readDiversifier(lastDiversifier);

--- a/src/spark/sparkwallet.cpp
+++ b/src/spark/sparkwallet.cpp
@@ -110,17 +110,20 @@ CSparkWallet::CSparkWallet(const std::string& strWalletFile) {
 }
 
 CSparkWallet::~CSparkWallet() {
+    LOCK(cs_thread_pool);
     delete (ParallelOpThreadPool<void>*)threadPool;
     threadPool = nullptr;
 }
 
 void CSparkWallet::FinishTasks() {
+    LOCK(cs_thread_pool);
     if (threadPool) {
         ((ParallelOpThreadPool<void>*)threadPool)->Shutdown();
     }
 }
 
 void CSparkWallet::WaitForPendingTasks() {
+    LOCK(cs_thread_pool);
     if (!threadPool)
         return;
 

--- a/src/spark/sparkwallet.h
+++ b/src/spark/sparkwallet.h
@@ -221,6 +221,8 @@ public:
     // Returns the list of pairs of coins and metadata for that coin,
     std::list<CSparkMintMeta> GetAvailableSparkCoins(const CCoinControl *coinControl = NULL) const;
 
+    /** Wait for all Spark wallet tasks queued before this call. */
+    void WaitForPendingTasks();
     void FinishTasks();
 
 public:

--- a/src/spark/sparkwallet.h
+++ b/src/spark/sparkwallet.h
@@ -269,6 +269,7 @@ private:
     const CSparkMintMeta* findMintMeta(const spark::Coin& coin) const
         EXCLUSIVE_LOCKS_REQUIRED(cs_spark_wallet);
 
+    CCriticalSection cs_thread_pool;
     void* threadPool;
 };
 

--- a/src/test/fixtures.cpp
+++ b/src/test/fixtures.cpp
@@ -25,6 +25,7 @@
 #include "ui_interface.h"
 #include "rpc/server.h"
 #include "rpc/register.h"
+#include "spark/state.h"
 
 #include "test/testutil.h"
 #include "test/fixtures.h"
@@ -313,5 +314,5 @@ CTransaction SparkTestingSetup::GenerateSparkSpend(
 
 SparkTestingSetup::~SparkTestingSetup()
 {
-    pwalletMain->sparkWallet->FinishTasks();
+    spark::CSparkState::GetState()->Reset();
 }

--- a/src/test/spark_mintspend_test.cpp
+++ b/src/test/spark_mintspend_test.cpp
@@ -87,6 +87,9 @@ BOOST_AUTO_TEST_CASE(spark_mintspend_test)
     BOOST_CHECK_MESSAGE(mempool.size() == 0, "Mempool not cleared");
     GenerateBlocks(2);
 
+    // Block and mempool updates reach the Spark wallet asynchronously. Drain
+    // them before deliberately rewinding the wallet and chain spend state.
+    pwalletMain->sparkWallet->WaitForPendingTasks();
     auto tempTags = sparkState->usedLTags;
     sparkState->usedLTags.clear();
 


### PR DESCRIPTION
Wait for queued Spark wallet updates before the mint-spend test deliberately rewinds wallet and chain spend state. Reset global Spark state from the fixture destructor so an early test failure cannot contaminate the following test. This removes the Debug-only race that intermittently produced InsufficientFunds and a secondary GetAnonymitySetHash crash.