### PR TITLE
LLMQ: Reject unmined InstantSend parents

### DIFF
--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -540,9 +540,9 @@ bool CInstantSendManager::CheckCanLock(const COutPoint& outpoint, bool printDebu
     CTransactionRef tx;
     uint256 hashBlock;
     // this relies on enabled txindex and won't work if we ever try to remove the requirement for txindex for masternodes
-    if (!GetTransaction(outpoint.hash, tx, params, hashBlock, false)) {
+    if (!GetTransaction(outpoint.hash, tx, params, hashBlock, false) || hashBlock.IsNull()) {
         if (printDebug) {
-            LogPrint("instantsend", "CInstantSendManager::%s -- txid=%s: failed to find parent TX %s\n", __func__,
+            LogPrint("instantsend", "CInstantSendManager::%s -- txid=%s: failed to find mined parent TX %s\n", __func__,
                      txHash.ToString(), outpoint.hash.ToString());
         }
         return false;

--- a/src/llmq/quorums_instantsend.h
+++ b/src/llmq/quorums_instantsend.h
@@ -74,6 +74,8 @@ public:
 
 class CInstantSendManager : public CRecoveredSigsListener
 {
+    friend struct CInstantSendManagerTestAccess;
+
 private:
     CCriticalSection cs;
     CInstantSendDb db;

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -50,6 +50,7 @@ add_executable(test_firo
   ${CMAKE_CURRENT_SOURCE_DIR}/limitedmap_tests.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/logging_tests.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/llmq_signing_shares_tests.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/quorums_instantsend_tests.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/main_tests.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/mbstring_tests.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/mempool_tests.cpp

--- a/src/test/quorums_instantsend_tests.cpp
+++ b/src/test/quorums_instantsend_tests.cpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 The Firo developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "chainparams.h"
+#include "llmq/quorums_instantsend.h"
+#include "test/test_bitcoin.h"
+#include "validation.h"
+
+#include <boost/test/unit_test.hpp>
+
+namespace llmq
+{
+struct CInstantSendManagerTestAccess
+{
+    static bool CheckCanLock(CInstantSendManager& manager, const COutPoint& outpoint)
+    {
+        return manager.CheckCanLock(outpoint, false, uint256(), nullptr, Params().GetConsensus());
+    }
+};
+
+BOOST_FIXTURE_TEST_SUITE(quorums_instantsend_tests, TestingSetup)
+
+BOOST_AUTO_TEST_CASE(stem_parent_is_not_treated_as_mined)
+{
+    CMutableTransaction parent;
+    parent.vin.resize(1);
+    parent.vin[0].scriptSig = CScript() << OP_11;
+    parent.vout.resize(1);
+    parent.vout[0].nValue = 1;
+    parent.vout[0].scriptPubKey = CScript() << OP_TRUE;
+
+    txpools.clear();
+    TestMemPoolEntryHelper entry;
+    txpools.getStemTxPool().addUnchecked(parent.GetHash(), entry.FromTx(parent));
+
+    BOOST_REQUIRE(!mempool.exists(parent.GetHash()));
+    BOOST_REQUIRE(txpools.getStemTxPool().exists(parent.GetHash()));
+    BOOST_CHECK(!CInstantSendManagerTestAccess::CheckCanLock(
+        *quorumInstantSendManager, COutPoint(parent.GetHash(), 0)));
+
+    txpools.clear();
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}


### PR DESCRIPTION
## PR intention
Prevent InstantSend processing from treating an unmined stem-pool parent as a mined transaction.

`GetTransaction()` searches both transaction pools and can return `true` for a stem-only transaction without setting `hashBlock`. `CheckCanLock()` then passed the null hash to `mapBlockIndex.at()`, which throws `std::out_of_range` from the InstantSend worker path.

Require a non-null block hash before consulting `mapBlockIndex`. An unlocked, unmined parent remains ineligible for InstantSend, matching the existing policy for an unlocked parent in the main mempool.

## Code changes brief

- Reject a parent lookup that does not identify a containing block.
- Clarify the diagnostic as a failure to find a mined parent.
- Add a focused unit test with the parent present only in the stem pool.

### Validation

- Built the Windows `test_firo` target successfully.
- Confirmed the regression test fails on the vulnerable condition with `std::out_of_range: Unable to find key in unordered_map`.
- Confirmed `test_firo --run_test=quorums_instantsend_tests --catch_system_error=no --log_level=test_suite -- DEBUG_LOG_OUT` passes with the fix.
- `git diff --check` passes.

The supplied multi-node functional PoC was not rerun locally.

### Related work

This overlaps #1939 in `quorums_instantsend.h`, `src/test/CMakeLists.txt`, and `quorums_instantsend_tests.cpp` because both changes add InstantSend unit coverage. The production behavior changes are distinct. Whichever PR lands second will need a small test-file reconciliation.