### PR TITLE
Validation: fix in-memory coin-cache allocation

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -154,6 +154,7 @@ testScripts = [
     'decodescript.py',
     # 'blockchain.py',
     'disablewallet.py',
+    'dbcache.py',
     'keypool.py',
     'p2p-mempool.py',
     # 'prioritise_transaction.py',

--- a/qa/rpc-tests/dbcache.py
+++ b/qa/rpc-tests/dbcache.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Firo developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""Check that the remaining -dbcache budget is assigned to the UTXO cache."""
+
+import os
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import start_nodes
+
+
+class DbCacheTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 4
+
+    def setup_network(self):
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [
+            ['-disablewallet', '-txindex=0'],
+            ['-disablewallet', '-txindex=0', '-dbcache=2048'],
+            ['-disablewallet', '-txindex=0', '-dbcache=4'],
+            ['-disablewallet', '-txindex=1'],
+        ])
+
+    def run_test(self):
+        # The block-index and coin database caches are deducted first.
+        for node, expected_mib in enumerate(['440.0', '2038.0', '1.8', '385.8']):
+            log_path = os.path.join(self.options.tmpdir, 'node' + str(node),
+                                    'regtest', 'debug.log')
+            with open(log_path, encoding='utf-8') as log_file:
+                log = log_file.read()
+            expected = '* Using {}MiB for in-memory UTXO set'.format(expected_mib)
+            assert expected in log, 'node {}: missing cache allocation: {}'.format(node, expected)
+
+
+if __name__ == '__main__':
+    DbCacheTest().main()

--- a/qa/rpc-tests/dbcache.py
+++ b/qa/rpc-tests/dbcache.py
@@ -3,7 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-"""Check that the remaining -dbcache budget is assigned to the UTXO cache."""
+"""Check that all database caches and the UTXO cache share the -dbcache budget."""
 
 import os
 
@@ -25,14 +25,22 @@ class DbCacheTest(BitcoinTestFramework):
         ])
 
     def run_test(self):
-        # The block-index and coin database caches are deducted first.
-        for node, expected_mib in enumerate(['440.0', '2038.0', '1.8', '385.8']):
+        # Reserve EvoDB inside the budget, including at the 4 MiB minimum.
+        cache_names = ['in-memory UTXO set', 'block index database',
+                       'EvoDB database', 'chain state database']
+        for node, allocations in enumerate([
+            ['424.0', '2.0', '16.0', '8.0'],
+            ['2022.0', '2.0', '16.0', '8.0'],
+            ['1.5', '0.5', '0.4', '1.5'],
+            ['369.8', '56.2', '16.0', '8.0'],
+        ]):
             log_path = os.path.join(self.options.tmpdir, 'node' + str(node),
                                     'regtest', 'debug.log')
             with open(log_path, encoding='utf-8') as log_file:
                 log = log_file.read()
-            expected = '* Using {}MiB for in-memory UTXO set'.format(expected_mib)
-            assert expected in log, 'node {}: missing cache allocation: {}'.format(node, expected)
+            for expected_mib, cache_name in zip(allocations, cache_names):
+                expected = '* Using {}MiB for {}'.format(expected_mib, cache_name)
+                assert expected in log, 'node {}: missing cache allocation: {}'.format(node, expected)
 
 
 if __name__ == '__main__':

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1999,15 +1999,17 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     if (nBlockTreeDBCache > (1 << 21) && !GetBoolArg("-txindex", false))
         nBlockTreeDBCache = (1 << 21); // block tree db cache shouldn't be larger than 2 MiB
     nTotalCache -= nBlockTreeDBCache;
+    int64_t nEvoDbCache = std::min(nTotalCache / 8, int64_t{16} << 20);
+    nTotalCache -= nEvoDbCache;
     int64_t nCoinDBCache = std::min(nTotalCache / 2,
                                     (nTotalCache / 4) + (1 << 23)); // use 25%-50% of the remainder for disk cache
     nCoinDBCache = std::min(nCoinDBCache, nMaxCoinsDBCache << 20); // cap total coins db cache
     nTotalCache -= nCoinDBCache;
     nCoinCacheUsage = nTotalCache; // the rest goes to in-memory cache, in bytes
     int64_t nMempoolSizeMax = GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000;
-    int64_t nEvoDbCache = 1024 * 1024 * 16; // TODO
     LogPrintf("Cache configuration:\n");
     LogPrintf("* Using %.1fMiB for block index database\n", nBlockTreeDBCache * (1.0 / 1024 / 1024));
+    LogPrintf("* Using %.1fMiB for EvoDB database\n", nEvoDbCache * (1.0 / 1024 / 1024));
     LogPrintf("* Using %.1fMiB for chain state database\n", nCoinDBCache * (1.0 / 1024 / 1024));
     LogPrintf("* Using %.1fMiB for in-memory UTXO set (plus up to %.1fMiB of unused mempool space)\n", nCoinCacheUsage * (1.0 / 1024 / 1024), nMempoolSizeMax * (1.0 / 1024 / 1024));
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2003,8 +2003,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                                     (nTotalCache / 4) + (1 << 23)); // use 25%-50% of the remainder for disk cache
     nCoinDBCache = std::min(nCoinDBCache, nMaxCoinsDBCache << 20); // cap total coins db cache
     nTotalCache -= nCoinDBCache;
-//    nCoinCacheUsage = nTotalCache; // the rest goes to in-memory cache
-    nCoinCacheUsage = nTotalCache / 300;
+    nCoinCacheUsage = nTotalCache; // the rest goes to in-memory cache, in bytes
     int64_t nMempoolSizeMax = GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000;
     int64_t nEvoDbCache = 1024 * 1024 * 16; // TODO
     LogPrintf("Cache configuration:\n");


### PR DESCRIPTION
## PR intention

Correct the in-memory coin-cache byte budget and include EvoDB within `-dbcache`. Dividing the remaining bytes by 300 left only about 1.5 MiB for UTXOs at the default setting. EvoDB also received an extra 16 MiB outside the configured budget.

## Code changes brief

Assign the remaining bytes directly to `nCoinCacheUsage`. Reserve one eighth of the budget remaining after the block-index allocation for EvoDB, capped at 16 MiB, before allocating the coin caches. Small settings therefore retain space for each cache.

At the default 450 MiB with `txindex=0`, the allocation is 2 MiB block index + 16 MiB EvoDB + 8 MiB chainstate + 424 MiB UTXO. The existing unused-mempool allowance and flush safety factors remain unchanged. This is a cache target, not a hard process-memory limit; small EvoDB caches may increase database I/O.

Register `dbcache.py` in the regular RPC runner and check all four cache allocations for default, 2048 MiB, minimum 4 MiB, and txindex-enabled configurations.

Validation at `a3f78d354`:

- `cmake --build build --target firod firo-cli test_firo -j 8`: passed, native Windows/MinGW Debug.
- `python qa/rpc-tests/dbcache.py --tmpdir=build/dbcache-evodb-fixed --portseed=955 --nocleanup`: all four configurations passed. The updated test fails against the preceding PR binary `17f654270`, which still assigns 440 MiB to UTXOs before the extra EvoDB allocation.
- `build/bin/test_firo.exe --run_test=coins_tests,dbwrapper_tests --catch_system_error=no --log_level=test_suite -- DEBUG_LOG_OUT`: all 14 cases passed.
- `git diff --check` passed; merge-tree integration with master `f1cba134a` was clean.

Local configuration required a temporary missing-test-helper workaround and Berkeley DB include path; neither is committed. Fresh CI is pending. Full sync benchmarks, peak-memory/flush-latency measurements, the full test suite, and Linux/macOS builds were not run locally.