### PR TITLE
Qt: avoid blocking on Spark activation height

### DIFF
--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -38,7 +38,7 @@ ClientModel::ClientModel(OptionsModel *_optionsModel, QObject *parent) :
 {
     cachedBestHeaderHeight = -1;
     cachedBestHeaderTime = -1;
-    cachedNumBlocks = 0;
+    cachedNumBlocks = g_connman ? g_connman->GetBestHeight() : 0;
     cachedLastBlockDate = QDateTime();
     peerTableModel = new PeerTableModel(this);
     banTableModel = new BanTableModel(this);
@@ -360,12 +360,12 @@ static void BlockTipChanged(ClientModel *clientmodel, bool initialSync, const CB
         now = GetTimeMillis();
 
     int64_t& nLastUpdateNotification = fHeader ? nLastHeaderTipUpdateNotification : nLastBlockTipUpdateNotification;
-    clientmodel->cachedNumBlocks = pIndex->nHeight;
-
     if (fHeader) {
         // cache best headers time and height to reduce future cs_main locks
         clientmodel->cachedBestHeaderHeight = pIndex->nHeight;
         clientmodel->cachedBestHeaderTime = pIndex->GetBlockTime();
+    } else {
+        clientmodel->cachedNumBlocks = pIndex->nHeight;
     }
     // if we are in-sync, update the UI regardless of last update time
     if (!initialSync || now - nLastUpdateNotification > MODEL_UPDATE_DELAY) {

--- a/src/qt/test/CMakeLists.txt
+++ b/src/qt/test/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(test_firo-qt
 # Add this to skip specific files from UIC processing
 set_source_files_properties(
     ${CMAKE_CURRENT_SOURCE_DIR}/../../test/test_bitcoin.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_sendcoinsentry.cpp
     PROPERTIES SKIP_AUTOUIC ON 
 )
 

--- a/src/qt/test/test_sendcoinsentry.cpp
+++ b/src/qt/test/test_sendcoinsentry.cpp
@@ -1,8 +1,11 @@
 #include "test_sendcoinsentry.h"
 
+#include "chain.h"
+#include "clientmodel.h"
 #include "coincontroldialog.h"
 #include "platformstyle.h"
 #include "sendcoinsdialog.h"
+#include "ui_interface.h"
 
 #include <QCheckBox>
 
@@ -74,4 +77,24 @@ void TestSendCoinsEntry::testSparkCoinControlSizeEstimate()
             std::numeric_limits<size_t>::max(),
             true),
         std::numeric_limits<unsigned int>::max());
+}
+
+void TestSendCoinsEntry::testBlockHeightCacheIgnoresHeaders()
+{
+    ClientModel client(nullptr);
+    CBlockIndex block;
+    block.nHeight = 100;
+    uiInterface.NotifyBlockTip(false, &block);
+    QCOMPARE(client.cachedNumBlocks.load(), 100);
+
+    // Spark send controls must not use a header-only activation height.
+    CBlockIndex header;
+    header.nHeight = 200;
+    uiInterface.NotifyHeaderTip(false, &header);
+    QCOMPARE(client.cachedBestHeaderHeight.load(), 200);
+    QCOMPARE(client.cachedNumBlocks.load(), 100);
+
+    block.nHeight = 99;
+    uiInterface.NotifyBlockTip(false, &block);
+    QCOMPARE(client.cachedNumBlocks.load(), 99);
 }

--- a/src/qt/test/test_sendcoinsentry.h
+++ b/src/qt/test/test_sendcoinsentry.h
@@ -14,6 +14,7 @@ private Q_SLOTS:
     void testTransactionCreationErrorDetails();
     void testPrivateModeUpdatesExistingEntries();
     void testSparkCoinControlSizeEstimate();
+    void testBlockHeightCacheIgnoresHeaders();
 };
 
 #endif // BITCOIN_QT_TEST_SENDCOINSENTRY_H

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -1715,8 +1715,7 @@ bool WalletModel::sparkNamesAllowed() const
 
 bool WalletModel::versionedSparkSpendsAllowed() const
 {
-    LOCK(cs_main);
-    return chainActive.Height() + 1 >=
+    return _client_model && _client_model->getNumBlocks() + 1 >=
         Params().GetConsensus().nSparkChaumV2StartBlock;
 }
 

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -161,6 +161,7 @@ void WalletView::setClientModel(ClientModel *_clientModel)
 void WalletView::setWalletModel(WalletModel *_walletModel)
 {
     this->walletModel = _walletModel;
+    walletModel->setClientModel(clientModel);
 
     // Put transaction list in tabs
     firoTransactionList->setModel(_walletModel);
@@ -206,7 +207,6 @@ void WalletView::setWalletModel(WalletModel *_walletModel)
             connect(autoMintSparkModel, &AutoMintSparkModel::requireShowAutomintSparkNotification, this, &WalletView::showAutomintSparkNotification);
             connect(autoMintSparkModel, &AutoMintSparkModel::closeAutomintSparkNotification, this, &WalletView::closeAutomintSparkNotification);
         }
-        walletModel->setClientModel(clientModel);
     }
 }
 


### PR DESCRIPTION
Use ClientModel's nonblocking cached-height accessor for Spark send controls, leaving transaction creation's locked chain-height checks unchanged. Initialize the cache and client-model wiring before use, exclude header-only heights, and add Qt regression coverage. This addresses the height-query stall observed during Debug replay of 1,024 Spark spends; separate startup and replay stalls remain.
