### PR TITLE
Spark: clear all state on reset

### DIFF
--- a/src/spark/state.cpp
+++ b/src/spark/state.cpp
@@ -1587,6 +1587,8 @@ void CSparkState::Reset() {
     }
     usedLTags.clear();
     mobileUsedLTags.clear();
+    ltagTxhash.clear();
+    extendedMintMetaInfo.clear();
     mintMetaInfo.clear();
     spendMetaInfo.clear();
 }


### PR DESCRIPTION
CSparkState::Reset() currently leaves the linking-tag transaction index and extended mint metadata populated. Clear both containers so reset restores constructor-equivalent empty state and cannot expose stale entries after a rebuild or between tests.