### PR TITLE
Qt: defer Spark GUI callbacks during validation

### DIFF
--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -14,6 +14,7 @@
 #include "csvmodelwriter.h"
 #include "editaddressdialog.h"
 #include "createsparknamepage.h"
+#include "guiconstants.h"
 #include "guiutil.h"
 #include "platformstyle.h"
 #include "validation.h"
@@ -24,6 +25,7 @@
 #include <QMenu>
 #include <QMessageBox>
 #include <QSortFilterProxyModel>
+#include <QTimer>
 
 AddressBookPage::AddressBookPage(const PlatformStyle *_platformStyle, Mode _mode, Tabs _tab, QWidget *parent, bool isReused) :
     QDialog(parent),
@@ -222,10 +224,12 @@ bool AddressBookPage::updateSpark()
 {
     bool sparkAllowed;
     {
-        // Leave the current choices intact; the next block-tip update retries.
         TRY_LOCK(cs_main, lockMain);
-        if (!lockMain)
+        if (!lockMain) {
+            // Retry this page even if another page completes the shared refresh.
+            QTimer::singleShot(MODEL_UPDATE_DELAY, this, &AddressBookPage::updateSpark);
             return false;
+        }
         sparkAllowed = model && model->IsSparkAllowed();
     }
     populateAddressTypes(sparkAllowed);

--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -16,6 +16,7 @@
 #include "createsparknamepage.h"
 #include "guiutil.h"
 #include "platformstyle.h"
+#include "validation.h"
 #include "bip47/paymentcode.h"
 #include "bip47/paymentchannel.h"
 
@@ -219,7 +220,14 @@ void AddressBookPage::setModel(AddressTableModel *_model)
 
 bool AddressBookPage::updateSpark()
 {
-    const bool sparkAllowed = model && model->IsSparkAllowed();
+    bool sparkAllowed;
+    {
+        // Leave the current choices intact; the next block-tip update retries.
+        TRY_LOCK(cs_main, lockMain);
+        if (!lockMain)
+            return false;
+        sparkAllowed = model && model->IsSparkAllowed();
+    }
     populateAddressTypes(sparkAllowed);
 
     chooseAddressType(0);

--- a/src/qt/automintmodel.cpp
+++ b/src/qt/automintmodel.cpp
@@ -111,8 +111,14 @@ void IncomingFundNotifier::check()
 
 void IncomingFundNotifier::importTransactions()
 {
-    LOCK2(cs_main, cs);
-    LOCK(wallet->cs_wallet);
+    TRY_LOCK(cs_main, lockMain);
+    TRY_LOCK(cs, lock);
+    TRY_LOCK(wallet->cs_wallet, lockWallet);
+    if (!lockMain || !lock || !lockWallet) {
+        // This queued startup scan must retry after long-running validation.
+        QTimer::singleShot(MODEL_UPDATE_DELAY, this, &IncomingFundNotifier::importTransactions);
+        return;
+    }
 
     for (auto const &tx : wallet->mapWallet) {
         if (tx.second.GetAvailableCredit() > 0 || tx.second.GetImmatureCredit() > 0) {
@@ -247,6 +253,10 @@ void AutoMintSparkModel::checkAutoMintSpark(bool force)
             return;
         }
 
+        // The periodic check can try again on its next timer tick.
+        TRY_LOCK(cs_main, lockMain);
+        if (!lockMain)
+            return;
         bool allowed = spark::IsSparkAllowed();
         if (!allowed) {
             return;

--- a/src/qt/test/CMakeLists.txt
+++ b/src/qt/test/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(test_firo-qt
   ${CMAKE_CURRENT_SOURCE_DIR}/test_main.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/uritests.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_sendcoinsentry.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/sparkmodeltests.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/../../test/test_bitcoin.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/../../test/testutil.cpp
 )

--- a/src/qt/test/sparkmodeltests.cpp
+++ b/src/qt/test/sparkmodeltests.cpp
@@ -79,7 +79,7 @@ void SparkModelTests::addressBookDefers()
     AddressTableModel model(&wallet);
     const std::unique_ptr<const PlatformStyle> style(PlatformStyle::instantiate("other"));
     QVERIFY(style);
-    AddressBookPage page(style.get(), AddressBookPage::ForEditing, AddressBookPage::SendingTab);
+    AddressBookPage page(style.get(), AddressBookPage::ForEditing, AddressBookPage::SendingTab, nullptr);
     page.setModel(&model);
     QComboBox* types = page.findChild<QComboBox*>("addressType");
     QVERIFY(types);

--- a/src/qt/test/sparkmodeltests.cpp
+++ b/src/qt/test/sparkmodeltests.cpp
@@ -1,0 +1,118 @@
+#include "sparkmodeltests.h"
+
+#include "addressbookpage.h"
+#include "addresstablemodel.h"
+#include "automintmodel.h"
+#include "optionsmodel.h"
+#include "platformstyle.h"
+#include "sparkmodel.h"
+
+#include "masternode-sync.h"
+#include "validation.h"
+#include "wallet/wallet.h"
+
+#include <QComboBox>
+#include <QCoreApplication>
+#include <QEvent>
+#include <QTest>
+#include <QTimer>
+
+#include <chrono>
+#include <functional>
+#include <future>
+#include <memory>
+#include <thread>
+
+namespace {
+
+// Exercise the GUI callback while another thread owns the real core lock.
+// The timeout lets a blocking regression fail instead of hanging the suite.
+bool WithContendedLock(CCriticalSection& mutex, const std::function<void()>& callback)
+{
+    std::promise<void> locked, release;
+    auto released = release.get_future();
+    bool timedOut = false;
+    std::jthread worker([&] {
+        LOCK(mutex);
+        locked.set_value();
+        timedOut = released.wait_for(std::chrono::seconds(5)) != std::future_status::ready;
+    });
+    locked.get_future().wait();
+    callback();
+    release.set_value();
+    worker.join();
+    return !timedOut;
+}
+
+} // namespace
+
+void SparkModelTests::importRetries_data()
+{
+    QTest::addColumn<bool>("walletLock");
+    QTest::newRow("chain-lock") << false;
+    QTest::newRow("wallet-lock") << true;
+}
+
+void SparkModelTests::importRetries()
+{
+    QFETCH(bool, walletLock);
+    CWallet wallet;
+    IncomingFundNotifier notifier(&wallet);
+    QTimer* timer = notifier.findChild<QTimer*>();
+    QVERIFY(timer);
+
+    bool deferred = false;
+    const bool responsive = WithContendedLock(walletLock ? wallet.cs_wallet : cs_main, [&] {
+        // Deliver the constructor's queued startup scan on the GUI thread.
+        QCoreApplication::sendPostedEvents(&notifier, QEvent::MetaCall);
+        deferred = !timer->isActive();
+    });
+    QVERIFY(responsive);
+    QVERIFY(deferred);
+    // No new block or transaction notification is needed to retry the scan.
+    QTRY_VERIFY(timer->isActive());
+}
+
+void SparkModelTests::addressBookDefers()
+{
+    CWallet wallet;
+    AddressTableModel model(&wallet);
+    const std::unique_ptr<const PlatformStyle> style(PlatformStyle::instantiate("other"));
+    QVERIFY(style);
+    AddressBookPage page(style.get(), AddressBookPage::ForEditing, AddressBookPage::SendingTab);
+    page.setModel(&model);
+    QComboBox* types = page.findChild<QComboBox*>("addressType");
+    QVERIFY(types);
+    const int originalCount = types->count();
+    types->addItem("Retain this selection while busy");
+    types->setCurrentIndex(originalCount);
+
+    bool updated = true;
+    const bool responsive = WithContendedLock(cs_main, [&] { updated = page.updateSpark(); });
+    QVERIFY(responsive);
+    QVERIFY(!updated);
+    QCOMPARE(types->count(), originalCount + 1);
+    QCOMPARE(types->currentIndex(), originalCount);
+
+    page.updateSpark();
+    QCOMPARE(types->count(), originalCount);
+}
+
+void SparkModelTests::autoMintDefers()
+{
+    CWallet wallet;
+    OptionsModel options;
+    SparkModel model(nullptr, &wallet, &options);
+    // Reach the activation check even though this test has no network peers.
+    const CMasternodeSync savedSync = masternodeSync;
+    CConnman connman(0, 0);
+    masternodeSync.Reset();
+    masternodeSync.SwitchToNextAsset(connman);
+    masternodeSync.SwitchToNextAsset(connman);
+    const bool responsive = WithContendedLock(cs_main, [&] {
+        model.getAutoMintSparkModel()->checkAutoMintSpark();
+    });
+    masternodeSync = savedSync;
+    QVERIFY(responsive);
+    QVERIFY(!model.getAutoMintSparkModel()->isSparkAnonymizing());
+}

--- a/src/qt/test/sparkmodeltests.cpp
+++ b/src/qt/test/sparkmodeltests.cpp
@@ -94,8 +94,8 @@ void SparkModelTests::addressBookDefers()
     QCOMPARE(types->count(), originalCount + 1);
     QCOMPARE(types->currentIndex(), originalCount);
 
-    page.updateSpark();
-    QCOMPARE(types->count(), originalCount);
+    // Retry independently of another page or block-tip notification.
+    QTRY_COMPARE(types->count(), originalCount);
 }
 
 void SparkModelTests::autoMintDefers()

--- a/src/qt/test/sparkmodeltests.h
+++ b/src/qt/test/sparkmodeltests.h
@@ -1,0 +1,17 @@
+#ifndef FIRO_QT_TEST_SPARKMODELTESTS_H
+#define FIRO_QT_TEST_SPARKMODELTESTS_H
+
+#include <QObject>
+
+class SparkModelTests : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void importRetries_data();
+    void importRetries();
+    void addressBookDefers();
+    void autoMintDefers();
+};
+
+#endif // FIRO_QT_TEST_SPARKMODELTESTS_H

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -13,6 +13,7 @@
 #include "uritests.h"
 #include "compattests.h"
 #include "test_sendcoinsentry.h"
+#include "sparkmodeltests.h"
 #include <QApplication>
 #include <QObject>
 #include <openssl/ssl.h>
@@ -57,6 +58,10 @@ int main(int argc, char *argv[])
 
     CompatTests test4;
     if (QTest::qExec(&test4) != 0)
+        fInvalid = true;
+
+    SparkModelTests sparkModelTests;
+    if (QTest::qExec(&sparkModelTests) != 0)
         fInvalid = true;
 
     ECC_Stop();


### PR DESCRIPTION
## PR intention

Alternative to #1940 for the Qt freeze during Spark batch verification. Long validation holds `cs_main`, while the queued incoming-fund scan, auto-mint activation check, and Spark address-book refresh can wait for that lock on the GUI thread.

## Code changes brief

Use existing `TRY_LOCK` and Qt timer patterns to defer these automatic callbacks. The startup scan and each busy address-book page retry after `MODEL_UPDATE_DELAY` (250 ms); auto-mint retries on its next timer tick. Address choices remain intact while busy. Each page retries independently because the shared refresh may finish when another page succeeds.

Two production files, 25 additions and 3 deletions. Core proof verification remains serialized, preserving master's historical batching and recent-block verification behavior. Independent of #1940, based on master `4f0c771462b2f327e3a7ff7bf2532bc33c727713`; deferred-proof drain and recovery-marker improvements remain separate work.

Qt regression tests cover chain/wallet lock contention, automatic retries without another block notification, and preservation of address choices.

Integration with #1914 at `425c6db` was checked in an isolated test merge. Production code merges cleanly. Resolve the two conflicts in `src/qt/test/CMakeLists.txt` and `src/qt/test/test_main.cpp` by retaining both test suites and #1914's resource/settings setup. The combined GUI has not been built or exercised.

Validation at `82c9f8f` ([CI run](https://github.com/firoorg/firo/actions/runs/34181444208)):

- Linux Debug and RelWithDebInfo builds passed. `cd build && ctest --output-on-failure` passed 94/94 tests in each, including `test_firo-qt`. `qa/pull-tester/rpc-tests.py -extended` passed in both configurations.
- Windows and macOS CMake builds passed in both configurations. Jenkins branch validation passed. Four Guix jobs passed; the Windows Guix job is still at Install Guix.
- `git diff origin/master...HEAD --check` and `git merge-tree --write-tree --messages origin/master origin/pr1950-thorough-review` passed against the current base. The resolved #1914 integration diff check also passed.

Local Qt development files are unavailable, so no local GUI build/test was run. A live batch-sync GUI run has not been reproduced. Keep this draft until the reported hang is verified fixed; these callbacks are not proven to be its only cause.
