### PR TITLE
Qt: avoid blocking on chain height during sync

### DIFF
--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -38,7 +38,7 @@ ClientModel::ClientModel(OptionsModel *_optionsModel, QObject *parent) :
 {
     cachedBestHeaderHeight = -1;
     cachedBestHeaderTime = -1;
-    cachedNumBlocks = 0;
+    cachedNumBlocks = g_connman ? g_connman->GetBestHeight() : 0;
     cachedLastBlockDate = QDateTime();
     peerTableModel = new PeerTableModel(this);
     banTableModel = new BanTableModel(this);
@@ -360,12 +360,12 @@ static void BlockTipChanged(ClientModel *clientmodel, bool initialSync, const CB
         now = GetTimeMillis();
 
     int64_t& nLastUpdateNotification = fHeader ? nLastHeaderTipUpdateNotification : nLastBlockTipUpdateNotification;
-    clientmodel->cachedNumBlocks = pIndex->nHeight;
-
     if (fHeader) {
         // cache best headers time and height to reduce future cs_main locks
         clientmodel->cachedBestHeaderHeight = pIndex->nHeight;
         clientmodel->cachedBestHeaderTime = pIndex->GetBlockTime();
+    } else {
+        clientmodel->cachedNumBlocks = pIndex->nHeight;
     }
     // if we are in-sync, update the UI regardless of last update time
     if (!initialSync || now - nLastUpdateNotification > MODEL_UPDATE_DELAY) {

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -1715,8 +1715,7 @@ bool WalletModel::sparkNamesAllowed() const
 
 bool WalletModel::versionedSparkSpendsAllowed() const
 {
-    LOCK(cs_main);
-    return chainActive.Height() + 1 >=
+    return _client_model && _client_model->getNumBlocks() + 1 >=
         Params().GetConsensus().nSparkChaumV2StartBlock;
 }
 

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -161,6 +161,7 @@ void WalletView::setClientModel(ClientModel *_clientModel)
 void WalletView::setWalletModel(WalletModel *_walletModel)
 {
     this->walletModel = _walletModel;
+    walletModel->setClientModel(clientModel);
 
     // Put transaction list in tabs
     firoTransactionList->setModel(_walletModel);
@@ -206,7 +207,6 @@ void WalletView::setWalletModel(WalletModel *_walletModel)
             connect(autoMintSparkModel, &AutoMintSparkModel::requireShowAutomintSparkNotification, this, &WalletView::showAutomintSparkNotification);
             connect(autoMintSparkModel, &AutoMintSparkModel::closeAutomintSparkNotification, this, &WalletView::closeAutomintSparkNotification);
         }
-        walletModel->setClientModel(clientModel);
     }
 }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4086,7 +4086,7 @@ bool InvalidateBlock(CValidationState& state, const CChainParams& chainparams, C
     InvalidChainFound(pindex);
     txpools.removeForReorg(pcoinsTip, chainActive.Tip()->nHeight + 1, STANDARD_LOCKTIME_VERIFY_FLAGS);
     GetMainSignals().UpdatedBlockTip(chainActive.Tip(), NULL, IsInitialBlockDownload());
-    uiInterface.NotifyBlockTip(IsInitialBlockDownload(), pindex->pprev);
+    uiInterface.NotifyBlockTip(IsInitialBlockDownload(), chainActive.Tip());
     return true;
 }
 


### PR DESCRIPTION
## PR intention
Prevent Firo-Qt from freezing when a queued block-tip update checks Spark V2 activation while block validation holds `cs_main`.

## Code changes brief
Use the nonblocking active-chain height cache for this UI check, keep header height separate, and ensure invalidation notifications cache the actual active tip. This changes only Qt state reporting; transaction and consensus rules are unchanged.